### PR TITLE
Fix for issue #16. There is now a check that prevents an empty view i…

### DIFF
--- a/src/main/scala/code/views/MapperViews.scala
+++ b/src/main/scala/code/views/MapperViews.scala
@@ -160,16 +160,20 @@ private object MapperViews extends Views with Loggable {
   }
 
   def createView(bankAccount: BankAccount, view: ViewCreationJSON): Box[View] = {
+    if(view.name.contentEquals("")) {
+      return Failure("It is not allowed to create a view with an empty name")
+    }
+
     val newViewPermalink = {
-      view.name.replaceAllLiterally(" ","").toLowerCase
+      view.name.replaceAllLiterally(" ", "").toLowerCase
     }
 
     val existing = ViewImpl.count(
-        By(ViewImpl.permalink_, newViewPermalink) ::
+      By(ViewImpl.permalink_, newViewPermalink) ::
         ViewImpl.accountFilter(bankAccount.bankId, bankAccount.accountId): _*
-      ) == 1
+    ) == 1
 
-    if(existing)
+    if (existing)
       Failure(s"There is already a view with permalink $newViewPermalink on this bank account")
     else {
       val createdView = ViewImpl.create.
@@ -181,7 +185,6 @@ private object MapperViews extends Views with Loggable {
       createdView.setFromViewData(view)
       Full(createdView.saveMe)
     }
-
   }
 
   def updateView(bankAccount : BankAccount, viewId: ViewId, viewUpdateJson : ViewUpdateData) : Box[View] = {

--- a/src/test/scala/code/api/API121Test.scala
+++ b/src/test/scala/code/api/API121Test.scala
@@ -1459,6 +1459,28 @@ class API1_2_1Test extends User1AllPrivileges with DefaultUsers with PrivateUser
       And("we should get an error message")
       reply.body.extract[ErrorMessage].error.nonEmpty should equal (true)
     }
+
+    scenario("we are not allowed to create a view with an empty name") {
+      Given("We will use an access token")
+      val bankId = randomBank
+      val bankAccount : AccountJSON = randomPrivateAccount(bankId)
+      val viewsBefore = getAccountViews(bankId, bankAccount.id, user1).body.extract[ViewsJSON].views
+      val viewWithEmptyName = ViewCreationJSON(
+        name = "",
+        description = randomString(3),
+        is_public = true,
+        which_alias_to_use="alias",
+        hide_metadata_if_alias_used = false,
+        allowed_actions = viewFields
+      )
+
+      When("the request is sent")
+      val reply = postView(bankId, bankAccount.id, viewWithEmptyName, user1)
+      Then("we should get a 400 code")
+      reply.code should equal (400)
+      And("we should get an error message")
+      reply.body.extract[ErrorMessage].error.nonEmpty should equal (true)
+    }
   }
 
   feature("Update a view on a bank account") {


### PR DESCRIPTION
…d on creation.

It does not address the mentioned wish for a system-generated UUID as an alternative to the user-generated id and in the API call the the field "name" has not been changed to "id" for consistency.