### PR TITLE
 #469 Add additional fields to the Bank, Branch, Account 

### DIFF
--- a/src/main/scala/code/api/util/APIUtil.scala
+++ b/src/main/scala/code/api/util/APIUtil.scala
@@ -87,7 +87,7 @@ object ErrorMessages {
 
   val InvalidConsumerKey = "OBP-20008: Invalid Consumer Key."
   val InvalidConsumerCredentials = "OBP-20009: Invalid consumer credentials"
-  val UserNotHaveEntilement  = "OBP-20010: Login in user do not have the entitlement:" //When use this, should contact the entitlement name after it .
+  val InsufficientAuthorisationToCreateBranch  = "OBP-20010: Insufficient authorisation to Create Branch offered by the bank. The Request could not be created because you don't have access to CanCreateBranch."
 
   val InvalidValueLength = "OBP-20010: Value too long"
   val InvalidValueCharacters = "OBP-20011: Value contains invalid characters"
@@ -132,7 +132,7 @@ object ErrorMessages {
   val BankAccountNotFound = "OBP-30018: Bank Account not found. Please specify valid values for BANK_ID and ACCOUNT_ID. "
   val ConsumerNotFoundByConsumerId = "OBP-30019: Consumer not found. Please specify a valid value for CONSUMER_ID."
   
-  val CreateBankInsertError = "OBP-30020: Could not insert the Bank"
+  val CreateBankInsertError = "OBP-30020: Could not create the Bank"
   val CreateBankUpdateError = "OBP-30021: Could not update the Bank"
   
 

--- a/src/main/scala/code/api/v1_2_1/APIMethods121.scala
+++ b/src/main/scala/code/api/v1_2_1/APIMethods121.scala
@@ -136,7 +136,7 @@ trait APIMethods121 {
         |* Logo URL
         |* Website""",
       emptyObjectJson,
-      decompose(BanksJSON(List(BankJSON("1", "EFG", "Eurobank", "None", "www.eurobank.rs")))),
+      decompose(BanksJSON(List(BankJSON("gh.29.uk", "EFG", "Eurobank", "None", "www.eurobank.rs","obp","gh.29.uk")))),
       emptyObjectJson :: Nil,
       Catalogs(Core, notPSD2, OBWG),
       apiTagBank :: Nil)
@@ -172,7 +172,7 @@ trait APIMethods121 {
         |* Logo URL
         |* Website""",
       emptyObjectJson,
-      decompose(BankJSON("1", "EFG", "Eurobank", "None", "www.eurobank.rs")),
+      decompose(BankJSON("gh.29.uk", "EFG", "Eurobank", "None", "www.eurobank.rs","obp","gh.29.uk")),
       emptyObjectJson :: Nil,
       Catalogs(Core, notPSD2, OBWG),
       apiTagBank :: Nil)

--- a/src/main/scala/code/api/v1_2_1/JSONFactory1.2.1.scala
+++ b/src/main/scala/code/api/v1_2_1/JSONFactory1.2.1.scala
@@ -65,7 +65,9 @@ case class BankJSON(
   short_name : String,
   full_name : String,
   logo : String,
-  website : String
+  website : String,
+  bankRoutingScheme : String,
+  bankRoutingAddress : String
 )
 case class ViewsJSON(
   views : List[ViewJSON]
@@ -163,7 +165,9 @@ case class ModeratedAccountJSON(
   IBAN : String,
   swift_bic: String,
   views_available : List[ViewJSON],
-  bank_id : String
+  bank_id : String,
+  account_routing_scheme : String,
+  account_routing_address : String
 )
 case class UserJSON(
   id : String,
@@ -344,7 +348,9 @@ object JSONFactory{
       stringOrNull(bank.shortName),
       stringOrNull(bank.fullName),
       stringOrNull(bank.logoUrl),
-      stringOrNull(bank.websiteUrl)
+      stringOrNull(bank.websiteUrl),
+      stringOrNull(bank.bankRoutingScheme),
+      stringOrNull(bank.bankRoutingAddress)
     )
   }
 
@@ -452,7 +458,9 @@ object JSONFactory{
       stringOptionOrNull(account.iban),
       stringOptionOrNull(account.swift_bic),
       viewsAvailable,
-      stringOrNull(account.bankId.value)
+      stringOrNull(account.bankId.value),
+      stringOptionOrNull(account.accountRoutingScheme),
+      stringOptionOrNull(account.accountRoutingAddress)
     )
   }
 

--- a/src/main/scala/code/api/v1_4_0/JSONFactory1_4_0.scala
+++ b/src/main/scala/code/api/v1_4_0/JSONFactory1_4_0.scala
@@ -16,7 +16,8 @@ import net.liftweb.json.JsonAST.{JObject, JValue}
 import org.pegdown.PegDownProcessor
 import code.api.v1_2_1.AmountOfMoneyJSON
 import code.api.v2_0_0.TransactionRequestChargeJSON
-import code.transactionrequests.{TransactionRequestTypeCharge}
+import code.api.v2_2_0.BranchRoutingJSON
+import code.transactionrequests.TransactionRequestTypeCharge
 import net.liftweb.common.Full
 
 object JSONFactory1_4_0 {
@@ -79,7 +80,8 @@ object JSONFactory1_4_0 {
                         location : LocationJson,
                         lobby : LobbyJson,
                         drive_up: DriveUpJson,
-                        meta : MetaJson)
+                        meta : MetaJson,
+                        branch_routing: BranchRoutingJSON)
 
   case class BranchesJson (branches : List[BranchJson])
 
@@ -176,7 +178,12 @@ object JSONFactory1_4_0 {
                 createLocationJson(branch.location),
                 createLobbyJson(branch.lobby.hours),
                 createDriveUpJson(branch.driveUp.hours),
-                createMetaJson(branch.meta))
+                createMetaJson(branch.meta),
+                BranchRoutingJSON(
+                  branch_routing_scheme = branch.branchRoutingScheme,
+                  branch_routing_address = branch.branchRoutingAddress
+                )
+    )
   }
 
   def createBranchesJson(branchesList: List[Branch]) : BranchesJson = {

--- a/src/main/scala/code/api/v2_0_0/JSONFactory2.0.0.scala
+++ b/src/main/scala/code/api/v2_0_0/JSONFactory2.0.0.scala
@@ -518,7 +518,9 @@ object JSONFactory200{
                                    balance : AmountOfMoneyJSON,
                                    IBAN : String,
                                    swift_bic: String,
-                                   bank_id : String
+                                   bank_id : String,
+                                   account_routing_scheme : String,
+                                   account_routing_address : String
                                  )
 
   case class CoreTransactionsJSON(
@@ -704,7 +706,9 @@ object JSONFactory200{
       JSONFactory121.createAmountOfMoneyJSON(account.currency.getOrElse(""), account.balance),
       JSONFactory121.stringOptionOrNull(account.iban),
       JSONFactory121.stringOptionOrNull(account.swift_bic),
-      stringOrNull(account.bankId.value)
+      stringOrNull(account.bankId.value),
+      JSONFactory121.stringOptionOrNull(account.accountRoutingScheme),
+      JSONFactory121.stringOptionOrNull(account.accountRoutingAddress)
     )
   }
 

--- a/src/main/scala/code/api/v2_1_0/APIMethods210.scala
+++ b/src/main/scala/code/api/v2_1_0/APIMethods210.scala
@@ -1410,7 +1410,7 @@ trait APIMethods210 {
             u <- user ?~ ErrorMessages.UserNotLoggedIn
             bank <- Bank(bankId) ?~! {ErrorMessages.BankNotFound}
             branch <- tryo {json.extract[BranchJsonPut]} ?~! ErrorMessages.InvalidJsonFormat
-            canCreateBranch <- booleanToBox(hasEntitlement(bank.bankId.value, u.userId, CanCreateBranch) == true,s"${ErrorMessages.UserNotHaveEntilement} ${CanCreateBranch}")
+            canCreateBranch <- booleanToBox(hasEntitlement(bank.bankId.value, u.userId, CanCreateBranch) == true, ErrorMessages.InsufficientAuthorisationToCreateBranch)
             //package the BranchJsonPut to toBranchJsonPost, to call the createOrUpdateBranch method
             branchPost <- toBranchJsonPost(branchId,branch)
             success <- Connector.connector.vend.createOrUpdateBranch(
@@ -1454,7 +1454,7 @@ trait APIMethods210 {
             u <- user ?~ ErrorMessages.UserNotLoggedIn
             bank <- Bank(bankId)?~! {ErrorMessages.BankNotFound}
             branch <- tryo {json.extract[BranchJsonPost]} ?~! ErrorMessages.InvalidJsonFormat
-            canCreateBranch <- booleanToBox(hasEntitlement(bank.bankId.value, u.userId, CanCreateBranch) == true,s"${ErrorMessages.UserNotHaveEntilement} ${CanCreateBranch}")
+            canCreateBranch <- booleanToBox(hasEntitlement(bank.bankId.value, u.userId, CanCreateBranch) == true, ErrorMessages.InsufficientAuthorisationToCreateBranch)
             success <- Connector.connector.vend.createOrUpdateBranch(
               branch,
               "", //new field in V220

--- a/src/main/scala/code/api/v2_1_0/APIMethods210.scala
+++ b/src/main/scala/code/api/v2_1_0/APIMethods210.scala
@@ -1007,6 +1007,7 @@ trait APIMethods210 {
       "/banks/BANK_ID/branches/BRANCH_ID",
       "Get Bank Branch",
       s"""Returns information about branches for a single bank specified by BANK_ID and BRANCH_ID including:
+          | meta.license.id and eta.license.name fields must not be empty. 
           |
           |* Name
           |* Address
@@ -1030,7 +1031,8 @@ trait APIMethods210 {
             else
               user ?~! ErrorMessages.UserNotLoggedIn
             bank <- Bank(bankId) ?~! {ErrorMessages.BankNotFound}
-            branch <- Box(Branches.branchesProvider.vend.getBranch(branchId)) ?~! {ErrorMessages.BranchNotFoundByBranchId}
+            branch <- Box(Branches.branchesProvider.vend.getBranch(branchId)) ?~! 
+              s"${ErrorMessages.BranchNotFoundByBranchId}, or License may not be set. meta.license.id and eta.license.name can not be empty"
           } yield {
             // Format the data as json
             val json = JSONFactory1_4_0.createBranchJson(branch)

--- a/src/main/scala/code/api/v2_2_0/APIMethods220.scala
+++ b/src/main/scala/code/api/v2_2_0/APIMethods220.scala
@@ -310,8 +310,10 @@ trait APIMethods220 {
           website_url = "https://www.example.com",
           swift_bic = "IIIGGB22",
           national_identifier = "UK97ZZZ1234567890",
-          bank_routing_scheme = "IIIGGB22",
-          bank_routing_address = "UK97ZZZ1234567890"
+          bank_routing = BankRoutingJSON(
+            bank_routing_scheme = "IIIGGB22",
+            bank_routing_address = "UK97ZZZ1234567890"
+          )
         )
       ),
       emptyObjectJson,
@@ -334,8 +336,8 @@ trait APIMethods220 {
               bank.website_url,
               bank.swift_bic,
               bank.national_identifier,
-              bank.bank_routing_scheme,
-              bank.bank_routing_address
+              bank.bank_routing.bank_routing_scheme,
+              bank.bank_routing.bank_routing_address
             )
           } yield {
             val json = JSONFactory220.createBankJSON(success)
@@ -363,9 +365,11 @@ trait APIMethods220 {
           location = LocationJson(1.2, 2.1),
           meta = MetaJson(LicenseJson("", "")),
           lobby = LobbyJson("Ma-Pe 10:00-16:30"),
-          driveUp = DriveUpJson("Ma-Pe 09:00-14:00"),
-          branch_routing_scheme = "IIIGGB22",
-          branch_routing_address = "UK97ZZZ1234567890"
+          drive_up = DriveUpJson("Ma-Pe 09:00-14:00"),
+          branch_routing = BranchRoutingJSON(
+            branch_routing_scheme = "IIIGGB22",
+            branch_routing_address = "UK97ZZZ1234567890"
+          )
         )
       ),
       emptyObjectJson,
@@ -380,7 +384,7 @@ trait APIMethods220 {
           for {
             u <- user ?~ ErrorMessages.UserNotLoggedIn
             bank <- Bank(bankId)?~! {ErrorMessages.BankNotFound}
-            canCreateBranch <- booleanToBox(hasEntitlement(bank.bankId.value, u.userId, CanCreateBranch) == true,s"${ErrorMessages.UserNotHaveEntilement} ${CanCreateBranch}")
+            canCreateBranch <- booleanToBox(hasEntitlement(bank.bankId.value, u.userId, CanCreateBranch) == true, ErrorMessages.InsufficientAuthorisationToCreateBranch)
             branch <- tryo {json.extract[BranchJSON]} ?~! ErrorMessages.InvalidJsonFormat
             success <- Connector.connector.vend.createOrUpdateBranch(
               BranchJsonPost(
@@ -391,13 +395,13 @@ trait APIMethods220 {
                 branch.location,
                 branch.meta,
                 branch.lobby,
-                branch.driveUp
+                branch.drive_up
               ),
-              branch.branch_routing_scheme,
-              branch.branch_routing_address
+              branch.branch_routing.branch_routing_scheme,
+              branch.branch_routing.branch_routing_address
             )
           } yield {
-            val json = JSONFactory220.createBranchJson(success)
+            val json = JSONFactory220.createBranchJSON(success)
             createdJsonResponse(Extraction.decompose(json))
           }
       }
@@ -429,8 +433,10 @@ trait APIMethods220 {
             "0"
           ),
           branch_id = "1234",
-          account_routing_scheme = "OBP",
-          account_routing_address = "UK123456"
+          account_routing = AccountRoutingJSON(
+            account_routing_scheme = "OBP",
+            account_routing_address = "UK123456"
+          )
         )
       ),
       emptyObjectJson,
@@ -473,15 +479,13 @@ trait APIMethods220 {
               initialBalanceAsNumber,
               postedOrLoggedInUser.name,
               jsonBody.branch_id,
-              jsonBody.account_routing_scheme,
-              jsonBody.account_routing_address
+              jsonBody.account_routing.account_routing_scheme,
+              jsonBody.account_routing.account_routing_address
             )
           } yield {
             BankAccountCreation.setAsOwner(bankId, accountId, postedOrLoggedInUser)
           
-            val dataContext = DataContext(user, Some(bankAccount.bankId), Some(bankAccount.accountId), Empty, Empty, Empty)
-            val links = code.api.util.APIUtil.getHalLinks(CallerContext(createAccount), codeContext, dataContext)
-            val json = JSONFactory200.createCoreAccountJSON(bankAccount, links)
+            val json = JSONFactory220.createAccountJSON(user_id, bankAccount)
           
             successJsonResponse(Extraction.decompose(json))
           }

--- a/src/main/scala/code/api/v2_2_0/APIMethods220.scala
+++ b/src/main/scala/code/api/v2_2_0/APIMethods220.scala
@@ -359,11 +359,11 @@ trait APIMethods220 {
       Extraction.decompose(
         BranchJSON(
           id = "123",
-          bank_id = "gh.29.fi",
+          bank_id = "gh.29.uk",
           name = "OBP",
           address = AddressJson("VALTATIE 8", "", "", "AKAA", "", "", "37800"),
           location = LocationJson(1.2, 2.1),
-          meta = MetaJson(LicenseJson("", "")),
+          meta = MetaJson(LicenseJson("copyright2016", "copyright2016")),
           lobby = LobbyJson("Ma-Pe 10:00-16:30"),
           drive_up = DriveUpJson("Ma-Pe 09:00-14:00"),
           branch_routing = BranchRoutingJSON(

--- a/src/main/scala/code/api/v2_2_0/JSONFactory2.2.0.scala
+++ b/src/main/scala/code/api/v2_2_0/JSONFactory2.2.0.scala
@@ -168,6 +168,10 @@ case class BankJSON(
   website_url: String,
   swift_bic: String,
   national_identifier: String,
+  bank_routing: BankRoutingJSON
+)
+
+case class BankRoutingJSON(
   bank_routing_scheme: String,
   bank_routing_address: String
 )
@@ -181,7 +185,11 @@ case class BranchJSON(
   location: LocationJson,
   meta: MetaJson,
   lobby: LobbyJson,
-  driveUp: DriveUpJson,
+  drive_up: DriveUpJson,
+  branch_routing: BranchRoutingJSON
+)
+
+case class BranchRoutingJSON(
   branch_routing_scheme: String,
   branch_routing_address: String
 )
@@ -193,8 +201,12 @@ case class CreateAccountJSON(
   `type` : String,
   balance : AmountOfMoneyJSON,
   branch_id : String,
-  account_routing_scheme : String,
-  account_routing_address : String
+  account_routing: AccountRoutingJSON
+)
+
+case class AccountRoutingJSON(
+  account_routing_scheme: String,
+  account_routing_address: String
 )
 
 object JSONFactory220{
@@ -330,13 +342,15 @@ object JSONFactory220{
       website_url = bank.websiteUrl,
       swift_bic = bank.swiftBic,
       national_identifier = bank.nationalIdentifier,
-      bank_routing_scheme = bank.bankRoutingScheme,
-      bank_routing_address = bank.bankRoutingAddress
+      bank_routing = BankRoutingJSON(
+        bank_routing_scheme = bank.bankRoutingScheme,
+        bank_routing_address = bank.bankRoutingAddress
+      )
     )
   }
   
   // keep similar to def createBranchJson(branch: Branch) -- v140
-  def createBranchJson(branch: Branch): BranchJSON = {
+  def createBranchJSON(branch: Branch): BranchJSON = {
     BranchJSON(
       id= branch.branchId.value,
       bank_id= branch.bankId.value,
@@ -345,9 +359,28 @@ object JSONFactory220{
       location= createLocationJson(branch.location),
       meta= createMetaJson(branch.meta),
       lobby= createLobbyJson(branch.lobby.hours),
-      driveUp= createDriveUpJson(branch.driveUp.hours),
-      branch_routing_scheme= branch.branchRoutingScheme,
-      branch_routing_address=branch.branchRoutingAddress
+      drive_up= createDriveUpJson(branch.driveUp.hours),
+      branch_routing = BranchRoutingJSON(
+        branch_routing_scheme = branch.branchRoutingScheme,
+        branch_routing_address = branch.branchRoutingAddress
+      )
+    )
+  }
+  
+  def createAccountJSON(userId: String, account: BankAccount): CreateAccountJSON = {
+    CreateAccountJSON(
+      user_id = userId,
+      label = account.label,
+      `type` = account.accountType,
+      balance = AmountOfMoneyJSON(
+        account.currency,
+        account.balance.toString()
+      ),
+      branch_id = account.branchId,
+      account_routing = AccountRoutingJSON(
+        account_routing_scheme = account.accountRoutingScheme,
+        account_routing_address = account.accountRoutingAddress
+      )
     )
   }
   

--- a/src/main/scala/code/model/ModeratedBankingData.scala
+++ b/src/main/scala/code/model/ModeratedBankingData.scala
@@ -192,7 +192,9 @@ class ModeratedBankAccount(
   val iban : Moderated[String],
   val number: Moderated[String],
   val bankName: Moderated[String],
-  val bankId : BankId
+  val bankId : BankId,
+  val accountRoutingScheme : Moderated[String],
+  val accountRoutingAddress :Moderated[String]
 ){
   @deprecated(Helper.deprecatedJsonGenerationMessage)
   def toJson = {

--- a/src/main/scala/code/model/View.scala
+++ b/src/main/scala/code/model/View.scala
@@ -471,6 +471,8 @@ trait View {
       val number = if(canSeeBankAccountNumber) Some(bankAccount.number) else None
       val bankName = if(canSeeBankAccountBankName) Some(bankAccount.bankName) else None
       val bankId = bankAccount.bankId
+      val accountRoutingScheme = Some(bankAccount.accountRoutingScheme)
+      val accountRoutingAddress = Some(bankAccount.accountRoutingAddress)
 
       Some(
         new ModeratedBankAccount(
@@ -485,7 +487,9 @@ trait View {
           iban = iban,
           number = number,
           bankName = bankName,
-          bankId = bankId
+          bankId = bankId,
+          accountRoutingScheme = accountRoutingScheme,
+          accountRoutingAddress = accountRoutingAddress
         )
       )
     }

--- a/src/test/scala/code/api/LocalMappedConnectorTestSetup.scala
+++ b/src/test/scala/code/api/LocalMappedConnectorTestSetup.scala
@@ -28,7 +28,10 @@ trait LocalMappedConnectorTestSetup extends TestConnectorSetupWithStandardPermis
           .fullBankName(randomString(5))
           .shortBankName(randomString(5))
           .permalink(id)
-          .national_identifier(randomString(5)).saveMe
+          .national_identifier(randomString(5))
+          .mBankRoutingScheme(randomString(5))
+          .mBankRoutingAddress(randomString(5))
+          .saveMe
   }
 
   override protected def createCounterparty(bankId: String, accountId: String, accountRoutingAddress: String, otherAccountRoutingScheme: String, isBeneficiary: Boolean, createdByUserId: String): CounterpartyTrait = {
@@ -73,7 +76,11 @@ trait LocalMappedConnectorTestSetup extends TestConnectorSetupWithStandardPermis
       .accountBalance(900000000)
       .holder(randomString(4))
       .accountNumber(randomString(4))
-      .accountLabel(randomString(4)).saveMe
+      .accountLabel(randomString(4))
+      .mAccountRoutingScheme(randomString(4))  
+      .mAccountRoutingAddress(randomString(4))   
+      .mBranchId(randomString(4))   
+      .saveMe
   }
 
   override protected def updateAccountCurrency(bankId: BankId, accountId : AccountId, currency : String) : BankAccount = {

--- a/src/test/scala/code/api/v2_2_0/API2_2_0Test.scala
+++ b/src/test/scala/code/api/v2_2_0/API2_2_0Test.scala
@@ -137,12 +137,12 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
   }
 
   def getBanksInfo : APIResponse  = {
-    val request = v1_2Request / "banks"
+    val request = v2_2Request / "banks"
     makeGetRequest(request)
   }
 
   def getBankInfo(bankId : String) : APIResponse  = {
-    val request = v1_2Request / "banks" / bankId
+    val request = v2_2Request / "banks" / bankId
     makeGetRequest(request)
   }
 


### PR DESCRIPTION
add the two fields for the following get endpoints:

Get Banks - v121 
Get Bank   - v121
Get Transactions for Account (Core) - v200
Get Transactions for Account (Full)  - v121
Get Bank Branch -v121
Get Bank Branches -v140

And fixed some tests for all mapped.
fixed the payment tests over Kafka,  https://github.com/OpenBankProject/OBP-Kafka-Python/commit/9684ed6b879f34a3fb3d649df3bdd1e5b2fc44dd
fixed the obpjvm connector, all python scripts pass
