### PR TITLE
Updating htmlunit version to 2.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,10 +137,9 @@
       <version>4.5</version>
     </dependency>
     <dependency>
-        <!-- 2.18-SNAPSHOT needed for selenium webdriver (http://htmlunit.10904.n7.nabble.com/HtmlUnit-htmlunit-bugs-1692-Update-to-HttpComponents-4-5-td36318.html) - potentially update to 2.18 when possible -->
       <groupId>net.sourceforge.htmlunit</groupId>
       <artifactId>htmlunit</artifactId>
-      <version>2.18-SNAPSHOT</version>
+      <version>2.18</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>


### PR DESCRIPTION
2.18-SNAPSHOT is not available at maven repo at all and there is no reason to not use stable version now. Removing comment as webdriver works fine with 2.18