### PR TITLE
CanCreateTransactionType role

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ If Kafka connector is selected in props (connector=kafka), Kafka and Zookeeper h
 * Advanced architecture: http://exploring.liftweb.net/master/index-9.html
 
 * A good book on Lift: "Lift in Action" by Timothy Perrett published by Manning.
-
+ 

--- a/src/main/scala/code/api/util/ApiRole.scala
+++ b/src/main/scala/code/api/util/ApiRole.scala
@@ -48,14 +48,9 @@ object ApiRole {
   case object CanGetEntitlementsForAnyUserAtAnyBank extends ApiRole{
     val requiresBankId = false
   }
-  case object CanGetConsumers extends ApiRole{
-    val requiresBankId = false
-  }
-  case object CanDisableConsumers extends ApiRole{
-    val requiresBankId = false
-  }
-  case object CanEnableConsumers extends ApiRole{
-    val requiresBankId = false
+
+  case object CanCreateTransactionType extends ApiRole{
+    val requiresBankId = true
   }
 
   def valueOf(value: String): ApiRole = value match {
@@ -73,9 +68,7 @@ object ApiRole {
     case "CanCreateSandbox" => CanCreateSandbox
     case "CanGetEntitlementsForAnyUserAtOneBank" => CanGetEntitlementsForAnyUserAtOneBank
     case "CanGetEntitlementsForAnyUserAtAnyBank" => CanGetEntitlementsForAnyUserAtAnyBank
-    case "CanGetConsumers" => CanGetConsumers
-    case "CanDisableConsumers" => CanDisableConsumers
-    case "CanEnableConsumers" => CanEnableConsumers
+    case "CanCreateTransactionType" => CanCreateTransactionType
     case _ => throw new IllegalArgumentException()
   }
 
@@ -93,9 +86,7 @@ object ApiRole {
                       "CanCreateSandbox" ::
                       "CanGetEntitlementsForAnyUserAtOneBank" ::
                       "CanGetEntitlementsForAnyUserAtAnyBank" ::
-                      "CanGetConsumers" ::
-                      "CanDisableConsumers" ::
-                      "CanEnableConsumers" ::
+                      "CanCreateTransactionType"::
                        Nil
 
 }


### PR DESCRIPTION
add the new role for CanCreateTransactionType in 

/OBP-API/src/main/scala/code/api/util/ApiRole.scala