### PR TITLE
#196 Add POST and PUT to /banks/BANK_ID/transaction-types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>9.4-1206-jdbc4</version>
+      <version>9.4.1211</version>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>9.4.1211</version>
+      <version>9.4-1206-jdbc4</version>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/src/main/scala/code/api/util/APIUtil.scala
+++ b/src/main/scala/code/api/util/APIUtil.scala
@@ -128,8 +128,8 @@ object ErrorMessages {
   val InvalidTransactionRequestCurrency = "OBP-40003: Transaction Request Currency must be the same as From Account Currency."
   val InvalidTransactionRequestId = "OBP-40004: Transaction Request Id not found."
   val InsufficientAuthorisationToCreateTransactionType  = "OBP-40005: Insufficient authorisation to Create Transaction Type offered by the bank. The Request could not be created because you don't have access to CanCreateTransactionType."
-  val InsertingDataError  = "OBP-40006: Inserting data error "
-  val UpdatingDataError  = "OBP-40008: Updating data error"
+  val InvalidCreateTransactionTypeInsertingDataError  = "OBP-40006: Inserting data error "
+  val InvalidCreateTransactionTypeUpdatingDataError  = "OBP-40007: Updating data error"
 
 }
 

--- a/src/main/scala/code/api/util/APIUtil.scala
+++ b/src/main/scala/code/api/util/APIUtil.scala
@@ -127,12 +127,9 @@ object ErrorMessages {
   val InsufficientAuthorisationToCreateTransactionRequest  = "OBP-40002: Insufficient authorisation to create TransactionRequest. The Transaction Request could not be created because you don't have access to the owner view of the from account and you don't have access to canCreateAnyTransactionRequest."
   val InvalidTransactionRequestCurrency = "OBP-40003: Transaction Request Currency must be the same as From Account Currency."
   val InvalidTransactionRequestId = "OBP-40004: Transaction Request Id not found."
-
-
-
-
-
-
+  val InsufficientAuthorisationToCreateTransactionType  = "OBP-40005: Insufficient authorisation to Create Transaction Type offered by the bank. The Request could not be created because you don't have access to CanCreateTransactionType."
+  val InsertingDataError  = "OBP-40006: Inserting data error "
+  val UpdatingDataError  = "OBP-40008: Updating data error"
 
 }
 

--- a/src/main/scala/code/api/v2_1_0/OBPAPI2_1_0.scala
+++ b/src/main/scala/code/api/v2_1_0/OBPAPI2_1_0.scala
@@ -241,6 +241,7 @@ object OBPAPI2_1_0 extends OBPRestHelper with APIMethods130 with APIMethods140 w
                          "enableDisableConsumers" ::
                          "addCardsForBank" ::
                          "getUsers" ::
+                         "createTransactionType"::
                          Nil
   //Second step - iterate through all endpoints defined in resource doc
   //       then - omit endpoints of disabled version in props file

--- a/src/main/scala/code/transactiontypes/MappedTransactionTypeProvider.scala
+++ b/src/main/scala/code/transactiontypes/MappedTransactionTypeProvider.scala
@@ -51,12 +51,12 @@ object MappedTransactionTypeProvider extends TransactionTypeProvider {
             mappedTransactionTypeUpdate.save
           }
           mappedTransactionType.toTransactionType.get
-        } ?~! ErrorMessages.UpdatingDataError
+        } ?~! ErrorMessages.InvalidCreateTransactionTypeUpdatingDataError
       case _ =>
         tryo {
           mappedTransactionType.save
           mappedTransactionType.toTransactionType.get
-        } ?~! ErrorMessages.InsertingDataError
+        } ?~! ErrorMessages.InvalidCreateTransactionTypeInsertingDataError
     }
   }
 

--- a/src/main/scala/code/transactiontypes/MappedTransactionTypeProvider.scala
+++ b/src/main/scala/code/transactiontypes/MappedTransactionTypeProvider.scala
@@ -3,15 +3,17 @@ package code.transaction_types
 import code.TransactionTypes.TransactionTypeProvider
 import code.model._
 import code.TransactionTypes.TransactionType._
-
 import code.util.DefaultStringField
-import net.liftweb.common.Logger
-import net.liftweb.json
-import net.liftweb.mapper._
-import java.util.Date
+import net.liftweb.common.{Box, _}
+import net.liftweb.mapper.{By, _}
+
+import code.api.{ErrorMessage, TokenValidity}
+import code.api.util.ErrorMessages
+import code.api.v2_0_0.TransactionTypeJSON
+import net.liftweb.http.{JsonResponse, S}
+import net.liftweb.util.Helpers._
 
 object MappedTransactionTypeProvider extends TransactionTypeProvider {
-
 
 
   override protected def getTransactionTypeFromProvider(TransactionTypeId: TransactionTypeId): Option[TransactionType] =
@@ -20,9 +22,45 @@ object MappedTransactionTypeProvider extends TransactionTypeProvider {
   override protected def getTransactionTypesForBankFromProvider(bankId: BankId): Some[List[TransactionType]] = {
     Some(MappedTransactionType.findAll(By(MappedTransactionType.mBankId, bankId.value)).flatMap(_.toTransactionType))
   }
+
+  /**
+    * This method will create or update the data. It need to check the BankId and TransactionTypeId to make the data is
+    * uniqueness in the database
+    *
+    */
+  override def createOrUpdateTransactionTypeAtProvider(transactionType: TransactionTypeJSON): Box[TransactionType] = {
+
+    // get the Input data from GUI and prepare to store and return
+    val mappedTransactionType = MappedTransactionType.create
+      .mTransactionTypeId(transactionType.id.toString)
+      .mBankId(transactionType.bank_id)
+      .mShortCode(transactionType.short_code)
+      .mSummary(transactionType.summary)
+      .mDescription(transactionType.description)
+      .mCustomerFee_Currency(transactionType.charge.currency.toString)
+      .mCustomerFee_Amount(transactionType.charge.amount.toString.toLong)
+
+    //check the transactionTypeId existence and update or insert data
+    TransactionTypeProvider.vend.getTransactionType(transactionType.id) match {
+      case Full(f) =>
+        tryo {
+          for {
+            mappedTransactionTypeUpdate <- MappedTransactionType.find(By(MappedTransactionType.mTransactionTypeId, transactionType.id.toString))
+          } yield {
+            mappedTransactionTypeUpdate.updateAllFields(mappedTransactionType)
+            mappedTransactionTypeUpdate.save
+          }
+          mappedTransactionType.toTransactionType.get
+        } ?~! ErrorMessages.UpdatingDataError
+      case _ =>
+        tryo {
+          mappedTransactionType.save
+          mappedTransactionType.toTransactionType.get
+        } ?~! ErrorMessages.InsertingDataError
+    }
+  }
+
 }
-
-
 class MappedTransactionType extends LongKeyedMapper[MappedTransactionType] with IdPK with CreatedUpdated {
 
   private val logger = Logger(classOf[MappedTransactionType])
@@ -55,6 +93,17 @@ class MappedTransactionType extends LongKeyedMapper[MappedTransactionType] with 
         )
       )
     )
+  }
+
+  def updateAllFields(mappedTransactionType: MappedTransactionType): Box[MappedTransactionType] = {
+    mTransactionTypeId.set(mappedTransactionType.mTransactionTypeId)
+    mBankId.set(mappedTransactionType.mBankId)
+    mShortCode.set(mappedTransactionType.mShortCode)
+    mSummary.set(mappedTransactionType.mSummary)
+    mDescription.set(mappedTransactionType.mDescription)
+    mCustomerFee_Currency.set(mappedTransactionType.mCustomerFee_Currency)
+    mCustomerFee_Amount.set(mappedTransactionType.mCustomerFee_Amount)
+    Some(this)
   }
 }
 

--- a/src/main/scala/code/transactiontypes/TransactionType.scala
+++ b/src/main/scala/code/transactiontypes/TransactionType.scala
@@ -3,10 +3,10 @@ package code.TransactionTypes
 
 import java.util.Date
 
-
+import code.api.v2_0_0.TransactionTypeJSON
 import code.model._
 import code.transaction_types.MappedTransactionTypeProvider
-import net.liftweb.common.Logger
+import net.liftweb.common.{Box, Logger}
 import net.liftweb.util.{Props, SimpleInjector}
 
 
@@ -63,13 +63,18 @@ trait TransactionTypeProvider {
     getTransactionTypesForBankFromProvider(bankId)
   }
 
-  final def getTransactionType(transactionTypeId : TransactionTypeId) : Option[TransactionType] = {
+  final def getTransactionType(transactionTypeId : TransactionTypeId) : Box[TransactionType] = {
     getTransactionTypeFromProvider(transactionTypeId)
   }
 
+  final def createOrUpdateTransactionType(postedData:TransactionTypeJSON) : Box[TransactionType] = {
+    createOrUpdateTransactionTypeAtProvider(postedData)
+  }
 
   protected def getTransactionTypesForBankFromProvider(bankId : BankId) : Option[List[TransactionType]]
 
   protected def getTransactionTypeFromProvider(TransactionTypeId : TransactionTypeId) : Option[TransactionType]
+
+  protected def createOrUpdateTransactionTypeAtProvider(postedData:TransactionTypeJSON) : Box[TransactionType]
 }
 

--- a/src/test/scala/code/api/v2_1_0/CreateTransactionTypeTest.scala
+++ b/src/test/scala/code/api/v2_1_0/CreateTransactionTypeTest.scala
@@ -1,0 +1,154 @@
+package code.api.v2_1_0
+
+import code.api.DefaultUsers
+import code.api.util.APIUtil.OAuth._
+import code.api.util.ApiRole.{CanCreateAnyTransactionRequest, CanCreateTransactionType, CanGetEntitlementsForAnyUserAtAnyBank, CanGetEntitlementsForAnyUserAtOneBank}
+import code.api.util.{ApiRole, ErrorMessages}
+import code.api.v1_2_1.AmountOfMoneyJSON
+import code.api.v2_0_0.{CreateAccountJSON, TransactionTypeJSON}
+import code.entitlement.Entitlement
+import code.model.dataAccess.MappedBankAccount
+import code.model.{AmountOfMoney, BankId, TransactionTypeId}
+import code.transaction_types.MappedTransactionType
+import net.liftweb.json.JsonAST._
+import net.liftweb.json.Serialization._
+import net.liftweb.util.TimeHelpers._
+import org.scalatest.BeforeAndAfter
+
+/**
+  * Created by zhanghongwei on 17/11/16.
+  */
+class CreateTransactionTypeTest extends V210ServerSetup with DefaultUsers {
+
+  val mockBankId = "testBank1"
+  lazy val transactionTypeJSON = TransactionTypeJSON(
+    TransactionTypeId("1"), //mockTransactionTypeId,
+    "1", //mockBankId.value,
+    "1", //short_code
+    "This is for test ", //summary,
+    "Many data here", //description,
+    AmountOfMoneyJSON("EUR", "0"))
+
+  override def beforeAll() {
+    super.beforeAll()
+  }
+
+  override def afterAll() {
+    super.afterAll()
+    MappedTransactionType.bulkDelete_!!()
+  }
+
+  feature("Assuring that endpoint 'Create Transaction Type offered by the bank' works as expected - v2.1.0") {
+
+    scenario("We try to put data without Authentication - Create Transaction Type...") {
+      When("We make the request")
+      val requestPut = (v2_1Request / "banks" / mockBankId / "transaction-types").PUT <@ (user1)
+      val responsePut = makePutRequest(requestPut, write(transactionTypeJSON))
+      Then("We should get a 400")
+      responsePut.code should equal(400)
+      val error = for {JObject(o) <- responsePut.body; JField("error", JString(error)) <- o} yield error
+      And("We should get a message: " + ErrorMessages.InsufficientAuthorisationToCreateTransactionType)
+      error should contain(ErrorMessages.InsufficientAuthorisationToCreateTransactionType)
+    }
+
+    scenario("We try to get all roles with Authentication - Create Transaction Type...") {
+      Given("The Authentication")
+      setCanCreateTransactionType
+
+      When("We make the request")
+      val requestPut = (v2_1Request / "banks" / mockBankId / "transaction-types").PUT <@ (user1)
+      val responsePut = makePutRequest(requestPut, write(transactionTypeJSON))
+
+      And("We should get a 200")
+      responsePut.code should equal(200)
+    }
+  }
+
+  feature("Assuring We pass the Authentication - Create Transaction Type...") {
+
+    scenario("We try to insert and update data, call 'Create Transaction Type offered by the bank' correctly ") {
+      Given("The Authentication")
+      setCanCreateTransactionType
+
+      Then("We make the request")
+      val requestPut1 = (v2_1Request / "banks" / mockBankId / "transaction-types").PUT <@ (user1)
+      val responsePut1 = makePutRequest(requestPut1, write(transactionTypeJSON))
+
+      And("We should get a 200")
+      responsePut1.code should equal(200)
+
+      Then("update input value and We make the request")
+      lazy val transactionTypeJSON2 = TransactionTypeJSON(
+        TransactionTypeId("1"), //mockTransactionTypeId,
+        "1", //mockBankId.value,
+        "1", //short_code
+        "change here  ", //summary,
+        "Many data here", //description,
+        AmountOfMoneyJSON("EUR", "0"))
+
+      val requestPut = (v2_1Request / "banks" / mockBankId / "transaction-types").PUT <@ (user1)
+      val responsePut = makePutRequest(requestPut, write(transactionTypeJSON2))
+
+      And("We should get a 200")
+      responsePut.code should equal(200)
+    }
+
+    scenario("We try to insert and update error ,call 'Create Transaction Type offered by the bank' correctly ") {
+      Given("The Authentication")
+      setCanCreateTransactionType
+
+      Then("insert some data and We make the request")
+      val requestPut1 = (v2_1Request / "banks" / mockBankId / "transaction-types").PUT <@ (user1)
+      val responsePut1 = makePutRequest(requestPut1, write(transactionTypeJSON))
+
+      And("We should get a 200")
+      responsePut1.code should equal(200)
+
+      Then("insert new data and We make the request")
+      lazy val transactionTypeJSON1 = TransactionTypeJSON(
+        TransactionTypeId("3"), //mockTransactionTypeId,
+        "1", //mockBankId.value,
+        "1", //short_code
+        "1  ", //summary,
+        "1", //description,
+        AmountOfMoneyJSON("EUR", "0"))
+
+      val requestPut2 = (v2_1Request / "banks" / mockBankId / "transaction-types").PUT <@ (user1)
+      val responsePut2 = makePutRequest(requestPut2, write(transactionTypeJSON1))
+
+      And("We should get a 400")
+      responsePut2.code should equal(400)
+      val errorInsert = for {JObject(o) <- responsePut2.body; JField("error", JString(error)) <- o} yield error
+      And("We should get a message: " + ErrorMessages.InsertingDataError)
+      errorInsert should contain(ErrorMessages.InsertingDataError)
+
+
+      Then("insert new data and We make the request")
+      lazy val transactionTypeJSON2 = TransactionTypeJSON(
+        TransactionTypeId("1"), //mockTransactionTypeId,
+        "1", //mockBankId.value,
+        "1", //short_code
+        "1  ", //summary,
+        "1", //description,
+        AmountOfMoneyJSON("EUReeeeeeee", "0"))
+
+      val requestPut3 = (v2_1Request / "banks" / mockBankId / "transaction-types").PUT <@ (user1)
+      val responsePut3 = makePutRequest(requestPut3, write(transactionTypeJSON2))
+
+      And("We should get a 400")
+      responsePut3.code should equal(400)
+      val errorUpdate = for {JObject(o) <- responsePut3.body; JField("error", JString(error)) <- o} yield error
+      And("We should get a message: " + ErrorMessages.UpdatingDataError)
+      errorUpdate should contain(ErrorMessages.UpdatingDataError)
+    }
+  }
+  /**
+    * set CanCreateTransactionType Entitlements to user1
+    */
+  def setCanCreateTransactionType: Unit = {
+    addEntitlement(mockBankId, obpuser1.userId, CanCreateTransactionType.toString)
+    Then("We add entitlement to user1")
+    val hasEntitlement = code.api.util.APIUtil.hasEntitlement(mockBankId, obpuser1.userId, CanCreateTransactionType)
+    hasEntitlement should equal(true)
+  }
+}

--- a/src/test/scala/code/api/v2_1_0/CreateTransactionTypeTest.scala
+++ b/src/test/scala/code/api/v2_1_0/CreateTransactionTypeTest.scala
@@ -119,8 +119,8 @@ class CreateTransactionTypeTest extends V210ServerSetup with DefaultUsers {
       And("We should get a 400")
       responsePut2.code should equal(400)
       val errorInsert = for {JObject(o) <- responsePut2.body; JField("error", JString(error)) <- o} yield error
-      And("We should get a message: " + ErrorMessages.InsertingDataError)
-      errorInsert should contain(ErrorMessages.InsertingDataError)
+      And("We should get a message: " + ErrorMessages.InvalidCreateTransactionTypeInsertingDataError)
+      errorInsert should contain(ErrorMessages.InvalidCreateTransactionTypeInsertingDataError)
 
 
       Then("insert new data and We make the request")
@@ -138,8 +138,8 @@ class CreateTransactionTypeTest extends V210ServerSetup with DefaultUsers {
       And("We should get a 400")
       responsePut3.code should equal(400)
       val errorUpdate = for {JObject(o) <- responsePut3.body; JField("error", JString(error)) <- o} yield error
-      And("We should get a message: " + ErrorMessages.UpdatingDataError)
-      errorUpdate should contain(ErrorMessages.UpdatingDataError)
+      And("We should get a message: " + ErrorMessages.InvalidCreateTransactionTypeUpdatingDataError)
+      errorUpdate should contain(ErrorMessages.InvalidCreateTransactionTypeUpdatingDataError)
     }
   }
   /**


### PR DESCRIPTION
1 Design the 'Create Transaction Type offered by the bank' URL
   can insert and update data

2 Create test for this method.
   CreateTransactionTypeTest.scala

3 modify the org.postgresql.version
   to work on new org.postgresql  9.6

4 I run all the Tests, it is working well.