### PR TITLE
Username instead of email

### DIFF
--- a/src/main/scala/code/api/directlogin.scala
+++ b/src/main/scala/code/api/directlogin.scala
@@ -303,7 +303,7 @@ object DirectLogin extends RestHelper with Loggable {
         val user = token.user
         //just a log
         user match {
-          case Full(u) => logger.info("user " + u.emailAddress + " was found from the DirectLogin token")
+          case Full(u) => logger.info("user " + u.name + " was found from the DirectLogin token")
           case _ => logger.info("no user was found for the DirectLogin token")
         }
         user

--- a/src/main/scala/code/api/oauth1.0.scala
+++ b/src/main/scala/code/api/oauth1.0.scala
@@ -519,7 +519,7 @@ object OAuthHandshake extends RestHelper with Loggable {
           val user = token.user
           //just a log
           user match {
-            case Full(u) => logger.info("user " + u.emailAddress + " was found from the oauth token")
+            case Full(u) => logger.info("user " + u.name + " was found from the oauth token")
             case _ => logger.info("no user was found for the oauth token")
           }
           user

--- a/src/main/scala/code/api/v2_0_0/APIMethods200.scala
+++ b/src/main/scala/code/api/v2_0_0/APIMethods200.scala
@@ -1340,7 +1340,7 @@ trait APIMethods200 {
         | May require validation of email address.
         |
         |""",
-      Extraction.decompose(CreateUserJSON("someone@example.com", "my-secure-password", "James", "Brown")),
+      Extraction.decompose(CreateUserJSON("someone@example.com", "my-username", "my-secure-password", "James", "Brown")),
       emptyObjectJson,
       emptyObjectJson :: Nil,
       true,
@@ -1354,10 +1354,11 @@ trait APIMethods200 {
           for {
             postedData <- tryo {json.extract[CreateUserJSON]} ?~! ErrorMessages.InvalidJsonFormat
           } yield {
-            if (OBPUser.find(By(OBPUser.email, postedData.email)).isEmpty) {
+            if (OBPUser.find(By(OBPUser.username, postedData.username)).isEmpty) {
               val userCreated = OBPUser.create
                 .firstName(postedData.first_name)
                 .lastName(postedData.last_name)
+                .username(postedData.username)
                 .email(postedData.email)
                 .password(postedData.password)
                 .validated(true) // TODO Get this from Props

--- a/src/main/scala/code/api/v2_0_0/APIMethods200.scala
+++ b/src/main/scala/code/api/v2_0_0/APIMethods200.scala
@@ -1667,8 +1667,8 @@ trait APIMethods200 {
       "getUser",
       "GET",
       "/users/USER_EMAIL",
-      "Get User by Email Address",
-      """Get the user by email address
+      "Get Users by Email Address",
+      """Get users by email address
         |
         |Login is required.
         |CanGetAnyUser entitlement is required,
@@ -1688,14 +1688,13 @@ trait APIMethods200 {
         user =>
             for {
               l <- user ?~ ErrorMessages.UserNotLoggedIn
-              //b <- tryo{Bank.all.headOption} ?~! {ErrorMessages.BankNotFound} //TODO: This is a temp workaround
               canGetAnyUser <- booleanToBox(hasEntitlement("", l.userId, ApiRole.CanGetAnyUser), "CanGetAnyUser entitlement required")
               // Workaround to get userEmail address directly from URI without needing to URL-encode it
-              u <- OBPUser.getApiUserByEmail(CurrentReq.value.uri.split("/").last) ?~! {ErrorMessages.UserNotFoundByEmail}
+              users <- tryo{OBPUser.getApiUsersByEmail(CurrentReq.value.uri.split("/").last)} ?~! {ErrorMessages.UserNotFoundByEmail}
             }
               yield {
                 // Format the data as V2.0.0 json
-                val json = JSONFactory200.createUserJSON(u)
+                val json = JSONFactory200.createUserJSONs(users)
                 successJsonResponse(Extraction.decompose(json))
               }
       }

--- a/src/main/scala/code/api/v2_0_0/APIMethods200.scala
+++ b/src/main/scala/code/api/v2_0_0/APIMethods200.scala
@@ -1377,7 +1377,7 @@ trait APIMethods200 {
               }
             }
             else {
-              Full(errorJsonResponse("User with the same email already exists.", 409))
+              Full(errorJsonResponse("User with the same username already exists.", 409))
             }
           }
       }

--- a/src/main/scala/code/api/v2_0_0/JSONFactory2.0.0.scala
+++ b/src/main/scala/code/api/v2_0_0/JSONFactory2.0.0.scala
@@ -79,6 +79,9 @@ case class CreateUserJSON(
                      last_name: String
                    )
 
+case class CreateUserJSONs(
+                            users : List[CreateUserJSON]
+                          )
 
 case class CreateMeetingJSON(
                               provider_id: String,
@@ -482,11 +485,12 @@ object JSONFactory200{
                        email : String,
                        provider_id: String,
                        provider : String,
-                       display_name : String
+                       user_name : String
                      )
 
-
-
+  case class UserJSONs(
+                      users: List[UserJSON]
+                      )
 
 
   def createUserJSONfromOBPUser(user : OBPUser) : UserJSON = new UserJSON(
@@ -494,7 +498,7 @@ object JSONFactory200{
     email = user.email,
     provider_id = stringOrNull(user.provider),
     provider = stringOrNull(user.provider),
-    display_name = stringOrNull(user.displayName())
+    user_name = stringOrNull(user.username)
   )
 
 
@@ -504,7 +508,7 @@ object JSONFactory200{
       email = user.emailAddress,
       provider_id = user.idGivenByProvider,
       provider = stringOrNull(user.provider),
-      display_name = stringOrNull(user.name) //TODO: Rename to displayName ?
+      user_name = stringOrNull(user.name) //TODO: Rename to displayName ?
     )
   }
 
@@ -513,6 +517,10 @@ object JSONFactory200{
       case Full(u) => createUserJSON(u)
       case _ => null
     }
+  }
+
+  def createUserJSONs(users : List[User]) : UserJSONs = {
+    UserJSONs(users.map(createUserJSON))
   }
 
 
@@ -682,7 +690,6 @@ object JSONFactory200{
 
   /** Creates v2.0.0 representation of a TransactionType
     *
-    *
     * @param transactionType An internal TransactionType instance
     * @return a v2.0.0 representation of a TransactionType
     */
@@ -705,7 +712,6 @@ def createTransactionTypeJSON(transactionType : TransactionType) : TransactionTy
 
 
   /** Creates v2.0.0 representation of a TransactionType
-    *
     *
     * @param tr An internal TransactionRequest instance
     * @return a v2.0.0 representation of a TransactionRequest

--- a/src/main/scala/code/api/v2_0_0/JSONFactory2.0.0.scala
+++ b/src/main/scala/code/api/v2_0_0/JSONFactory2.0.0.scala
@@ -74,6 +74,7 @@ class ResultAndLinksJSON(
 
 case class CreateUserJSON(
                      email: String,
+                     username: String,
                      password: String,
                      first_name: String,
                      last_name: String
@@ -485,7 +486,7 @@ object JSONFactory200{
                        email : String,
                        provider_id: String,
                        provider : String,
-                       user_name : String
+                       username : String
                      )
 
   case class UserJSONs(
@@ -496,9 +497,9 @@ object JSONFactory200{
   def createUserJSONfromOBPUser(user : OBPUser) : UserJSON = new UserJSON(
     user_id = user.user.foreign.get.userId,
     email = user.email,
+    username = stringOrNull(user.username),
     provider_id = stringOrNull(user.provider),
-    provider = stringOrNull(user.provider),
-    user_name = stringOrNull(user.username)
+    provider = stringOrNull(user.provider)
   )
 
 
@@ -506,9 +507,9 @@ object JSONFactory200{
     new UserJSON(
       user_id = user.userId,
       email = user.emailAddress,
+      username = stringOrNull(user.name),
       provider_id = user.idGivenByProvider,
-      provider = stringOrNull(user.provider),
-      user_name = stringOrNull(user.name) //TODO: Rename to displayName ?
+      provider = stringOrNull(user.provider)
     )
   }
 

--- a/src/main/scala/code/model/dataAccess/OBPUser.scala
+++ b/src/main/scala/code/model/dataAccess/OBPUser.scala
@@ -452,7 +452,6 @@ import net.liftweb.util.Helpers._
   }
 
   protected def findUserByUsername(name: String): Box[TheUserType] = {
-    println("[findUserByUsername]------------------------------------------> " + name)
     find(By(this.username, name))
   }
 

--- a/src/main/scala/code/sandbox/CreateOBPUsers.scala
+++ b/src/main/scala/code/sandbox/CreateOBPUsers.scala
@@ -18,7 +18,7 @@ trait CreateOBPUsers {
       }
     }
 
-    val existingObpUser = OBPUser.find(By(OBPUser.email, u.email))
+    val existingObpUser = OBPUser.find(By(OBPUser.username, u.user_name))
 
     if(existingObpUser.isDefined) {
       logger.warn(s"Existing OBPUser with email ${u.email} detected in data import where no APIUser was found")
@@ -26,7 +26,8 @@ trait CreateOBPUsers {
     } else {
       val obpUser = OBPUser.create
         .email(u.email)
-        .lastName(u.display_name)
+        .lastName(u.user_name)
+        .username(u.user_name)
         .password(u.password)
         .validated(true)
 

--- a/src/main/scala/code/sandbox/OBPDataImport.scala
+++ b/src/main/scala/code/sandbox/OBPDataImport.scala
@@ -47,7 +47,7 @@ trait OBPDataImport extends Loggable {
   type MetadataType <: OtherBankAccountMetadata
   type ViewType <: View
   type TransactionType <: TransactionUUID
-  type AccountOwnerEmail = String
+  type AccountOwnerUsername = String
   type BranchType <: Branch
   type AtmType <: Atm
   type ProductType <: Product
@@ -135,17 +135,17 @@ trait OBPDataImport extends Loggable {
   protected def createSaveableUser(u : SandboxUserImport) : Box[Saveable[APIUser]]
 
   protected def createUsers(toImport : List[SandboxUserImport]) : Box[List[Saveable[APIUser]]] = {
-    val existingApiUsers = toImport.flatMap(u => APIUser.find(By(APIUser.email, u.email)))
-    val allEmails = toImport.map(_.email)
-    val duplicateEmails = allEmails diff allEmails.distinct
+    val existingApiUsers = toImport.flatMap(u => APIUser.find(By(APIUser.name_, u.user_name)))
+    val allUsernames = toImport.map(_.user_name)
+    val duplicateUsernames = allUsernames diff allUsernames.distinct
 
     def usersExist(existingEmails : List[String]) =
       Failure(s"User(s) with email(s) $existingEmails already exist (and may be different (e.g. different display_name)")
 
     if(!existingApiUsers.isEmpty) {
-      usersExist(existingApiUsers.map(_.email.get))
-    } else if(!duplicateEmails.isEmpty) {
-      Failure(s"Users must have unique emails: Duplicates found: $duplicateEmails")
+      usersExist(existingApiUsers.map(_.name))
+    } else if(!duplicateUsernames.isEmpty) {
+      Failure(s"Users must have unique usernames: Duplicates found: $duplicateUsernames")
     }else {
 
       val apiUsers = toImport.map(createSaveableUser(_))
@@ -159,8 +159,8 @@ trait OBPDataImport extends Loggable {
    *
    * TODO: this only works after createdUsers have been saved (and thus an APIUser has been created
    */
-  protected def setAccountOwner(owner : AccountOwnerEmail, account: BankAccount, createdUsers: List[APIUser]): AnyVal = {
-    val apiUserOwner = createdUsers.find(user => owner == user.emailAddress)
+  protected def setAccountOwner(owner : AccountOwnerUsername, account: BankAccount, createdUsers: List[APIUser]): AnyVal = {
+    val apiUserOwner = createdUsers.find(user => owner == user.name)
 
     apiUserOwner match {
       case Some(o) => {
@@ -168,7 +168,7 @@ trait OBPDataImport extends Loggable {
       }
       case None => {
         //This shouldn't happen as OBPUser should generate the APIUsers when saved
-        logger.error(s"api user(s) with email $owner not found.")
+        logger.error(s"api user $owner not found.")
         logger.error("Data import completed with errors.")
       }
     }
@@ -286,9 +286,9 @@ trait OBPDataImport extends Loggable {
   final protected def createCrmEvents(data : SandboxDataImport) = {
       createSaveableCrmEvents(data.crm_events)
   }
-    
-    
-  
+
+
+
 
 
 
@@ -297,8 +297,8 @@ trait OBPDataImport extends Loggable {
     for {
       ownersNonEmpty <- Helper.booleanToBox(acc.owners.nonEmpty) ?~
         s"Accounts must have at least one owner. Violation: (bank id ${acc.bank}, account id ${acc.id})"
-      ownersDefinedInDataImport <- Helper.booleanToBox(acc.owners.forall(ownerEmail => data.users.exists(u => u.email == ownerEmail))) ?~ {
-        val violations = acc.owners.filter(ownerEmail => !data.users.exists(u => u.email == ownerEmail))
+      ownersDefinedInDataImport <- Helper.booleanToBox(acc.owners.forall(ownerUsername => data.users.exists(u => u.user_name == ownerUsername))) ?~ {
+        val violations = acc.owners.filter(ownerUsername => !data.users.exists(u => u.user_name == ownerUsername))
         s"Accounts must have owner(s) defined in data import. Violation: ${violations.mkString(",")}"
       }
       accId = AccountId(acc.id)
@@ -312,7 +312,7 @@ trait OBPDataImport extends Loggable {
     } yield acc
   }
 
-  final protected def createAccountsAndViews(data : SandboxDataImport, banks : List[BankType]) : Box[List[(Saveable[AccountType], List[Saveable[ViewType]], List[AccountOwnerEmail])]] = {
+  final protected def createAccountsAndViews(data : SandboxDataImport, banks : List[BankType]) : Box[List[(Saveable[AccountType], List[Saveable[ViewType]], List[AccountOwnerUsername])]] = {
 
     val banksNotSpecifiedInImport = data.accounts.flatMap(acc => {
       if(data.banks.exists(b => b.id == acc.bank)) None
@@ -356,7 +356,7 @@ trait OBPDataImport extends Loggable {
   }
 
   final protected def createSaveableAccountResults(accs : List[SandboxAccountImport], banks : List[BankType])
-  : Box[List[(Saveable[AccountType], List[Saveable[ViewType]], List[AccountOwnerEmail])]] = {
+  : Box[List[(Saveable[AccountType], List[Saveable[ViewType]], List[AccountOwnerUsername])]] = {
 
     logger.info("Hello from createSaveableAccountResults")
 
@@ -518,18 +518,18 @@ trait OBPDataImport extends Loggable {
 
       logger.info(s"importData is saving ${accountResults.size} accountResults (accounts, views and permissions)..")
       accountResults.foreach {
-        case (account, views, accOwnerEmails) =>
+        case (account, views, accOwnerUsernames) =>
           account.save()
           views.foreach(_.save())
 
           views.map(_.value).filterNot(_.isPublic).foreach(v => {
             //grant the owner access to non-public views
             //this should always find the owners as that gets verified at an earlier stage, but it's not perfect this way
-            val accOwners = users.map(_.value).filter(u => accOwnerEmails.exists(email => u.emailAddress == email))
+            val accOwners = users.map(_.value).filter(u => accOwnerUsernames.exists(name => u.name == name))
             accOwners.foreach(Views.views.vend.addPermission(v.uid, _))
           })
 
-          accOwnerEmails.foreach(setAccountOwner(_, account.value, users.map(_.value)))
+          accOwnerUsernames.foreach(setAccountOwner(_, account.value, users.map(_.value)))
       }
       logger.info(s"importData is saving ${transactions.size} transactions (and loading them again)")
       transactions.foreach { t =>

--- a/src/main/scala/code/sandbox/OBPDataImport.scala
+++ b/src/main/scala/code/sandbox/OBPDataImport.scala
@@ -594,7 +594,7 @@ case class SandboxLocationImport(
 case class SandboxUserImport(
   email : String,
   password : String,
-  display_name : String)
+  user_name : String)
 
 case class SandboxAccountImport(
   id : String,

--- a/src/main/scala/code/snippet/Login.scala
+++ b/src/main/scala/code/snippet/Login.scala
@@ -32,14 +32,12 @@ Berlin 13359, Germany
 
 package code.snippet
 
-import code.model.dataAccess.OBPUser
-import net.liftweb.common.Loggable
-import scala.xml.NodeSeq
+import code.model.dataAccess.{Admin, OBPUser}
+import net.liftweb.http.{S, SHtml}
 import net.liftweb.util.Helpers._
-import net.liftweb.util.{Props, CssSel}
-import net.liftweb.http.S
-import code.model.dataAccess.Admin
-import net.liftweb.http.SHtml
+import net.liftweb.util.{CssSel, Props}
+
+import scala.xml.NodeSeq
 
 class Login {
 
@@ -50,7 +48,7 @@ class Login {
       ".logout [href]" #> {
         OBPUser.logoutPath.foldLeft("")(_ + "/" + _)
       } &
-      ".username *" #> OBPUser.currentUser.get.email.get
+      ".username *" #> OBPUser.currentUser.get.username.get
     }
   }
 

--- a/src/main/webapp/media/css/website.css
+++ b/src/main/webapp/media/css/website.css
@@ -462,7 +462,7 @@ input.submit {
 #main-partners a {
     vertical-align: top;
     display: inline-block;
-    *display: inline;
+    /* *display: inline; */
     /* zoom: 1; */
     margin: 30px 30px 30px 30px;
 }

--- a/src/main/webapp/templates-hidden/_login.html
+++ b/src/main/webapp/templates-hidden/_login.html
@@ -3,7 +3,7 @@
 		<div class="account account-in-content">
 			<div class="login-error"><span class="lift:Msg?id=login&errorClass=error"/></div>
 			<!-- LOGGED OUT -->
-			Please login with your username or e-mail address.
+			Please login with your username.
 			<div class="lift:embed?what=_login_form"></div>
 		</div>
 	</div>

--- a/src/main/webapp/templates-hidden/_login_form.html
+++ b/src/main/webapp/templates-hidden/_login_form.html
@@ -7,7 +7,7 @@
 
 
     <div class="field username">
-        <input class="username" type="email" placeholder="Username" name="username" tabindex=1 autofocus />
+        <input class="username" type="text" placeholder="Username" name="username" tabindex=1 autofocus />
     </div>
     <div class="field password">
         <input class="password" type="password" placeholder="Password"  name="password" tabindex=2 />

--- a/src/main/webapp/templates-hidden/default.html
+++ b/src/main/webapp/templates-hidden/default.html
@@ -103,7 +103,7 @@ Berlin 13359, Germany
                         </div>
                         <div class="lift:Login.loggedIn">
                             <div class="profile-info">
-                                <span class="username">username@domain.com</span>&nbsp;<a href="" class="logout">Logout</a>
+                                <span class="username">username</span>&nbsp;<a href="" class="logout">Logout</a>
                             </div>
                         </div>
                     </li>

--- a/src/test/scala/code/api/directloginTest.scala
+++ b/src/test/scala/code/api/directloginTest.scala
@@ -20,7 +20,7 @@ class directloginTest extends ServerSetup with BeforeAndAfter {
   val PASSWORD = randomString(20)
 
   before {
-    if (OBPUser.find(By(OBPUser.email, EMAIL)).isEmpty)
+    if (OBPUser.find(By(OBPUser.username, USERNAME)).isEmpty)
       OBPUser.create.
         email(EMAIL).
         username(USERNAME).
@@ -41,14 +41,14 @@ class directloginTest extends ServerSetup with BeforeAndAfter {
 
   val accessControlOriginHeader = ("Access-Control-Allow-Origin", "*")
 
-  val invalidUsernamePasswordHeader = ("Authorization", ("DirectLogin username=\"does-not-exist@example.com\", " +
+  val invalidUsernamePasswordHeader = ("Authorization", ("DirectLogin username=\"does-not-exist\", " +
     "password=\"no-good-password\", consumer_key=%s").format(KEY))
 
   val invalidConsumerKeyHeader = ("Authorization", ("DirectLogin username=%s, " +
-    "password=%s, consumer_key=%s").format(EMAIL, PASSWORD, "invalid"))
+    "password=%s, consumer_key=%s").format(USERNAME, PASSWORD, "invalid"))
 
   val validHeader = ("Authorization", "DirectLogin username=%s, password=%s, consumer_key=%s".
-    format(EMAIL, PASSWORD, KEY))
+    format(USERNAME, PASSWORD, KEY))
 
   val invalidUsernamePasswordHeaders = List(accessControlOriginHeader, invalidUsernamePasswordHeader)
 

--- a/src/test/scala/code/api/directloginTest.scala
+++ b/src/test/scala/code/api/directloginTest.scala
@@ -16,12 +16,14 @@ class directloginTest extends ServerSetup with BeforeAndAfter {
   val KEY = randomString(40).toLowerCase
   val SECRET = randomString(40).toLowerCase
   val EMAIL = randomString(10).toLowerCase + "@example.com"
+  val USERNAME = randomString(10).toLowerCase
   val PASSWORD = randomString(20)
 
   before {
     if (OBPUser.find(By(OBPUser.email, EMAIL)).isEmpty)
       OBPUser.create.
         email(EMAIL).
+        username(USERNAME).
         password(PASSWORD).
         validated(true).
         firstName(randomString(10)).

--- a/src/test/scala/code/api/oauthTest.scala
+++ b/src/test/scala/code/api/oauthTest.scala
@@ -70,6 +70,7 @@ class OAuthTest extends ServerSetup {
   lazy val user1 =
     OBPUser.create.
       email(randomString(3)+"@example.com").
+      username(randomString(9)).
       password(user1Password).
       validated(true).
       firstName(randomString(10)).
@@ -113,7 +114,7 @@ class OAuthTest extends ServerSetup {
     def getVerifier(loginPage: String, userName: String, password: String) : Box[String] = {
       tryo{
         go.to(loginPage)
-        emailField("username").value = userName
+        textField("username").value = userName
         val pwField = NameQuery("password").webElement
         pwField.clear()
         pwField.sendKeys(password)
@@ -198,7 +199,7 @@ class OAuthTest extends ServerSetup {
       val reply = getRequestToken(consumer, selfCallback)
       val requestToken = extractToken(reply.body)
       When("the browser is launched to login")
-      val verifier = getVerifier(requestToken.value, user1.email.get, user1Password)
+      val verifier = getVerifier(requestToken.value, user1.username.get, user1Password)
       Then("we should get a verifier")
       verifier.get.nonEmpty should equal (true)
     }
@@ -207,21 +208,21 @@ class OAuthTest extends ServerSetup {
       val reply = getRequestToken(consumer, oob)
       val requestToken = extractToken(reply.body)
       When("the browser is launched to login")
-      val verifier = getVerifier(requestToken.value, user1.email.get, user1Password)
+      val verifier = getVerifier(requestToken.value, user1.username.get, user1Password)
       Then("we should get a verifier")
       verifier.isEmpty should equal (false)
     }
     scenario("the user cannot login because there is no token", Verifier, Oauth){
       Given("there will be no token")
       When("the browser is launched to login")
-      val verifier = getVerifier(user1.email.get, user1Password)
+      val verifier = getVerifier(user1.username.get, user1Password)
       Then("we should not get a verifier")
       verifier.isEmpty should equal (true)
     }
     scenario("the user cannot login because the token does not exist", Verifier, Oauth){
       Given("we will use a random request token")
       When("the browser is launched to login")
-      val verifier = getVerifier(randomString(4), user1.email.get, user1Password)
+      val verifier = getVerifier(randomString(4), user1.username.get, user1Password)
       Then("we should not get a verifier")
       verifier.isEmpty should equal (true)
     }
@@ -231,7 +232,7 @@ class OAuthTest extends ServerSetup {
       Given("we will first get a request token and a verifier")
       val reply = getRequestToken(consumer, oob)
       val requestToken = extractToken(reply.body)
-      val verifier = getVerifier(requestToken.value, user1.email.get, user1Password)
+      val verifier = getVerifier(requestToken.value, user1.username.get, user1Password)
       When("when we ask for an access token")
       val accessToken = getAccessToken(consumer, requestToken, verifier.get)
       Then("we should get an access token")
@@ -241,7 +242,7 @@ class OAuthTest extends ServerSetup {
       Given("we will first get a request token and a verifier")
       val reply = getRequestToken(consumer, selfCallback)
       val requestToken = extractToken(reply.body)
-      val verifier = getVerifier(requestToken.value, user1.email.get, user1Password)
+      val verifier = getVerifier(requestToken.value, user1.username.get, user1Password)
       When("when we ask for an access token")
       val accessToken = getAccessToken(consumer, requestToken, verifier.get)
       Then("we should get an access token")
@@ -260,7 +261,7 @@ class OAuthTest extends ServerSetup {
       Given("we will first get request token and a verifier")
       val reply = getRequestToken(consumer, selfCallback)
       val requestToken = extractToken(reply.body)
-      val verifier = getVerifier(requestToken.value, user1.email.get, user1Password)
+      val verifier = getVerifier(requestToken.value, user1.username.get, user1Password)
       When("when we ask for an access token with a request token")
       val randomRequestToken = Token(randomString(5), randomString(5))
       val accessTokenReply = getAccessToken(consumer, randomRequestToken, verifier.get)

--- a/src/test/scala/code/api/v2_0_0/CreateUserTest.scala
+++ b/src/test/scala/code/api/v2_0_0/CreateUserTest.scala
@@ -20,6 +20,7 @@ class CreateUserTest extends V200ServerSetup with BeforeAndAfter {
 
   val FIRSTNAME = randomString(8).toLowerCase
   val LASTNAME = randomString(16).toLowerCase
+  val USERNAME = randomString(10).toLowerCase
   val EMAIL = randomString(10).toLowerCase + "@example.com"
   val PASSWORD = randomString(20)
 
@@ -43,7 +44,7 @@ class CreateUserTest extends V200ServerSetup with BeforeAndAfter {
 
   val accessControlOriginHeader = ("Access-Control-Allow-Origin", "*")
   val validHeader = ("Authorization", "DirectLogin username=%s, password=%s, consumer_key=%s".
-    format(EMAIL, PASSWORD, KEY))
+    format(USERNAME, PASSWORD, KEY))
   val validHeaders = List(accessControlOriginHeader, validHeader)
 
   private def getAPIResponse(req : Req) : OAuthResponse = {
@@ -72,9 +73,10 @@ class CreateUserTest extends V200ServerSetup with BeforeAndAfter {
 
   feature("we can create an user and login as newly created user using both directLogin and OAuth") {
 
-    scenario("we create an user with email, first name, last name and password", CreateUser) {
+    scenario("we create an user with email, first name, last name , username and password", CreateUser) {
       When("we create a new user")
       val params = Map("email" -> EMAIL,
+        "username" -> USERNAME,
         "password" -> PASSWORD,
         "first_name" -> FIRSTNAME,
         "last_name" -> LASTNAME)
@@ -114,6 +116,7 @@ class CreateUserTest extends V200ServerSetup with BeforeAndAfter {
     scenario("we try to create a same user again", CreateUser) {
       When("we create a same user")
       val params = Map("email" -> EMAIL,
+        "username" -> USERNAME,
         "password" -> PASSWORD,
         "first_name" -> FIRSTNAME,
         "last_name" -> LASTNAME)

--- a/src/test/scala/code/sandbox/SandboxDataLoadingTest.scala
+++ b/src/test/scala/code/sandbox/SandboxDataLoadingTest.scala
@@ -257,15 +257,15 @@ class SandboxDataLoadingTest extends FlatSpec with SendServerRequests with Shoul
   }
 
   def verifyUserCreated(user : SandboxUserImport) = {
-    val foundUserBox = Users.users.vend.getUserByProviderId(defaultProvider, user.email)
+    val foundUserBox = Users.users.vend.getUserByProviderId(defaultProvider, user.user_name)
     foundUserBox.isDefined should equal(true)
 
     val foundUser = foundUserBox.get
 
     foundUser.provider should equal(defaultProvider)
-    foundUser.idGivenByProvider should equal(user.email)
+    foundUser.idGivenByProvider should equal(user.user_name)
     foundUser.emailAddress should equal(user.email)
-    foundUser.name should equal(user.display_name)
+    foundUser.name should equal(user.user_name)
   }
 
   def verifyAccountCreated(account : SandboxAccountImport) = {
@@ -457,8 +457,8 @@ class SandboxDataLoadingTest extends FlatSpec with SendServerRequests with Shoul
   val standardProducts = product1AtBank1 :: product2AtBank1 :: Nil
 
 
-  val user1 = SandboxUserImport(email = "user1@example.com", password = "qwerty", display_name = "User 1")
-  val user2 = SandboxUserImport(email = "user2@example.com", password = "qwerty", display_name = "User 2")
+  val user1 = SandboxUserImport(email = "user1@example.com", password = "qwerty", user_name = "User 1")
+  val user2 = SandboxUserImport(email = "user2@example.com", password = "qwerty", user_name = "User 2")
 
   val standardUsers = user1 :: user2 :: Nil
 
@@ -773,7 +773,7 @@ class SandboxDataLoadingTest extends FlatSpec with SendServerRequests with Shoul
     val user1Json = Extraction.decompose(user1)
 
     val differentDisplayName = "Jessica Bloggs"
-    differentDisplayName should not equal(user1.display_name)
+    differentDisplayName should not equal(user1.user_name)
     val userWithSameEmailAsUser1 = user1Json.replace("display_name", differentDisplayName)
 
     //neither of the users should exist initially
@@ -803,7 +803,7 @@ class SandboxDataLoadingTest extends FlatSpec with SendServerRequests with Shoul
     firstUser.get.emailAddress should equal(user1.email)
     secondUser.get.emailAddress should equal(secondUserEmail)
 
-    firstUser.get.name should equal(user1.display_name)
+    firstUser.get.name should equal(user1.user_name)
     secondUser.get.name should equal(differentDisplayName)
   }
 
@@ -824,7 +824,7 @@ class SandboxDataLoadingTest extends FlatSpec with SendServerRequests with Shoul
     getResponse(List(user1Json, Extraction.decompose(otherUser))).code should equal(FAILED)
 
     //and the other user should not have been created
-    Users.users.vend.getUserByProviderId(defaultProvider, otherUser.email)
+    Users.users.vend.getUserByProviderId(defaultProvider, otherUser.user_name)
   }
 
   it should "fail if a user's password is missing or empty" in {
@@ -860,7 +860,7 @@ class SandboxDataLoadingTest extends FlatSpec with SendServerRequests with Shoul
 
     //TODO: we shouldn't reference OBPUser here as it is an implementation, but for now there
     //is no way to check User (the trait) passwords
-    val createdOBPUserBox = OBPUser.find(By(OBPUser.email, user1.email))
+    val createdOBPUserBox = OBPUser.find(By(OBPUser.username, user1.user_name))
     createdOBPUserBox.isDefined should equal(true)
 
     val createdOBPUser = createdOBPUserBox.get


### PR DESCRIPTION
Using "username" instead of "email" as unique user identifier. Newly added field "username" is unique, "email" is not unique any more. 

TODO: Kafkaconnector not updated for new logic yet

NOTE: The modifications in this pull request can break backwards compatibility, so use with caution.

