### PR TITLE
Adding customer endpoints enhanced in versions 1.4.0, 2.0.0 and 2.1.0 as well as appropriate tests

### DIFF
--- a/src/main/scala/code/api/v1_4_0/APIMethods140.scala
+++ b/src/main/scala/code/api/v1_4_0/APIMethods140.scala
@@ -1,27 +1,23 @@
 package code.api.v1_4_0
 
-import java.text.SimpleDateFormat
-import java.util.Date
-
 import code.api.util.APIUtil.isValidCurrencyISOCode
+import code.api.util.ApiRole.{CanCreateCustomer, CanCreateUserCustomerLink}
 import code.api.v1_4_0.JSONFactory1_4_0._
 import code.bankconnectors.Connector
-import code.metadata.comments.MappedComment
-import code.transactionrequests.TransactionRequests.{TransactionRequestBody, TransactionRequestAccount}
+import code.transactionrequests.TransactionRequests.{TransactionRequestAccount, TransactionRequestBody}
 import code.usercustomerlinks.UserCustomerLink
-import net.liftweb.common.{Failure, Loggable, Box, Full}
+import net.liftweb.common.{Box, Full, Loggable}
 import net.liftweb.http.js.JE.JsRaw
 import net.liftweb.http.{JsonResponse, Req}
 import net.liftweb.http.rest.RestHelper
-import net.liftweb.json.{ShortTypeHints, DefaultFormats, Extraction}
+import net.liftweb.json.{Extraction}
 import net.liftweb.json.JsonAST.{JField, JObject, JValue}
 import net.liftweb.util.Helpers.tryo
 import net.liftweb.json.JsonDSL._
 import net.liftweb.util.Props
 import net.liftweb.json.JsonAST.JValue
-
-
-import code.api.v1_2_1.{AmountOfMoneyJSON}
+import code.api.v1_2_1.AmountOfMoneyJSON
+import code.api.v2_0_0.CreateCustomerJson
 
 import scala.collection.immutable.Nil
 
@@ -565,7 +561,7 @@ trait APIMethods140 extends Loggable with APIMethods130 with APIMethods121{
         |${authenticationRequiredMessage(true)}
         |Note: This call is depreciated in favour of v.2.0.0 createCustomer
         |""",
-      Extraction.decompose(PostCustomerJson("687687678", "Joe David Bloggs",
+      Extraction.decompose(CreateCustomerJson("user_id to attach this customer to e.g. 123213", "new customer number 687687678", "Joe David Bloggs",
         "+44 07972 444 876", "person@example.com", CustomerFaceImageJson("www.example.com/person/123/image.png", exampleDate),
         exampleDate, "Single", 1, List(exampleDate), "Bachelor’s Degree", "Employed", true, exampleDate)),
       emptyObjectJson,
@@ -580,9 +576,12 @@ trait APIMethods140 extends Loggable with APIMethods130 with APIMethods121{
           for {
             u <- user ?~! "User must be logged in to post Customer"
             bank <- Bank(bankId) ?~! {ErrorMessages.BankNotFound}
-            customer <- booleanToBox(Customer.customerProvider.vend.getCustomerByResourceUserId(bankId, u.resourceUserId.value).isEmpty) ?~ ErrorMessages.CustomerAlreadyExistsForUser
-            postedData <- tryo{json.extract[PostCustomerJson]} ?~! ErrorMessages.InvalidJsonFormat
+            postedData <- tryo{json.extract[CreateCustomerJson]} ?~! ErrorMessages.InvalidJsonFormat
+            requiredEntitlements = CanCreateCustomer :: CanCreateUserCustomerLink :: Nil
+            requiredEntitlementsTxt = requiredEntitlements.mkString(" and ")
+            hasEntitlements <- booleanToBox(hasAllEntitlements(bankId.value, u.userId, requiredEntitlements), s"$requiredEntitlementsTxt entitlements required")
             checkAvailable <- tryo(assert(Customer.customerProvider.vend.checkCustomerNumberAvailable(bankId, postedData.customer_number) == true)) ?~! ErrorMessages.CustomerNumberAlreadyExists
+            user_id <- tryo{if (postedData.user_id.nonEmpty) postedData.user_id else u.userId} ?~ s"Problem getting user_id"
             customer <- Customer.customerProvider.vend.addCustomer(bankId,
                 u,
                 postedData.customer_number,
@@ -600,6 +599,7 @@ trait APIMethods140 extends Loggable with APIMethods130 with APIMethods121{
                 postedData.last_ok_date,
                 None,
                 None) ?~! "Could not create customer"
+            userCustomerLink <- UserCustomerLink.userCustomerLink.vend.createUserCustomerLink(user_id, customer.customerId, exampleDate, true) ?~! "Could not create user_customer_links"
           } yield {
             val successJson = JSONFactory1_4_0.createCustomerJson(customer)
             successJsonResponse(Extraction.decompose(successJson))

--- a/src/main/scala/code/api/v2_0_0/APIMethods200.scala
+++ b/src/main/scala/code/api/v2_0_0/APIMethods200.scala
@@ -1637,13 +1637,6 @@ trait APIMethods200 {
             checkAvailable <- tryo(assert(Customer.customerProvider.vend.checkCustomerNumberAvailable(bankId, postedData.customer_number) == true)) ?~! ErrorMessages.CustomerNumberAlreadyExists
             user_id <- tryo (if (postedData.user_id.nonEmpty) postedData.user_id else u.userId) ?~ s"Problem getting user_id"
             customer_user <- User.findByUserId(user_id) ?~! ErrorMessages.UserNotFoundById
-            //Find all user to customer links by user_id
-            userCustomerLinks <- UserCustomerLink.userCustomerLink.vend.getUserCustomerLinksByUserId(user_id)
-            customerIds: List[String] <-  tryo(userCustomerLinks.map(p => p.customerId))
-            //Try to find an existing customer at BANK_ID
-            alreadyHasCustomer <-booleanToBox(customerIds.forall(x => Customer.customerProvider.vend.getCustomerByCustomerId(x).isEmpty == true)) ?~ ErrorMessages.CustomerAlreadyExistsForUser
-            // TODO we still store the user inside the customer, we should only store the user in the usercustomer link
-            customer <- booleanToBox(Customer.customerProvider.vend.getCustomerByResourceUserId(bankId, customer_user.resourceUserId.value).isEmpty) ?~ ErrorMessages.CustomerAlreadyExistsForUser
             customer <- Customer.customerProvider.vend.addCustomer(bankId,
               customer_user,
               postedData.customer_number,

--- a/src/main/scala/code/api/v2_1_0/APIMethods210.scala
+++ b/src/main/scala/code/api/v2_1_0/APIMethods210.scala
@@ -1,7 +1,7 @@
 package code.api.v2_1_0
 
 import java.text.SimpleDateFormat
-import java.util.{Calendar, Date, GregorianCalendar, Locale, TimeZone}
+import java.util.{Date, Locale}
 
 import code.TransactionTypes.TransactionType
 import code.api.util.ApiRole._
@@ -27,7 +27,6 @@ import code.model.dataAccess.{AuthUser, MappedBankAccount}
 import code.model.{BankAccount, BankId, ViewId, _}
 import code.products.Products.ProductCode
 import code.usercustomerlinks.UserCustomerLink
-import net.liftweb.common.Failure
 import net.liftweb.http.{Req, S}
 import net.liftweb.json.Extraction
 import net.liftweb.json.JsonAST.JValue
@@ -45,7 +44,7 @@ import code.api.{ChargePolicy, APIFailure}
 import code.api.util.APIUtil._
 import code.sandbox.{OBPDataImport, SandboxDataImport}
 import code.util.Helper
-import net.liftweb.common.{Empty, Full, Box}
+import net.liftweb.common.{Full, Box}
 import net.liftweb.http.JsonResponse
 import net.liftweb.http.js.JE.JsRaw
 import net.liftweb.http.rest.RestHelper
@@ -1218,7 +1217,7 @@ trait APIMethods210 {
           |Dates need to be in the format 2013-01-21T23:08:00Z
           |${authenticationRequiredMessage(true)}
           |""",
-      Extraction.decompose(PostCustomerJson("user_id to attach this customer to e.g. 123213",
+      Extraction.decompose(code.api.v2_1_0.PostCustomerJson("user_id to attach this customer to e.g. 123213",
         "new customer number 687687678", "Joe David Bloggs",
         "+44 07972 444 876", "person@example.com",
         CustomerFaceImageJson("www.example.com/person/123/image.png", exampleDate),
@@ -1261,13 +1260,6 @@ trait APIMethods210 {
             checkAvailable <- tryo(assert(Customer.customerProvider.vend.checkCustomerNumberAvailable(bankId, postedData.customer_number) == true)) ?~! ErrorMessages.CustomerNumberAlreadyExists
             user_id <- tryo (if (postedData.user_id.nonEmpty) postedData.user_id else u.userId) ?~ s"Problem getting user_id"
             customer_user <- User.findByUserId(user_id) ?~! ErrorMessages.UserNotFoundById
-            //Find all user to customer links by user_id
-            userCustomerLinks <- UserCustomerLink.userCustomerLink.vend.getUserCustomerLinksByUserId(user_id)
-            customerIds: List[String] <-  tryo(userCustomerLinks.map(p => p.customerId))
-            //Try to find an existing customer at BANK_ID
-            alreadyHasCustomer <-booleanToBox(customerIds.forall(x => Customer.customerProvider.vend.getCustomerByCustomerId(x).isEmpty == true)) ?~ ErrorMessages.CustomerAlreadyExistsForUser
-            // TODO we still store the user inside the customer, we should only store the user in the usercustomer link
-            customer <- booleanToBox(Customer.customerProvider.vend.getCustomerByResourceUserId(bankId, customer_user.resourceUserId.value).isEmpty) ?~ ErrorMessages.CustomerAlreadyExistsForUser
             customer <- Customer.customerProvider.vend.addCustomer(bankId,
               customer_user,
               postedData.customer_number,

--- a/src/main/scala/code/usercustomerlinks/MappedUserCustomerLink.scala
+++ b/src/main/scala/code/usercustomerlinks/MappedUserCustomerLink.scala
@@ -59,8 +59,8 @@ class MappedUserCustomerLink extends UserCustomerLink with LongKeyedMapper[Mappe
     Full(MappedUserCustomerLink.findAll())
   }
 
-  override def getUserCustomerLinksByUserId(userId : String): Box[List[UserCustomerLink]] = {
-    Full(MappedUserCustomerLink.findAll(By(MappedUserCustomerLink.mUserId, userId)))
+  override def bulkDeleteUserCustomerLinks(): Boolean = {
+    MappedUserCustomerLink.bulkDelete_!!()
   }
 
 }

--- a/src/main/scala/code/usercustomerlinks/UserCustomerLink.scala
+++ b/src/main/scala/code/usercustomerlinks/UserCustomerLink.scala
@@ -25,6 +25,6 @@ trait UserCustomerLink {
   def getUserCustomerLink(customerId: String): Box[UserCustomerLink]
   def getUserCustomerLinkByUserId(userId: String): List[UserCustomerLink]
   def getUserCustomerLink(userId: String, customerId: String): Box[UserCustomerLink]
-  def getUserCustomerLinksByUserId(userId : String): Box[List[UserCustomerLink]]
   def getUserCustomerLinks: Box[List[UserCustomerLink]]
+  def bulkDeleteUserCustomerLinks(): Boolean
 }

--- a/src/test/scala/code/api/v1_4_0/CustomerTest.scala
+++ b/src/test/scala/code/api/v1_4_0/CustomerTest.scala
@@ -5,13 +5,14 @@ import java.text.SimpleDateFormat
 import code.api.DefaultUsers
 import code.api.util.{ApiRole, ErrorMessages}
 import code.api.v1_4_0.JSONFactory1_4_0.{CustomerFaceImageJson, CustomerJson}
-import code.api.v2_0_0.{CreateCustomerJson, CreateUserCustomerLinkJSON, V200ServerSetup}
-import code.customer.{Customer, MappedCustomer}
-import code.entitlement.Entitlement
+import code.api.v2_0_0.{CreateCustomerJson, V200ServerSetup}
+import code.customer.Customer
 import code.model.BankId
 import net.liftweb.json.JsonAST._
 import net.liftweb.json.Serialization._
 import code.api.util.APIUtil.OAuth._
+import code.entitlement.Entitlement
+import code.usercustomerlinks.UserCustomerLink
 
 class CustomerTest extends V200ServerSetup with DefaultUsers {
 
@@ -19,8 +20,29 @@ class CustomerTest extends V200ServerSetup with DefaultUsers {
   val simpleDateFormat: SimpleDateFormat = new SimpleDateFormat("dd/mm/yyyy")
   val exampleDate = simpleDateFormat.parse(exampleDateString)
 
-  val mockBankId = BankId("testBank1")
-  val mockCustomerNumber = "9393490320"
+  val mockBankId1 = BankId("testBank1")
+  val mockBankId2 = BankId("testBank2")
+  val mockCustomerNumber1 = "93934903201"
+  val mockCustomerNumber2 = "93934903202"
+
+  def createCustomerJson(customerNumber: String) = {
+    CreateCustomerJson(
+      user_id = authuser1.userId,
+      customer_number = customerNumber,
+      legal_name = "Someone",
+      mobile_phone_number = "125245",
+      email = "hello@hullo.com",
+      face_image = CustomerFaceImageJson("www.example.com/person/123/image.png", exampleDate),
+      date_of_birth = exampleDate,
+      relationship_status = "Single",
+      dependants = 1,
+      dob_of_dependants = List(exampleDate),
+      highest_education_attained = "Bachelor’s Degree",
+      employment_status = "Employed",
+      kyc_status = true,
+      last_ok_date = exampleDate
+    )
+  }
 
 
   override def beforeAll() {
@@ -30,6 +52,7 @@ class CustomerTest extends V200ServerSetup with DefaultUsers {
   override def afterAll() {
     super.afterAll()
     Customer.customerProvider.vend.bulkDeleteCustomers()
+    UserCustomerLink.userCustomerLink.vend.bulkDeleteUserCustomerLinks()
   }
 
 
@@ -37,62 +60,31 @@ class CustomerTest extends V200ServerSetup with DefaultUsers {
 
     scenario("There is a user, and the bank in questions has customer info for that user - v1.4.0") {
       Given("The bank in question has customer info")
-      val testBank = mockBankId
 
-      val customerPostJSON = CreateCustomerJson(
-        user_id = authuser1.userId,
-        customer_number = mockCustomerNumber,
-        legal_name = "Someone",
-        mobile_phone_number = "125245",
-        email = "hello@hullo.com",
-        face_image = CustomerFaceImageJson("www.example.com/person/123/image.png", exampleDate),
-        date_of_birth = exampleDate,
-        relationship_status = "Single",
-        dependants = 1,
-        dob_of_dependants = List(exampleDate),
-        highest_education_attained = "Bachelor’s Degree",
-        employment_status = "Employed",
-        kyc_status = true,
-        last_ok_date = exampleDate
-      )
-      val requestPost = (v1_4Request / "banks" / testBank.value / "customer").POST <@ (user1)
-      val responsePost = makePostRequest(requestPost, write(customerPostJSON))
+      val customerPostJSON1 = createCustomerJson(mockCustomerNumber1)
+      Then("User is linked to 0 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON1.user_id).size should equal(0)
+      val requestPost = (v1_4Request / "banks" / mockBankId1.value / "customer").POST <@ (user1)
+      val responsePost = makePostRequest(requestPost, write(customerPostJSON1))
+      Then("We should get a 400")
+      responsePost.code should equal(400)
+
+      When("We add one required entitlement")
+      Entitlement.entitlement.vend.addEntitlement(mockBankId1.value, authuser1.userId, ApiRole.CanCreateCustomer.toString)
+      val responsePost1Entitlement = makePostRequest(requestPost, write(customerPostJSON1))
+      Then("We should get a 400")
+      responsePost1Entitlement.code should equal(400)
+
+      When("We add all required entitlement")
+      Entitlement.entitlement.vend.addEntitlement(mockBankId1.value, authuser1.userId, ApiRole.CanCreateUserCustomerLink.toString)
+      val responsePost2Entitlement = makePostRequest(requestPost, write(customerPostJSON1))
       Then("We should get a 200")
-      responsePost.code should equal(200)
+      responsePost2Entitlement.code should equal(200)
       And("We should get the right information back")
-      val infoPost = responsePost.body.extract[CustomerJson]
-
-      When("We make the request without link user to customer")
-      val requestGetWithoutLink = (v1_4Request / "banks" / testBank.value / "customer").GET <@ (user1)
-      val responseGetWithoutLink = makeGetRequest(requestGetWithoutLink)
-      Then("We should get a 400")
-      responseGetWithoutLink.code should equal(400)
-      val error = for { JObject(o) <- responseGetWithoutLink.body; JField("error", JString(error)) <- o } yield error
-      And("We should get a message: " + ErrorMessages.CustomerDoNotExistsForUser)
-      error should contain (ErrorMessages.CustomerDoNotExistsForUser)
-
-
-      val customerId: String = (responsePost.body \ "customer_id") match {
-        case JString(i) => i
-        case _ => ""
-      }
-
-      When("We link user to customer")
-      val uclJSON = CreateUserCustomerLinkJSON(user_id = authuser1.userId, customer_id = customerId)
-      val requestPostUcl = (v2_0Request / "banks" / testBank.value / "user_customer_links").POST <@ (user1)
-      val responsePostUcl = makePostRequest(requestPostUcl, write(uclJSON))
-      Then("We should get a 400")
-      responsePostUcl.code should equal(400)
-
-      When("We add required entitlement")
-      Entitlement.entitlement.vend.addEntitlement(testBank.value, authuser1.userId, ApiRole.CanCreateUserCustomerLink.toString)
-      val responsePostUclSec = makePostRequest(requestPostUcl, write(uclJSON))
-      Then("We should get a 201")
-      responsePostUclSec.code should equal(201)
-
+      val infoPost = responsePost2Entitlement.body.extract[CustomerJson]
 
       When("We make the request")
-      val requestGet = (v1_4Request / "banks" / testBank.value / "customer").GET <@ (user1)
+      val requestGet = (v1_4Request / "banks" / mockBankId1.value / "customer").GET <@ (user1)
       val responseGet = makeGetRequest(requestGet)
 
       Then("We should get a 200")
@@ -103,6 +95,51 @@ class CustomerTest extends V200ServerSetup with DefaultUsers {
 
       And("POST feedback and GET feedback must be the same")
       infoGet should equal(infoPost)
+
+      And("User is linked to 1 customer")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON1.user_id).size should equal(1)
+
+
+      When("We try to make the second request with same customer number at same bank")
+      val secondResponsePost = makePostRequest(requestPost, write(customerPostJSON1))
+      Then("We should get a 400")
+      secondResponsePost.code should equal(400)
+      val error = for { JObject(o) <- secondResponsePost.body; JField("error", JString(error)) <- o } yield error
+      And("We should get a message: " + ErrorMessages.CustomerNumberAlreadyExists)
+      error should contain (ErrorMessages.CustomerNumberAlreadyExists)
+      And("User is linked to 1 customer")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON1.user_id).size should equal(1)
+
+      When("We try to make a request with changed customer number at same bank")
+      val customerPostJSON2 = createCustomerJson(mockCustomerNumber2)
+      val requestPost2 = (v1_4Request / "banks" / mockBankId1.value / "customer").POST <@ (user1)
+      val responsePost2 = makePostRequest(requestPost2, write(customerPostJSON2))
+      Then("We should get a 200")
+      responsePost2.code should equal(200)
+      And("User is linked to 2 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON1.user_id).size should equal(2)
+
+      When("We try to make a request with same customer number at different bank")
+      Then("first we add all required entitlements")
+      Entitlement.entitlement.vend.addEntitlement(mockBankId2.value, authuser1.userId, ApiRole.CanCreateCustomer.toString)
+      Entitlement.entitlement.vend.addEntitlement(mockBankId2.value, authuser1.userId, ApiRole.CanCreateUserCustomerLink.toString)
+      val customerPostJSON3 = createCustomerJson(mockCustomerNumber1)
+      val requestPost3 = (v1_4Request / "banks" / mockBankId2.value / "customer").POST <@ (user1)
+      val responsePost3 = makePostRequest(requestPost3, write(customerPostJSON3))
+      Then("We should get a 200")
+      responsePost3.code should equal(200)
+      And("User is linked to 3 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON1.user_id).size should equal(3)
+
+      When("We try to make the second request with same customer number at same bank")
+      val secondResponsePost3 = makePostRequest(requestPost3, write(customerPostJSON3))
+      Then("We should get a 400")
+      secondResponsePost3.code should equal(400)
+      val error3 = for { JObject(o) <- secondResponsePost3.body; JField("error", JString(error)) <- o } yield error
+      And("We should get a message: " + ErrorMessages.CustomerNumberAlreadyExists)
+      error3 should contain (ErrorMessages.CustomerNumberAlreadyExists)
+      And("User is linked to 3 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON3.user_id).size should equal(3)
     }
   }
 

--- a/src/test/scala/code/api/v2_0_0/CustomerTest.scala
+++ b/src/test/scala/code/api/v2_0_0/CustomerTest.scala
@@ -3,12 +3,14 @@ package code.api.v2_0_0
 import java.text.SimpleDateFormat
 
 import code.api.DefaultUsers
-import code.api.v1_4_0.JSONFactory1_4_0.{CustomerFaceImageJson, CustomerJson}
-import code.customer.{Customer}
+import code.customer.Customer
 import code.model.BankId
 import code.api.util.APIUtil.OAuth._
-import code.api.util.ApiRole
+import code.api.util.{ApiRole, ErrorMessages}
+import code.api.v1_4_0.JSONFactory1_4_0.{CustomerFaceImageJson, CustomerJson}
 import code.entitlement.Entitlement
+import code.usercustomerlinks.UserCustomerLink
+import net.liftweb.json.JsonAST.{JField, JObject, JString}
 import net.liftweb.json.Serialization.write
 
 class CustomerTest extends V200ServerSetup with DefaultUsers {
@@ -17,8 +19,29 @@ class CustomerTest extends V200ServerSetup with DefaultUsers {
   val simpleDateFormat: SimpleDateFormat = new SimpleDateFormat("dd/mm/yyyy")
   val exampleDate = simpleDateFormat.parse(exampleDateString)
 
-  val mockBankId = BankId("testBank1")
-  val mockCustomerNumber = "9393490320"
+  val mockBankId1 = BankId("testBank1")
+  val mockBankId2 = BankId("testBank2")
+  val mockCustomerNumber1 = "93934903201"
+  val mockCustomerNumber2 = "93934903202"
+
+  def createCustomerJson(customerNumber: String) = {
+    CreateCustomerJson(
+      user_id = authuser1.userId,
+      customer_number = customerNumber,
+      legal_name = "Someone",
+      mobile_phone_number = "125245",
+      email = "hello@hullo.com",
+      face_image = CustomerFaceImageJson("www.example.com/person/123/image.png", exampleDate),
+      date_of_birth = exampleDate,
+      relationship_status = "Single",
+      dependants = 1,
+      dob_of_dependants = List(exampleDate),
+      highest_education_attained = "Bachelor’s Degree",
+      employment_status = "Employed",
+      kyc_status = true,
+      last_ok_date = exampleDate
+    )
+  }
 
 
   override def beforeAll() {
@@ -28,44 +51,30 @@ class CustomerTest extends V200ServerSetup with DefaultUsers {
   override def afterAll() {
     super.afterAll()
     Customer.customerProvider.vend.bulkDeleteCustomers()
+    UserCustomerLink.userCustomerLink.vend.bulkDeleteUserCustomerLinks()
   }
 
   feature("Assuring that create customer, v2.0.0, feedback and get customer, v1.4.0, feedback are the same") {
 
     scenario("There is a user, and the bank in questions has customer info for that user - v2.0.0") {
       Given("The bank in question has customer info")
-      val testBank = mockBankId
 
-      val customerPostJSON = CreateCustomerJson(
-        user_id = authuser1.userId,
-        customer_number = mockCustomerNumber,
-        legal_name = "Someone",
-        mobile_phone_number = "125245",
-        email = "hello@hullo.com",
-        face_image = CustomerFaceImageJson("www.example.com/person/123/image.png", exampleDate),
-        date_of_birth = exampleDate,
-        relationship_status = "Single",
-        dependants = 1,
-        dob_of_dependants = List(exampleDate),
-        highest_education_attained = "Bachelor’s Degree",
-        employment_status = "Employed",
-        kyc_status = true,
-        last_ok_date = exampleDate
-      )
-
-      val requestPost = (v2_0Request / "banks" / testBank.value / "customers").POST <@ (user1)
+      val customerPostJSON = createCustomerJson(mockCustomerNumber1)
+      Then("User is linked to 0 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON.user_id).size should equal(0)
+      val requestPost = (v2_0Request / "banks" / mockBankId1.value / "customers").POST <@ (user1)
       val responsePost = makePostRequest(requestPost, write(customerPostJSON))
       Then("We should get a 400")
       responsePost.code should equal(400)
 
       When("We add one required entitlement")
-      Entitlement.entitlement.vend.addEntitlement(testBank.value, authuser1.userId, ApiRole.CanCreateCustomer.toString)
+      Entitlement.entitlement.vend.addEntitlement(mockBankId1.value, authuser1.userId, ApiRole.CanCreateCustomer.toString)
       val responsePost1 = makePostRequest(requestPost, write(customerPostJSON))
       Then("We should get a 400")
       responsePost1.code should equal(400)
 
       When("We add all required entitlement")
-      Entitlement.entitlement.vend.addEntitlement(testBank.value, authuser1.userId, ApiRole.CanCreateUserCustomerLink.toString)
+      Entitlement.entitlement.vend.addEntitlement(mockBankId1.value, authuser1.userId, ApiRole.CanCreateUserCustomerLink.toString)
       val responsePost2 = makePostRequest(requestPost, write(customerPostJSON))
       Then("We should get a 201")
       responsePost2.code should equal(201)
@@ -73,7 +82,7 @@ class CustomerTest extends V200ServerSetup with DefaultUsers {
       val infoPost = responsePost2.body.extract[CustomerJson]
 
       When("We make the request")
-      val requestGet = (v1_4Request / "banks" / testBank.value / "customer").GET <@ (user1)
+      val requestGet = (v2_0Request / "banks" / mockBankId1.value / "customer").GET <@ (user1)
       val responseGet = makeGetRequest(requestGet)
 
       Then("We should get a 200")
@@ -84,6 +93,52 @@ class CustomerTest extends V200ServerSetup with DefaultUsers {
 
       And("POST feedback and GET feedback must be the same")
       infoGet should equal(infoPost)
+
+      And("User is linked to 1 customer")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON.user_id).size should equal(1)
+
+
+      When("We try to make the second request with same customer number at same bank")
+      val secondResponsePost = makePostRequest(requestPost, write(customerPostJSON))
+      Then("We should get a 400")
+      secondResponsePost.code should equal(400)
+      val error = for { JObject(o) <- secondResponsePost.body; JField("error", JString(error)) <- o } yield error
+      And("We should get a message: " + ErrorMessages.CustomerNumberAlreadyExists)
+      error should contain (ErrorMessages.CustomerNumberAlreadyExists)
+      And("User is linked to 1 customer")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON.user_id).size should equal(1)
+
+      When("We try to make a request with changed customer number at same bank")
+      val customerPostJSON3 = createCustomerJson(mockCustomerNumber2)
+      val requestPost3 = (v2_0Request / "banks" / mockBankId1.value / "customers").POST <@ (user1)
+      val responsePost3 = makePostRequest(requestPost3, write(customerPostJSON3))
+      Then("We should get a 201")
+      responsePost3.code should equal(201)
+      And("User is linked to 2 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON3.user_id).size should equal(2)
+
+      When("We try to make a request with same customer number at different bank")
+      Then("first we add all required entitlements")
+      Entitlement.entitlement.vend.addEntitlement(mockBankId2.value, authuser1.userId, ApiRole.CanCreateCustomer.toString)
+      Entitlement.entitlement.vend.addEntitlement(mockBankId2.value, authuser1.userId, ApiRole.CanCreateUserCustomerLink.toString)
+      val customerPostJSON4 = createCustomerJson(mockCustomerNumber1)
+      val requestPost4 = (v2_0Request / "banks" / mockBankId2.value / "customers").POST <@ (user1)
+      val responsePost4 = makePostRequest(requestPost4, write(customerPostJSON4))
+      Then("We should get a 201")
+      responsePost4.code should equal(201)
+      And("User is linked to 3 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON4.user_id).size should equal(3)
+
+      When("We try to make the second request with same customer number at same bank")
+      val secondResponsePost4 = makePostRequest(requestPost4, write(customerPostJSON4))
+      Then("We should get a 400")
+      secondResponsePost4.code should equal(400)
+      val error4 = for { JObject(o) <- secondResponsePost4.body; JField("error", JString(error)) <- o } yield error
+      And("We should get a message: " + ErrorMessages.CustomerNumberAlreadyExists)
+      error4 should contain (ErrorMessages.CustomerNumberAlreadyExists)
+      And("User is linked to 3 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON.user_id).size should equal(3)
+
     }
   }
 

--- a/src/test/scala/code/api/v2_1_0/CustomerTest.scala
+++ b/src/test/scala/code/api/v2_1_0/CustomerTest.scala
@@ -3,14 +3,16 @@ package code.api.v2_1_0
 import java.text.SimpleDateFormat
 
 import code.api.DefaultUsers
-import code.api.util.ApiRole
-import code.api.v1_2_1.AmountOfMoneyJSON
+import code.api.util.{ApiRole, ErrorMessages}
 import code.api.v1_4_0.JSONFactory1_4_0.CustomerFaceImageJson
 import code.customer.Customer
 import code.entitlement.Entitlement
 import code.model.BankId
 import net.liftweb.json.Serialization.write
 import code.api.util.APIUtil.OAuth._
+import code.api.v1_2_1.AmountOfMoneyJSON
+import code.usercustomerlinks.UserCustomerLink
+import net.liftweb.json.JsonAST.{JField, JObject, JString}
 
 class CustomerTest extends V210ServerSetup with DefaultUsers {
 
@@ -18,8 +20,31 @@ class CustomerTest extends V210ServerSetup with DefaultUsers {
   val simpleDateFormat: SimpleDateFormat = new SimpleDateFormat("dd/mm/yyyy")
   val exampleDate = simpleDateFormat.parse(exampleDateString)
 
-  val mockBankId = BankId("testBank1")
-  val mockCustomerNumber = "9393490320"
+  val mockBankId1 = BankId("testBank1")
+  val mockBankId2 = BankId("testBank2")
+  val mockCustomerNumber1 = "93934903201"
+  val mockCustomerNumber2 = "93934903202"
+
+  def createCustomerJson(customerNumber: String) = {
+    PostCustomerJson(
+      user_id = authuser1.userId,
+      customer_number = customerNumber,
+      legal_name = "Someone",
+      mobile_phone_number = "125245",
+      email = "hello@hullo.com",
+      face_image = CustomerFaceImageJson("www.example.com/person/123/image.png", exampleDate),
+      date_of_birth = exampleDate,
+      relationship_status = "Single",
+      dependants = 1,
+      dob_of_dependants = List(exampleDate),
+      credit_rating = CustomerCreditRatingJSON(rating = "5", source = "Credit biro"),
+      credit_limit = AmountOfMoneyJSON(currency = "EUR", amount = "5000"),
+      highest_education_attained = "Bachelor’s Degree",
+      employment_status = "Employed",
+      kyc_status = true,
+      last_ok_date = exampleDate
+    )
+  }
 
 
   override def beforeAll() {
@@ -29,54 +54,39 @@ class CustomerTest extends V210ServerSetup with DefaultUsers {
   override def afterAll() {
     super.afterAll()
     Customer.customerProvider.vend.bulkDeleteCustomers()
+    UserCustomerLink.userCustomerLink.vend.bulkDeleteUserCustomerLinks()
   }
 
   feature("Assuring that create customer, v2.0.0, feedback and get customer, v1.4.0, feedback are the same") {
 
     scenario("There is a user, and the bank in questions has customer info for that user - v2.0.0") {
       Given("The bank in question has customer info")
-      val testBank = mockBankId
 
-      val customerPostJSON = PostCustomerJson(
-        user_id = authuser1.userId,
-        customer_number = mockCustomerNumber,
-        legal_name = "Someone",
-        mobile_phone_number = "125245",
-        email = "hello@hullo.com",
-        face_image = CustomerFaceImageJson("www.example.com/person/123/image.png", exampleDate),
-        date_of_birth = exampleDate,
-        relationship_status = "Single",
-        dependants = 1,
-        dob_of_dependants = List(exampleDate),
-        credit_rating = CustomerCreditRatingJSON(rating = "5", source = "Credit biro"),
-        credit_limit = AmountOfMoneyJSON(currency = "EUR", amount = "5000"),
-        highest_education_attained = "Bachelor’s Degree",
-        employment_status = "Employed",
-        kyc_status = true,
-        last_ok_date = exampleDate
-      )
-
-      val requestPost = (v2_1Request / "banks" / testBank.value / "customers").POST <@ (user1)
+      val customerPostJSON = createCustomerJson(mockCustomerNumber1)
+      Then("User is linked to 0 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON.user_id).size should equal(0)
+      val requestPost = (v2_1Request / "banks" / mockBankId1.value / "customers").POST <@ (user1)
       val responsePost = makePostRequest(requestPost, write(customerPostJSON))
       Then("We should get a 400")
       responsePost.code should equal(400)
 
       When("We add one required entitlement")
-      Entitlement.entitlement.vend.addEntitlement(testBank.value, authuser1.userId, ApiRole.CanCreateCustomer.toString)
+      Entitlement.entitlement.vend.addEntitlement(mockBankId1.value, authuser1.userId, ApiRole.CanCreateCustomer.toString)
       val responsePost1 = makePostRequest(requestPost, write(customerPostJSON))
       Then("We should get a 400")
       responsePost1.code should equal(400)
 
       When("We add all required entitlement")
-      Entitlement.entitlement.vend.addEntitlement(testBank.value, authuser1.userId, ApiRole.CanCreateUserCustomerLink.toString)
+      Entitlement.entitlement.vend.addEntitlement(mockBankId1.value, authuser1.userId, ApiRole.CanCreateUserCustomerLink.toString)
       val responsePost2 = makePostRequest(requestPost, write(customerPostJSON))
+      println("responsePost2 " + responsePost2)
       Then("We should get a 201")
       responsePost2.code should equal(201)
       And("We should get the right information back")
       val infoPost = responsePost2.body.extract[CustomerJson]
 
       When("We make the request")
-      val requestGet = (v2_1Request / "banks" / testBank.value / "customer").GET <@ (user1)
+      val requestGet = (v2_1Request / "banks" / mockBankId1.value / "customer").GET <@ (user1)
       val responseGet = makeGetRequest(requestGet)
 
       Then("We should get a 200")
@@ -87,6 +97,51 @@ class CustomerTest extends V210ServerSetup with DefaultUsers {
 
       And("POST feedback and GET feedback must be the same")
       infoGet should equal(infoPost)
+
+      And("User is linked to 1 customer")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON.user_id).size should equal(1)
+
+
+      When("We try to make the second request with same customer number at same bank")
+      val secondResponsePost = makePostRequest(requestPost, write(customerPostJSON))
+      Then("We should get a 400")
+      secondResponsePost.code should equal(400)
+      val error = for { JObject(o) <- secondResponsePost.body; JField("error", JString(error)) <- o } yield error
+      And("We should get a message: " + ErrorMessages.CustomerNumberAlreadyExists)
+      error should contain (ErrorMessages.CustomerNumberAlreadyExists)
+      And("User is linked to 1 customer")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON.user_id).size should equal(1)
+
+      When("We try to make a request with changed customer number at same bank")
+      val customerPostJSON3 = createCustomerJson(mockCustomerNumber2)
+      val requestPost3 = (v2_1Request / "banks" / mockBankId1.value / "customers").POST <@ (user1)
+      val responsePost3 = makePostRequest(requestPost3, write(customerPostJSON3))
+      Then("We should get a 201")
+      responsePost3.code should equal(201)
+      And("User is linked to 2 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON3.user_id).size should equal(2)
+
+      When("We try to make a request with same customer number at different bank")
+      Then("first we add all required entitlements")
+      Entitlement.entitlement.vend.addEntitlement(mockBankId2.value, authuser1.userId, ApiRole.CanCreateCustomer.toString)
+      Entitlement.entitlement.vend.addEntitlement(mockBankId2.value, authuser1.userId, ApiRole.CanCreateUserCustomerLink.toString)
+      val customerPostJSON4 = createCustomerJson(mockCustomerNumber1)
+      val requestPost4 = (v2_1Request / "banks" / mockBankId2.value / "customers").POST <@ (user1)
+      val responsePost4 = makePostRequest(requestPost4, write(customerPostJSON4))
+      Then("We should get a 201")
+      responsePost4.code should equal(201)
+      And("User is linked to 3 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON4.user_id).size should equal(3)
+
+      When("We try to make the second request with same customer number at same bank")
+      val secondResponsePost4 = makePostRequest(requestPost4, write(customerPostJSON4))
+      Then("We should get a 400")
+      secondResponsePost4.code should equal(400)
+      val error4 = for { JObject(o) <- secondResponsePost4.body; JField("error", JString(error)) <- o } yield error
+      And("We should get a message: " + ErrorMessages.CustomerNumberAlreadyExists)
+      error4 should contain (ErrorMessages.CustomerNumberAlreadyExists)
+      And("User is linked to 3 customers")
+      UserCustomerLink.userCustomerLink.vend.getUserCustomerLinkByUserId(customerPostJSON.user_id).size should equal(3)
     }
   }
 


### PR DESCRIPTION
@simonredfern Please consider the change
Enhanced test scenario:
1. We check that User to Customer Link has 0 connections before creation of any customer
2. We try to add customer without entitlement: CanCreateCustomer - UNSUCCESSFUL
3. We try to add customer without entitlement: CanCreateUserCustomerLink - UNSUCCESSFUL
4. We try to add customer with entitlements CanCreateCustomer and CanCreateUserCustomerLink - SUCCESSFUL
5. We check that User to Customer Link has 1 connections
6. We try to get customer and assure that posted and obtained data are same
7. We try to make the second request with same customer number at same bank - UNSUCCESSFUL due to ErrorMessages.CustomerNumberAlreadyExists
8. We try to make a request with changed customer number at same bank - - SUCCESSFUL
9. We check that User to Customer Link has 2 connections
10. We add all required entitlements at a new bank: CanCreateCustomer and CanCreateUserCustomerLink
11. We try to make a request with same customer number at the new bank - SUCCESSFUL
12.  We check that User to Customer Link has 3 connections
13. We try to make the second request with same customer number at same bank - UNSUCCESSFUL
14. We check that User to Customer Link has 3 connections