### PR TITLE
Issues #195, #184

### DIFF
--- a/src/main/resources/props/sample.props.template
+++ b/src/main/resources/props/sample.props.template
@@ -73,7 +73,7 @@ apiPathZero=obp
 mail.api.consumer.registered.sender.address=no-reply@example.com
 mail.api.consumer.registered.notification.addresses=you@example.com
 # This property allows sending API registration data to developer's email. Please note it can reveal sensitive data.
-#mail.api.consumer.registered.notification.send=true
+#mail.api.consumer.registered.notification.send=false
 mail.smtp.host=127.0.0.1
 mail.smtp.port=25
 

--- a/src/main/resources/props/sample.props.template
+++ b/src/main/resources/props/sample.props.template
@@ -72,6 +72,8 @@ apiPathZero=obp
 #not need in dev mode, but important for production
 mail.api.consumer.registered.sender.address=no-reply@example.com
 mail.api.consumer.registered.notification.addresses=you@example.com
+# This property allows sending API registration data to developer's email. Please note it can reveal sensitive data.
+#mail.api.consumer.registered.notification.send=true
 mail.smtp.host=127.0.0.1
 mail.smtp.port=25
 

--- a/src/main/scala/code/api/v2_1_0/APIMethods210.scala
+++ b/src/main/scala/code/api/v2_1_0/APIMethods210.scala
@@ -436,11 +436,11 @@ trait APIMethods210 {
             u <- user ?~ ErrorMessages.UserNotLoggedIn
             bank <- Bank(bankId) ?~ {ErrorMessages.BankNotFound}
             usr <- User.findByUserId(userId) ?~! ErrorMessages.UserNotFoundById
-            requiredEntitlements = CanGetEntitlementsForAnyUserAtOneBank ::
-                                   CanGetEntitlementsForAnyUserAtAnyBank::
-                                   Nil
-            requiredEntitlementsTxt = requiredEntitlements.mkString(" or ")
-            hasAtLeastOneEntitlement <- booleanToBox(hasAtLeastOneEntitlement(bankId.value, u.userId, requiredEntitlements), s"$requiredEntitlementsTxt entitlements required")
+            allowedEntitlements = CanGetEntitlementsForAnyUserAtOneBank ::
+                                  CanGetEntitlementsForAnyUserAtAnyBank::
+                                  Nil
+            allowedEntitlementsTxt = allowedEntitlements.mkString(" or ")
+            hasAtLeastOneEntitlement <- booleanToBox(hasAtLeastOneEntitlement(bankId.value, u.userId, allowedEntitlements), s"$allowedEntitlementsTxt entitlements required")
             entitlements <- Entitlement.entitlement.vend.getEntitlements(userId)
             filteredEntitlements <- tryo{entitlements.filter(_.bankId == bankId.value)}
           }


### PR DESCRIPTION
@simonredfern Please consider the changes
Note that new property #mail.api.consumer.registered.notification.send=true can be omitted, set to true or set to false. Only set to true will trigger mail sending.