### PR TITLE
Issue #111 - Final Commit

### DIFF
--- a/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -205,6 +205,7 @@ class Boot extends Loggable{
     LiftRules.statelessDispatch.append(v1_3_0.OBPAPI1_3_0)
     LiftRules.statelessDispatch.append(v1_4_0.OBPAPI1_4_0)
     LiftRules.statelessDispatch.append(v2_0_0.OBPAPI2_0_0)
+    LiftRules.statelessDispatch.append(v2_1_0.OBPAPI2_1_0)
 
     //add management apis
     LiftRules.statelessDispatch.append(ImporterAPI)

--- a/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
+++ b/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
@@ -17,6 +17,7 @@ import scala.collection.immutable.Nil
 import code.api.v1_2_1.{APIInfoJSON, APIMethods121, HostedBy, OBPAPI1_2_1}
 import code.api.v1_3_0.{APIMethods130, OBPAPI1_3_0}
 import code.api.v2_0_0.{APIMethods200, OBPAPI2_0_0}
+import code.api.v2_1_0.{APIMethods210, OBPAPI2_1_0}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -26,7 +27,7 @@ import java.text.SimpleDateFormat
 import code.api.util.APIUtil.{ResourceDoc, _}
 import code.model._
 
-trait ResourceDocsAPIMethods extends Loggable with APIMethods200 with APIMethods140 with APIMethods130 with APIMethods121{
+trait ResourceDocsAPIMethods extends Loggable with APIMethods210 with APIMethods200 with APIMethods140 with APIMethods130 with APIMethods121{
   //needs to be a RestHelper to get access to JsonGet, JsonPost, etc.
   // We add previous APIMethods so we have access to the Resource Docs
   self: RestHelper =>
@@ -50,6 +51,7 @@ trait ResourceDocsAPIMethods extends Loggable with APIMethods200 with APIMethods
       logger.info(s"getResourceDocsList says requestedApiVersion is $requestedApiVersion")
 
       val resourceDocs = requestedApiVersion match {
+        case "2.1.0" => Implementations2_1_0.resourceDocs ++ Implementations2_0_0.resourceDocs ++ Implementations1_4_0.resourceDocs ++ Implementations1_3_0.resourceDocs ++ Implementations1_2_1.resourceDocs
         case "2.0.0" => Implementations2_0_0.resourceDocs ++ Implementations1_4_0.resourceDocs ++ Implementations1_3_0.resourceDocs ++ Implementations1_2_1.resourceDocs
         case "1.4.0" => Implementations1_4_0.resourceDocs ++ Implementations1_3_0.resourceDocs ++ Implementations1_2_1.resourceDocs
         case "1.3.0" => Implementations1_3_0.resourceDocs ++ Implementations1_2_1.resourceDocs
@@ -59,6 +61,7 @@ trait ResourceDocsAPIMethods extends Loggable with APIMethods200 with APIMethods
       logger.info(s"There are ${resourceDocs.length} resource docs available to $requestedApiVersion")
 
       val versionRoutes = requestedApiVersion match {
+        case "2.1.0" => OBPAPI2_1_0.routes
         case "2.0.0" => OBPAPI2_0_0.routes
         case "1.4.0" => OBPAPI1_4_0.routes
         case "1.3.0" => OBPAPI1_3_0.routes

--- a/src/main/scala/code/api/util/APIUtil.scala
+++ b/src/main/scala/code/api/util/APIUtil.scala
@@ -109,6 +109,8 @@ object ErrorMessages {
   val InvalidGetBankAccountsConnectorResponse = "OBP-30201: Connector did not return the set of accounts we requested."
   val InvalidGetBankAccountConnectorResponse = "OBP-30202: Connector did not return the account we requested."
   val InvalidGetTransactionConnectorResponse = "OBP-30203: Connector did not return the transaction we requested."
+  val EntitlementIsBankRole = "OBP-30204: This entitlement is a Bank Role. Please set bank_id to a valid bank id."
+  val EntitlementIsSystemRole = "OBP-30205: This entitlement is a System Role. Please set bank_id to empty string."
 
 
 

--- a/src/main/scala/code/api/util/ApiRole.scala
+++ b/src/main/scala/code/api/util/ApiRole.scala
@@ -1,22 +1,47 @@
 package code.api.util
 
-sealed trait ApiRole
+sealed trait ApiRole{
+  val requiresBankId: Boolean
+}
 
 object ApiRole {
 
-  case object CanSearchAllTransactions extends ApiRole
-  case object CanSearchAllAccounts extends ApiRole
-  case object CanQueryOtherUser extends ApiRole
-  case object CanSearchWarehouse extends ApiRole
-  case object CanSearchMetrics extends ApiRole
-  case object CanCreateCustomer extends ApiRole
-  case object CanCreateAccount extends ApiRole
-  case object CanGetAnyUser extends ApiRole
-  case object IsHackathonDeveloper extends ApiRole
-  case object CanCreateAnyTransactionRequest extends ApiRole
-  case object CanAddSocialMediaHandle extends ApiRole
-  case object CanGetSocialMediaHandles extends ApiRole
-  case object CanCreateSandbox extends ApiRole
+  case object CanSearchAllTransactions extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanSearchAllAccounts extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanQueryOtherUser extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanSearchWarehouse extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanSearchMetrics extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanCreateCustomer extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanCreateAccount extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanGetAnyUser extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanCreateAnyTransactionRequest extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanAddSocialMediaHandle extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanGetSocialMediaHandles extends ApiRole{
+    val requiresBankId = true
+  }
+  case object CanCreateSandbox extends ApiRole{
+    val requiresBankId = false
+  }
 
   def valueOf(value: String): ApiRole = value match {
     case "CanSearchAllTransactions" => CanSearchAllTransactions
@@ -27,7 +52,6 @@ object ApiRole {
     case "CanCreateCustomer" => CanCreateCustomer
     case "CanCreateAccount" => CanCreateAccount
     case "CanGetAnyUser" => CanGetAnyUser
-    case "IsHackathonDeveloper" => IsHackathonDeveloper
     case "CanCreateAnyTransactionRequest" => CanCreateAnyTransactionRequest
     case "CanAddSocialMediaHandle" => CanAddSocialMediaHandle
     case "CanGetSocialMediaHandles" => CanGetSocialMediaHandles

--- a/src/main/scala/code/api/util/ApiRole.scala
+++ b/src/main/scala/code/api/util/ApiRole.scala
@@ -7,13 +7,13 @@ sealed trait ApiRole{
 object ApiRole {
 
   case object CanSearchAllTransactions extends ApiRole{
-    val requiresBankId = true
+    val requiresBankId = false
   }
   case object CanSearchAllAccounts extends ApiRole{
-    val requiresBankId = true
+    val requiresBankId = false
   }
   case object CanQueryOtherUser extends ApiRole{
-    val requiresBankId = true
+    val requiresBankId = false
   }
   case object CanSearchWarehouse extends ApiRole{
     val requiresBankId = true
@@ -28,7 +28,7 @@ object ApiRole {
     val requiresBankId = true
   }
   case object CanGetAnyUser extends ApiRole{
-    val requiresBankId = true
+    val requiresBankId = false
   }
   case object CanCreateAnyTransactionRequest extends ApiRole{
     val requiresBankId = true

--- a/src/main/scala/code/api/v2_0_0/APIMethods200.scala
+++ b/src/main/scala/code/api/v2_0_0/APIMethods200.scala
@@ -1773,6 +1773,8 @@ trait APIMethods200 {
             isSuperAdmin <- booleanToBox(isSuperAdmin(u.userId)) ?~ "Logged user is not super admin!"
             user <- User.findByUserId(userId) ?~! ErrorMessages.UserNotFoundById
             postedData <- tryo{json.extract[CreateEntitlementJSON]} ?~ "wrong format JSON"
+            isBankOrSystemRoleOk <- booleanToBox(ApiRole.valueOf(postedData.role_name).requiresBankId == postedData.bank_id.nonEmpty) ?~!
+              {if (ApiRole.valueOf(postedData.role_name).requiresBankId) ErrorMessages.EntitlementIsBankRole else ErrorMessages.EntitlementIsSystemRole}
             bank <- booleanToBox(Bank(BankId(postedData.bank_id)).isEmpty == false || postedData.bank_id.nonEmpty == false) ?~! {ErrorMessages.BankNotFound}
             role <- tryo{valueOf(postedData.role_name)} ?~! "wrong role name"
             hasEntitlement <- booleanToBox(hasEntitlement(postedData.bank_id, userId, role) == false, "Entitlement already exists for the user.")

--- a/src/main/scala/code/api/v2_1_0/APIMethods210.scala
+++ b/src/main/scala/code/api/v2_1_0/APIMethods210.scala
@@ -1,0 +1,130 @@
+package code.api.v2_1_0
+
+import java.text.SimpleDateFormat
+import java.util.Calendar
+
+import code.TransactionTypes.TransactionType
+import code.api.APIFailure
+import code.api.util.APIUtil._
+import code.api.util.ApiRole._
+import code.api.util.{APIUtil, ApiRole, ErrorMessages}
+import code.api.v1_2_1.OBPAPI1_2_1._
+import code.api.v1_2_1.{APIMethods121, AmountOfMoneyJSON => AmountOfMoneyJSON121, JSONFactory => JSONFactory121}
+import code.api.v1_4_0.JSONFactory1_4_0
+import code.api.v1_4_0.JSONFactory1_4_0.{ChallengeAnswerJSON, CustomerFaceImageJson, TransactionRequestAccountJSON}
+import code.entitlement.Entitlement
+import code.search.{elasticsearchMetrics, elasticsearchWarehouse}
+import net.liftweb.http.CurrentReq
+//import code.api.v2_0_0.{CreateCustomerJson}
+
+import code.model.dataAccess.OBPUser
+import net.liftweb.mapper.By
+
+//import code.api.v1_4_0.JSONFactory1_4_0._
+import code.api.v2_0_0.JSONFactory200._
+import code.bankconnectors.Connector
+import code.fx.fx
+import code.kycchecks.KycChecks
+import code.kycdocuments.KycDocuments
+import code.kycmedias.KycMedias
+import code.kycstatuses.KycStatuses
+import code.model._
+import code.model.dataAccess.BankAccountCreation
+import code.socialmedia.SocialMediaHandle
+import code.transactionrequests.TransactionRequests
+
+import code.meetings.Meeting
+import code.usercustomerlinks.UserCustomerLink
+
+import net.liftweb.common.{Full, _}
+import net.liftweb.http.rest.RestHelper
+import net.liftweb.http.{JsonResponse, Req}
+import net.liftweb.json.JsonAST.JValue
+import net.liftweb.util.Helpers._
+import net.liftweb.util.Props
+
+import scala.collection.immutable.Nil
+import scala.collection.mutable.ArrayBuffer
+// Makes JValue assignment to Nil work
+import code.customer.{MockCustomerFaceImage, Customer}
+import code.util.Helper._
+import net.liftweb.http.js.JE.JsRaw
+import net.liftweb.json.Extraction
+import net.liftweb.json.JsonDSL._
+
+import code.api.{APIFailure, OBPRestHelper}
+import code.api.util.APIUtil._
+import code.sandbox.{OBPDataImport, SandboxDataImport}
+import code.util.Helper
+import net.liftweb.common.{Box, Full, Failure, Loggable}
+import net.liftweb.http.{JsonResponse, ForbiddenResponse, S}
+import net.liftweb.http.js.JE.JsRaw
+import net.liftweb.http.rest.RestHelper
+import net.liftweb.util.Helpers._
+
+
+trait APIMethods210 {
+  //needs to be a RestHelper to get access to JsonGet, JsonPost, etc.
+  self: RestHelper =>
+
+  // helper methods begin here
+  // helper methods end here
+
+  val Implementations2_1_0 = new Object() {
+
+    val resourceDocs = ArrayBuffer[ResourceDoc]()
+    val apiRelations = ArrayBuffer[ApiRelation]()
+
+    val emptyObjectJson: JValue = Nil
+    val apiVersion: String = "2_1_0"
+
+    val exampleDateString: String = "22/08/2013"
+    val simpleDateFormat: SimpleDateFormat = new SimpleDateFormat("dd/mm/yyyy")
+    val exampleDate = simpleDateFormat.parse(exampleDateString)
+
+    val codeContext = CodeContext(resourceDocs, apiRelations)
+
+
+    resourceDocs += ResourceDoc(
+      sandboxDataImport,
+      apiVersion,
+      "sandboxDataImport",
+      "POST",
+      "/sandbox/data-import",
+      "Import data into the sandbox.",
+      s"""Import bulk data into the sandbox (Authenticated access).
+          |The user needs to have CanCreateSandbox entitlement.
+          |
+          |An example of an import set of data (json) can be found [here](https://raw.githubusercontent.com/OpenBankProject/OBP-API/develop/src/main/scala/code/api/sandbox/example_data/2016-04-28/example_import.json)
+         |${authenticationRequiredMessage(true)}
+          |""",
+      emptyObjectJson,
+      emptyObjectJson,
+      emptyObjectJson :: Nil,
+      false,
+      false,
+      false,
+      List(apiTagAccount, apiTagPrivateData, apiTagPublicData))
+
+
+    lazy val sandboxDataImport: PartialFunction[Req, Box[User] => Box[JsonResponse]] = {
+      //import data into the sandbox
+      case "sandbox" :: "data-import" :: Nil JsonPost json -> _ => {
+        user =>
+          for {
+            u <- user ?~! ErrorMessages.UserNotLoggedIn
+            allowDataImportProp <- Props.get("allow_sandbox_data_import") ~> APIFailure("Data import is disabled for this API instance.", 403)
+            allowDataImport <- Helper.booleanToBox(allowDataImportProp == "true") ~> APIFailure("Data import is disabled for this API instance.", 403)
+            canCreateSandbox <- booleanToBox(hasEntitlement("", u.userId, CanCreateSandbox), s"$CanCreateSandbox entitlement required")
+            importData <- tryo {json.extract[SandboxDataImport]} ?~ "invalid json"
+            importWorked <- OBPDataImport.importer.vend.importData(importData)
+          } yield {
+            successJsonResponse(JsRaw("{}"), 201)
+          }
+      }
+    }
+  }
+}
+
+object APIMethods210 {
+}

--- a/src/main/scala/code/api/v2_1_0/APIMethods210.scala
+++ b/src/main/scala/code/api/v2_1_0/APIMethods210.scala
@@ -1,63 +1,26 @@
 package code.api.v2_1_0
 
 import java.text.SimpleDateFormat
-import java.util.Calendar
-
-import code.TransactionTypes.TransactionType
-import code.api.APIFailure
-import code.api.util.APIUtil._
 import code.api.util.ApiRole._
-import code.api.util.{APIUtil, ApiRole, ErrorMessages}
-import code.api.v1_2_1.OBPAPI1_2_1._
-import code.api.v1_2_1.{APIMethods121, AmountOfMoneyJSON => AmountOfMoneyJSON121, JSONFactory => JSONFactory121}
-import code.api.v1_4_0.JSONFactory1_4_0
-import code.api.v1_4_0.JSONFactory1_4_0.{ChallengeAnswerJSON, CustomerFaceImageJson, TransactionRequestAccountJSON}
-import code.entitlement.Entitlement
-import code.search.{elasticsearchMetrics, elasticsearchWarehouse}
-import net.liftweb.http.CurrentReq
-//import code.api.v2_0_0.{CreateCustomerJson}
-
-import code.model.dataAccess.OBPUser
-import net.liftweb.mapper.By
-
-//import code.api.v1_4_0.JSONFactory1_4_0._
-import code.api.v2_0_0.JSONFactory200._
-import code.bankconnectors.Connector
-import code.fx.fx
-import code.kycchecks.KycChecks
-import code.kycdocuments.KycDocuments
-import code.kycmedias.KycMedias
-import code.kycstatuses.KycStatuses
+import code.api.util.ErrorMessages
 import code.model._
-import code.model.dataAccess.BankAccountCreation
-import code.socialmedia.SocialMediaHandle
-import code.transactionrequests.TransactionRequests
 
-import code.meetings.Meeting
-import code.usercustomerlinks.UserCustomerLink
-
-import net.liftweb.common.{Full, _}
-import net.liftweb.http.rest.RestHelper
-import net.liftweb.http.{JsonResponse, Req}
+import net.liftweb.http.Req
 import net.liftweb.json.JsonAST.JValue
-import net.liftweb.util.Helpers._
 import net.liftweb.util.Props
 
 import scala.collection.immutable.Nil
 import scala.collection.mutable.ArrayBuffer
 // Makes JValue assignment to Nil work
-import code.customer.{MockCustomerFaceImage, Customer}
 import code.util.Helper._
-import net.liftweb.http.js.JE.JsRaw
-import net.liftweb.json.Extraction
 import net.liftweb.json.JsonDSL._
 
-import code.api.{APIFailure, OBPRestHelper}
+import code.api.APIFailure
 import code.api.util.APIUtil._
 import code.sandbox.{OBPDataImport, SandboxDataImport}
 import code.util.Helper
-import net.liftweb.common.{Box, Full, Failure, Loggable}
-import net.liftweb.http.{JsonResponse, ForbiddenResponse, S}
+import net.liftweb.common.Box
+import net.liftweb.http.JsonResponse
 import net.liftweb.http.js.JE.JsRaw
 import net.liftweb.http.rest.RestHelper
 import net.liftweb.util.Helpers._

--- a/src/main/scala/code/api/v2_1_0/JSONFactory2.1.0.scala
+++ b/src/main/scala/code/api/v2_1_0/JSONFactory2.1.0.scala
@@ -1,0 +1,35 @@
+/**
+Open Bank Project - API
+Copyright (C) 2011-2015, TESOBE Ltd
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Email: contact@tesobe.com
+TESOBE / Music Pictures Ltd
+Osloerstrasse 16/17
+Berlin 13359, Germany
+
+  This product includes software developed at
+  TESOBE (http://www.tesobe.com/)
+  by
+  Simon Redfern : simon AT tesobe DOT com
+  Stefan Bethge : stefan AT tesobe DOT com
+  Everett Sochowski : everett AT tesobe DOT com
+  Ayoub Benali: ayoub AT tesobe DOT com
+
+ */
+package code.api.v2_1_0
+
+object JSONFactory210{
+}

--- a/src/main/scala/code/api/v2_1_0/OBPAPI2_1_0.scala
+++ b/src/main/scala/code/api/v2_1_0/OBPAPI2_1_0.scala
@@ -1,0 +1,194 @@
+/**
+  * Open Bank Project - API
+  * Copyright (C) 2011-2015, TESOBE / Music Pictures Ltd
+  **
+  *This program is free software: you can redistribute it and/or modify
+  *it under the terms of the GNU Affero General Public License as published by
+  *the Free Software Foundation, either version 3 of the License, or
+  *(at your option) any later version.
+  **
+  *This program is distributed in the hope that it will be useful,
+  *but WITHOUT ANY WARRANTY; without even the implied warranty of
+  *MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  *GNU Affero General Public License for more details.
+  **
+  *You should have received a copy of the GNU Affero General Public License
+  *along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  **
+  *Email: contact@tesobe.com
+  *TESOBE / Music Pictures Ltd
+  *Osloerstrasse 16/17
+  *Berlin 13359, Germany
+  **
+  *This product includes software developed at
+  *TESOBE (http://www.tesobe.com/)
+  * by
+  *Simon Redfern : simon AT tesobe DOT com
+  *Stefan Bethge : stefan AT tesobe DOT com
+  *Everett Sochowski : everett AT tesobe DOT com
+  *Ayoub Benali: ayoub AT tesobe DOT com
+  *
+  */
+package code.api.v2_1_0
+
+import code.api.OBPRestHelper
+import code.api.v1_3_0.APIMethods130
+import code.api.v1_4_0.APIMethods140
+import code.api.v2_0_0.APIMethods200
+import net.liftweb.common.Loggable
+
+object OBPAPI2_1_0 extends OBPRestHelper with APIMethods130 with APIMethods140 with APIMethods200 with APIMethods210 with Loggable {
+
+
+  val VERSION = "2.1.0"
+
+
+  // Note: Since we pattern match on these routes, if two implementations match a given url the first will match
+
+  var routes = List(
+    Implementations1_2_1.root(VERSION),
+    Implementations1_2_1.getBanks,
+    Implementations1_2_1.bankById,
+    // Now in 2_0_0
+    //  Implementations1_2_1.allAccountsAllBanks,
+    //  Implementations1_2_1.privateAccountsAllBanks,
+    //  Implementations1_2_1.publicAccountsAllBanks,
+    //  Implementations1_2_1.allAccountsAtOneBank,
+    //  Implementations1_2_1.privateAccountsAtOneBank,
+    //  Implementations1_2_1.publicAccountsAtOneBank,
+    //  Implementations1_2_1.accountById,
+    Implementations1_2_1.updateAccountLabel,
+    Implementations1_2_1.getViewsForBankAccount,
+    Implementations1_2_1.createViewForBankAccount,
+    Implementations1_2_1.updateViewForBankAccount,
+    Implementations1_2_1.deleteViewForBankAccount,
+    //    Implementations1_2_1.getPermissionsForBankAccount,
+    //    Implementations1_2_1.getPermissionForUserForBankAccount,
+    Implementations1_2_1.addPermissionForUserForBankAccountForMultipleViews,
+    Implementations1_2_1.addPermissionForUserForBankAccountForOneView,
+    Implementations1_2_1.removePermissionForUserForBankAccountForOneView,
+    Implementations1_2_1.removePermissionForUserForBankAccountForAllViews,
+    Implementations1_2_1.getCounterpartiesForBankAccount,
+    Implementations1_2_1.getCounterpartyByIdForBankAccount,
+    Implementations1_2_1.getCounterpartyMetadata,
+    Implementations1_2_1.getCounterpartyPublicAlias,
+    Implementations1_2_1.addCounterpartyPublicAlias,
+    Implementations1_2_1.updateCounterpartyPublicAlias,
+    Implementations1_2_1.deleteCounterpartyPublicAlias,
+    Implementations1_2_1.getCounterpartyPrivateAlias,
+    Implementations1_2_1.addCounterpartyPrivateAlias,
+    Implementations1_2_1.updateCounterpartyPrivateAlias,
+    Implementations1_2_1.deleteCounterpartyPrivateAlias,
+    Implementations1_2_1.addCounterpartyMoreInfo,
+    Implementations1_2_1.updateCounterpartyMoreInfo,
+    Implementations1_2_1.deleteCounterpartyMoreInfo,
+    Implementations1_2_1.addCounterpartyUrl,
+    Implementations1_2_1.updateCounterpartyUrl,
+    Implementations1_2_1.deleteCounterpartyUrl,
+    Implementations1_2_1.addCounterpartyImageUrl,
+    Implementations1_2_1.updateCounterpartyImageUrl,
+    Implementations1_2_1.deleteCounterpartyImageUrl,
+    Implementations1_2_1.addCounterpartyOpenCorporatesUrl,
+    Implementations1_2_1.updateCounterpartyOpenCorporatesUrl,
+    Implementations1_2_1.deleteCounterpartyOpenCorporatesUrl,
+    Implementations1_2_1.addCounterpartyCorporateLocation,
+    Implementations1_2_1.updateCounterpartyCorporateLocation,
+    Implementations1_2_1.deleteCounterpartyCorporateLocation,
+    Implementations1_2_1.addCounterpartyPhysicalLocation,
+    Implementations1_2_1.updateCounterpartyPhysicalLocation,
+    Implementations1_2_1.deleteCounterpartyPhysicalLocation,
+    Implementations1_2_1.getTransactionsForBankAccount,
+    Implementations1_2_1.getTransactionByIdForBankAccount,
+    Implementations1_2_1.getTransactionNarrative,
+    Implementations1_2_1.addTransactionNarrative,
+    Implementations1_2_1.updateTransactionNarrative,
+    Implementations1_2_1.deleteTransactionNarrative,
+    Implementations1_2_1.getCommentsForViewOnTransaction,
+    Implementations1_2_1.addCommentForViewOnTransaction,
+    Implementations1_2_1.deleteCommentForViewOnTransaction,
+    Implementations1_2_1.getTagsForViewOnTransaction,
+    Implementations1_2_1.addTagForViewOnTransaction,
+    Implementations1_2_1.deleteTagForViewOnTransaction,
+    Implementations1_2_1.getImagesForViewOnTransaction,
+    Implementations1_2_1.addImageForViewOnTransaction,
+    Implementations1_2_1.deleteImageForViewOnTransaction,
+    Implementations1_2_1.getWhereTagForViewOnTransaction,
+    Implementations1_2_1.addWhereTagForViewOnTransaction,
+    Implementations1_2_1.updateWhereTagForViewOnTransaction,
+    Implementations1_2_1.deleteWhereTagForViewOnTransaction,
+    Implementations1_2_1.getCounterpartyForTransaction,
+    Implementations1_2_1.makePayment,
+
+    // New in 1.3.0
+    Implementations1_3_0.getCards,
+    Implementations1_3_0.getCardsForBank,
+
+    // New in 1.4.0
+    Implementations1_4_0.getCustomer,
+    //  Now in 2.0.0 Implementations1_4_0.addCustomer,
+    Implementations1_4_0.getCustomerMessages,
+    Implementations1_4_0.addCustomerMessage,
+    Implementations1_4_0.getBranches,
+    Implementations1_4_0.getAtms,
+    Implementations1_4_0.getProducts,
+    Implementations1_4_0.getCrmEvents,
+    // Now in 2.0.0 Implementations1_4_0.createTransactionRequest,
+    // Now in 2.0.0 Implementations1_4_0.getTransactionRequests,
+    Implementations1_4_0.getTransactionRequestTypes,
+
+    // Updated in 2.0.0 (less info about the views)
+    Implementations2_0_0.allAccountsAllBanks,
+    Implementations2_0_0.privateAccountsAllBanks,
+    Implementations2_0_0.publicAccountsAllBanks,
+    Implementations2_0_0.allAccountsAtOneBank,
+    Implementations2_0_0.privateAccountsAtOneBank,
+    Implementations2_0_0.publicAccountsAtOneBank,
+    Implementations2_0_0.createTransactionRequest,
+    Implementations2_0_0.answerTransactionRequestChallenge,
+    Implementations2_0_0.getTransactionRequests, // Now has charges information
+    // Updated in 2.0.0 (added sorting and better guards / error messages)
+    Implementations2_0_0.accountById,
+    Implementations2_0_0.getPermissionsForBankAccount,
+    Implementations2_0_0.getPermissionForUserForBankAccount,
+    // New in 2.0.0
+    Implementations2_0_0.getKycDocuments,
+    Implementations2_0_0.getKycMedia,
+    Implementations2_0_0.getKycStatuses,
+    Implementations2_0_0.getKycChecks,
+    Implementations2_0_0.getSocialMediaHandles,
+    Implementations2_0_0.addKycDocument,
+    Implementations2_0_0.addKycMedia,
+    Implementations2_0_0.addKycStatus,
+    Implementations2_0_0.addKycCheck,
+    Implementations2_0_0.addSocialMediaHandle,
+    Implementations2_0_0.getCoreAccountById,
+    Implementations2_0_0.getCoreTransactionsForBankAccount,
+    Implementations2_0_0.createAccount,
+    Implementations2_0_0.getTransactionTypes,
+    Implementations2_0_0.createUser,
+    Implementations2_0_0.createMeeting,
+    Implementations2_0_0.getMeetings,
+    Implementations2_0_0.getMeeting,
+    Implementations2_0_0.createCustomer,
+    Implementations2_0_0.getCurrentUser,
+    Implementations2_0_0.getUser,
+    Implementations2_0_0.createUserCustomerLinks,
+    Implementations2_0_0.addEntitlement,
+    Implementations2_0_0.getEntitlements,
+    Implementations2_0_0.deleteEntitlement,
+    Implementations2_0_0.getAllEntitlements,
+    Implementations2_0_0.elasticSearchWarehouse,
+    Implementations2_0_0.elasticSearchMetrics,
+    Implementations2_0_0.getCustomers,
+    // New in 2.1.0
+    Implementations2_1_0.sandboxDataImport
+  )
+
+  routes.foreach(route => {
+    oauthServe(apiPrefix{route})
+  })
+
+
+
+
+}


### PR DESCRIPTION
+ ApiRoles (entitlements) now are split into Bank/System Roles (require/doesn't require a BankId)
+ API v2.1.0 created
+ /sandbox/data-import endpoint moved into the main API body from the sandbox

Please note that I am not very sure which ApiRoles require or don't a bank id. For the moment is like this:
- CanSearchAllTransactions requiresBankId = true
- CanSearchAllAccounts requiresBankId = true
- CanQueryOtherUser requiresBankId = true
- CanSearchWarehouse requiresBankId = true
- CanSearchMetrics requiresBankId = true
- CanCreateCustomer requiresBankId = true
- CanCreateAccount requiresBankId = true
- CanGetAnyUser requiresBankId = true
- CanCreateAnyTransactionRequest requiresBankId = true
- CanAddSocialMediaHandle requiresBankId = true
- CanGetSocialMediaHandles requiresBankId = true
- CanCreateSandbox requiresBankId = false
