### PR TITLE
#446 For Kafka / Kafka Mar 2017, add getTransactionRequestStatusesImpl

### DIFF
--- a/src/main/scala/code/bankconnectors/Connector.scala
+++ b/src/main/scala/code/bankconnectors/Connector.scala
@@ -607,14 +607,14 @@ trait Connector {
     }
   }
 
-  def getTransactionRequestStatuses() : Box[Map[String, String]] = {
+  def getTransactionRequestStatuses() : Box[TransactionRequestStatus] = {
     for {
       transactionRequestStatuses <- getTransactionRequestStatusesImpl()
     } yield transactionRequestStatuses
 
   }
 
-  protected def getTransactionRequestStatusesImpl() : Box[Map[String, String]]
+  protected def getTransactionRequestStatusesImpl() : Box[TransactionRequestStatus]
 
   protected def getTransactionRequestsImpl(fromAccount : BankAccount) : Box[List[TransactionRequest]]
 

--- a/src/main/scala/code/bankconnectors/KafkaMappedConnector.scala
+++ b/src/main/scala/code/bankconnectors/KafkaMappedConnector.scala
@@ -713,28 +713,9 @@ object KafkaMappedConnector extends Connector with Loggable {
   /*
     Transaction Requests
   */
-  override def getTransactionRequestStatusesImpl() : Box[Map[String, String]] = {
-      val req : Map[String,String] = Map(
-      "north" -> "fetch",
-      "version" -> formatVersion,
-      "name" -> "fetch"
-    )
-
-    val r = process(req)
-    try {
-      Full(r.extract[Map[String, String]])
-    } catch {
-      case mpex: net.liftweb.json.MappingException => Empty
-    }
-
-    //try {
-    //  r.extract[KafkaInboundTransactionRequestStatus] match {
-    //    case status: KafkaInboundTransactionRequestStatus => Full(status.transactionRequestId, status.bulkTransactionsStatus.map( x => TransactionStatus(x.transactionId, x.transactionStatus, x.transactionTimestamp))))
-    //    case _ => Empty
-    //  }
-    //} catch {
-    //  case mpex: net.liftweb.json.MappingException => Empty
-    //}
+  override def getTransactionRequestStatusesImpl() : Box[TransactionRequestStatus] ={
+    logger.info("Kafka getTransactionRequestStatusesImpl response -- This is KafkaMappedConnector, just call KafkaMappedConnector_vMar2017 methods:")
+    KafkaMappedConnector_vMar2017.getTransactionRequestStatusesImpl()
   }
 
   override def createTransactionRequestImpl(transactionRequestId: TransactionRequestId, transactionRequestType: TransactionRequestType,

--- a/src/main/scala/code/bankconnectors/LocalConnector.scala
+++ b/src/main/scala/code/bankconnectors/LocalConnector.scala
@@ -367,8 +367,7 @@ private object LocalConnector extends Connector with Loggable {
     }
   }
 
-  override def getTransactionRequestStatusesImpl() : Box[Map[String, String]] = ???
-
+  override def getTransactionRequestStatusesImpl() :  Box[TransactionRequestStatus] = Empty
   /*
    Transaction Requests
  */

--- a/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -494,7 +494,7 @@ object LocalMappedConnector extends Connector with Loggable {
   /*
     Transaction Requests
   */
-  override def getTransactionRequestStatusesImpl() : Box[Map[String, String]] = ???
+  override def getTransactionRequestStatusesImpl() : Box[TransactionRequestStatus] = Empty
 
   override def createTransactionRequestImpl(transactionRequestId: TransactionRequestId, transactionRequestType: TransactionRequestType,
                                             account : BankAccount, counterparty : BankAccount, body: TransactionRequestBody,

--- a/src/main/scala/code/model/BankingData.scala
+++ b/src/main/scala/code/model/BankingData.scala
@@ -80,21 +80,17 @@ object TransactionRequestType {
   def unapply(id : String) = Some(TransactionRequestType(id))
 }
 
-case class TransactionRequestStatus(
-  transactionRequestid : String,
-  bulkTransactionsStatus: List[TransactionStatus])
-
-object TransactionRequestStatus {
-  def unapply(trId : String, tStatuses: List[TransactionStatus]) = Some(TransactionRequestStatus(trId, tStatuses))
+//Note: change csae class -> trait, for kafka extends it
+trait TransactionRequestStatus{
+  def transactionRequestid : String
+  def bulkTransactionsStatus: List[TransactionStatus]
 }
 
-case class TransactionStatus(
-  transactionId : String,
-  transactionStatus: String,
-  transactionTimestamp: String)
 
-object TransactionStatus {
-  def unapply(trId : String, trStatus: String, trTimestamp: String) = Some(TransactionStatus(trId, trStatus, trTimestamp))
+trait TransactionStatus{
+  def transactionId : String
+  def transactionStatus: String
+  def transactionTimestamp: String
 }
 
 case class TransactionRequestId(val value : String) {

--- a/src/test/scala/code/api/v1_3_0/PhysicalCardsTest.scala
+++ b/src/test/scala/code/api/v1_3_0/PhysicalCardsTest.scala
@@ -63,8 +63,7 @@ class PhysicalCardsTest extends ServerSetup with DefaultUsers  with DefaultConne
 
     type AccountType = BankAccount
 
-    override def getTransactionRequestStatusesImpl() : Box[Map[String, String]] = ???
-
+    override def getTransactionRequestStatusesImpl() : Box[TransactionRequestStatus] = Empty
   def getUser(name: String, password: String): Box[InboundUser] = ???
     def updateUserAccountViews(user: ResourceUser): Unit = ???
 

--- a/src/test/scala/code/api/v1_4_0/MappedCustomerMessagesTest.scala
+++ b/src/test/scala/code/api/v1_4_0/MappedCustomerMessagesTest.scala
@@ -127,6 +127,7 @@ class MappedCustomerMessagesTest extends V140ServerSetup with DefaultUsers {
   override def beforeEach(): Unit = {
     super.beforeEach()
     MappedCustomerMessage.bulkDelete_!!()
+    createCustomer(mockBankId, authuser1, mockCustomerNumber)
   }
 
 }


### PR DESCRIPTION
I can test obpjvm now. Just keep it Similar as kafka.

I try to DTY the code, call KafkaMappedConnector_vMar2017 method in KafkaMappedConnector.scala . 
Double check whether it is a good practice .

