### PR TITLE
Option to run Mapped table access on a remote machine separated by Akka #154

### DIFF
--- a/src/main/scala/code/metadata/counterparties/Counterparties.scala
+++ b/src/main/scala/code/metadata/counterparties/Counterparties.scala
@@ -2,19 +2,21 @@ package code.metadata.counterparties
 
 import net.liftweb.common.Box
 import net.liftweb.util.SimpleInjector
-import code.model.{AccountId, BankId, CounterpartyMetadata, Counterparty}
+import code.model.{AccountId, BankId, Counterparty, CounterpartyMetadata}
+import code.views.AkkaMapperViews
 
 object Counterparties extends SimpleInjector {
 
   val counterparties = new Inject(buildOne _) {}
 
   def buildOne: Counterparties = MapperCounterparties
+//  def buildOne: Counterparties = AkkaMapperViews
 
 }
 
 trait Counterparties {
 
-  def getOrCreateMetadata(originalPartyBankId: BankId, originalPartyAccountId : AccountId, otherParty : Counterparty) : CounterpartyMetadata
+  def getOrCreateMetadata(originalPartyBankId: BankId, originalPartyAccountId : AccountId, otherParty : Counterparty) : Box[CounterpartyMetadata]
 
   //get all counterparty metadatas for a single OBP account
   def getMetadatas(originalPartyBankId: BankId, originalPartyAccountId : AccountId) : List[CounterpartyMetadata]
@@ -65,3 +67,25 @@ trait CounterpartyTrait {
   def isBeneficiary : Boolean
 
 }
+
+class RemoteCounterpartiesCaseClasses {
+  case class getOrCreateMetadata(originalPartyBankId: BankId, originalPartyAccountId: AccountId, otherParty: Counterparty)
+
+  case class getMetadatas(originalPartyBankId: BankId, originalPartyAccountId: AccountId)
+
+  case class getMetadata(originalPartyBankId: BankId, originalPartyAccountId: AccountId, counterpartyMetadataId: String)
+
+  case class getCounterparty(counterPartyId: String)
+
+  case class getCounterpartyByIban(iban: String)
+
+  case class createCounterparty(
+                                 createdByUserId: String, thisBankId: String, thisAccountId: String, thisViewId: String,
+                                 name: String, otherBankId: String, otherAccountId: String, otherAccountRoutingScheme: String,
+                                 otherAccountRoutingAddress: String, otherBankRoutingScheme: String,
+                                 otherBankRoutingAddress: String, isBeneficiary: Boolean)
+
+  case class checkCounterpartyAvailable(name: String, thisBankId: String, thisAccountId: String, thisViewId: String)
+}
+
+object RemoteCounterpartiesCaseClasses extends RemoteCounterpartiesCaseClasses

--- a/src/main/scala/code/metadata/counterparties/MapperCounterparties.scala
+++ b/src/main/scala/code/metadata/counterparties/MapperCounterparties.scala
@@ -10,7 +10,7 @@ import net.liftweb.mapper.{By, _}
 import net.liftweb.util.Helpers.tryo
 
 object MapperCounterparties extends Counterparties with Loggable {
-  override def getOrCreateMetadata(originalPartyBankId: BankId, originalPartyAccountId: AccountId, otherParty: Counterparty): CounterpartyMetadata = {
+  override def getOrCreateMetadata(originalPartyBankId: BankId, originalPartyAccountId: AccountId, otherParty: Counterparty): Box[CounterpartyMetadata] = {
 
     /**
      * Generates a new alias name that is guaranteed not to collide with any existing public alias names
@@ -59,12 +59,12 @@ object MapperCounterparties extends Counterparties with Loggable {
     val existing = findMappedCounterpartyMetadata(originalPartyBankId, originalPartyAccountId, otherParty)
 
     existing match {
-      case Full(e) => e
+      case Full(e) => Full(e)
       // Create it!
       case _ => {
         logger.debug("Before creating MappedCounterpartyMetadata")
         // Store a record that contains counterparty information from the perspective of an account at a bank
-        MappedCounterpartyMetadata.create
+        Full(MappedCounterpartyMetadata.create
           // Core info
           .thisAccountBankId(originalPartyBankId.value)
           .thisAccountId(originalPartyAccountId.value)
@@ -74,7 +74,7 @@ object MapperCounterparties extends Counterparties with Loggable {
           // otherParty.metadata is None at this point
           //.imageUrl("www.example.com/image.jpg")
           //.moreInfo("This is hardcoded moreInfo")
-          .saveMe
+          .saveMe)
       }
     }
   }

--- a/src/main/scala/code/metadata/counterparties/MongoCounterparties.scala
+++ b/src/main/scala/code/metadata/counterparties/MongoCounterparties.scala
@@ -27,7 +27,7 @@ object MongoCounterparties extends Counterparties with Loggable {
     } yield m
   }
 
-  def getOrCreateMetadata(originalPartyBankId: BankId, originalPartyAccountId : AccountId, otherParty : Counterparty) : CounterpartyMetadata = {
+  def getOrCreateMetadata(originalPartyBankId: BankId, originalPartyAccountId : AccountId, otherParty : Counterparty) : Box[CounterpartyMetadata] = {
 
     /**
      * This particular implementation requires the metadata id to be the same as the otherParty (OtherBankAccount) id
@@ -40,7 +40,7 @@ object MongoCounterparties extends Counterparties with Loggable {
       case _ => createMetadata(originalPartyBankId, originalPartyAccountId, otherParty.label, otherParty.thisAccountId.value)
     }
 
-    metadata
+    Full(metadata)
   }
 
   /**

--- a/src/main/scala/code/model/BankingData.scala
+++ b/src/main/scala/code/model/BankingData.scala
@@ -623,7 +623,7 @@ class Counterparty(
       case Some(meta) =>
         meta
       case None =>
-        Counterparties.counterparties.vend.getOrCreateMetadata(otherBankId, otherAccountId, this)
+        Counterparties.counterparties.vend.getOrCreateMetadata(otherBankId, otherAccountId, this).openOrThrowException("Can not getOrCreateMetadata !")
     }
   }
 }

--- a/src/main/scala/code/users/Users.scala
+++ b/src/main/scala/code/users/Users.scala
@@ -11,7 +11,7 @@ object Users  extends SimpleInjector {
   val users = new Inject(buildOne _) {}
   
   def buildOne: Users = LiftUsers
-  //def buildOne: Users = AkkaMapperViews
+//  def buildOne: Users = AkkaMapperViews
   
 }
 

--- a/src/test/scala/code/api/v2_1_0/CreateCounterpartyTest.scala
+++ b/src/test/scala/code/api/v2_1_0/CreateCounterpartyTest.scala
@@ -10,7 +10,7 @@ import net.liftweb.json.Serialization.write
 
 class CreateCounterpartyTest extends V210ServerSetup with DefaultUsers {
 
-  val customerPostJSON = PostCounterpartyJSON(
+  val counterpartyPostJSON = PostCounterpartyJSON(
     name = "Company Salary",
     other_bank_id ="gh.29.de",
     other_account_id="007a268b-98bf-44ef-8f6a-9944618378cf",
@@ -43,7 +43,7 @@ class CreateCounterpartyTest extends V210ServerSetup with DefaultUsers {
 
       When("We make the request Create counterparty for an account")
       val requestPost = (v2_1Request / "banks" / bankId.value / "accounts" / accountId.value / viewId.value / "counterparties" ).POST <@ (user1)
-      val responsePost = makePostRequest(requestPost, write(customerPostJSON))
+      val responsePost = makePostRequest(requestPost, write(counterpartyPostJSON))
 
       Then("We should get a 200 and check all the fields")
       responsePost.code should equal(200)
@@ -58,13 +58,13 @@ class CreateCounterpartyTest extends V210ServerSetup with DefaultUsers {
         case JString(i) => i
         case _ => ""
       }
-      accountRoutingAddress should  equal(customerPostJSON.other_account_routing_address)
+      accountRoutingAddress should  equal(counterpartyPostJSON.other_account_routing_address)
 
       var bankRoutingScheme = (responsePost.body \ "other_bank_routing" \ "scheme" ) match {
         case JString(i) => i
         case _ => ""
       }
-      bankRoutingScheme should  equal(customerPostJSON.other_bank_routing_scheme)
+      bankRoutingScheme should  equal(counterpartyPostJSON.other_bank_routing_scheme)
     }
 
     scenario("No BankAccount in Database") {
@@ -78,7 +78,7 @@ class CreateCounterpartyTest extends V210ServerSetup with DefaultUsers {
       grantAccessToView(authuser1, ownerView)
 
       val requestPost = (v2_1Request / "banks" / bankId.value / "accounts" / accountId.value / viewId.value / "counterparties" ).POST <@ (user1)
-      val responsePost = makePostRequest(requestPost, write(customerPostJSON))
+      val responsePost = makePostRequest(requestPost, write(counterpartyPostJSON))
       Then("We should get a 400")
       responsePost.code should equal(400)
 
@@ -96,10 +96,10 @@ class CreateCounterpartyTest extends V210ServerSetup with DefaultUsers {
 
       When("We make the request Create counterparty for an account")
       val requestPost = (v2_1Request / "banks" / bankId.value / "accounts" / accountId.value / viewId.value / "counterparties" ).POST <@ (user1)
-      var responsePost = makePostRequest(requestPost, write(customerPostJSON))
+      var responsePost = makePostRequest(requestPost, write(counterpartyPostJSON))
 
       Then("We make the request again, the same name/bank_id/account_id/view_id")
-      responsePost = makePostRequest(requestPost, write(customerPostJSON))
+      responsePost = makePostRequest(requestPost, write(counterpartyPostJSON))
 
       Then("We should get a 400 and check the error massage")
       responsePost.code should equal(400)


### PR DESCRIPTION
I am working on MapperCounterparties -- in process. 

I just comment the AkkaMapper, it will not affect any existing  code now .

def buildOne: Counterparties = MapperCounterparties
//  def buildOne: Counterparties = AkkaMapperViews