### PR TITLE
#471 Improve depth of Swagger definition for certain endp

### DIFF
--- a/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONFactory.scala
+++ b/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONFactory.scala
@@ -92,7 +92,7 @@ object SwaggerJSONFactory {
     name: String = "body",
     description: String = "BANK_BODY",
     required: Boolean = true,
-    `schema`: ResponseObjectSchemaJson = ResponseObjectSchemaJson("#/definitions/BasicViewJSON")
+    schema: ResponseObjectSchemaJson = ResponseObjectSchemaJson("#/definitions/BasicViewJSON")
   )extends OperationParameter
   
   case class ErrorPropertiesMessageJson(
@@ -353,10 +353,16 @@ object SwaggerJSONFactory {
             description = pegDownProcessor.markdownToHtml(rd.description.stripMargin).replaceAll("\n", ""),
             operationId = s"${rd.apiVersion.toString}-${rd.apiFunction.toString}",
             parameters =
-              if ("get".equals(rd.requestVerb.toLowerCase))
-                pathParameters
-              else
-                OperationParameterBodyJson() :: pathParameters,
+              rd.apiFunction match {
+                case "createTransactionRequest" => OperationParameterBodyJson(schema=ResponseObjectSchemaJson("#/definitions/TransactionRequestBodyJSON")) :: pathParameters//15	v210, v200,v140/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/TRANSACTION_REQUEST_TYPE/transaction-requests
+                case "answerTransactionRequestChallenge" => OperationParameterBodyJson(schema=ResponseObjectSchemaJson("#/definitions/ChallengeAnswerJSON")) :: pathParameters//16	v210, v200,v140 /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/TRANSACTION_REQUEST_TYPE/transaction-requests/TRANSACTION_REQUEST_ID/challenge
+                case "updateAccountLabel" => OperationParameterBodyJson(schema=ResponseObjectSchemaJson("#/definitions/UpdateAccountJSON")) :: pathParameters//19	/banks/BANK_ID/accounts/ACCOUNT_ID
+                case "createViewForBankAccount" =>OperationParameterBodyJson(schema=ResponseObjectSchemaJson("#/definitions/CreateViewJSON")) :: pathParameters//21	TODO V220 mixed V121 /banks/BANK_ID/accounts/ACCOUNT_ID/views
+                case "updateViewForBankAccount" => OperationParameterBodyJson(schema=ResponseObjectSchemaJson("#/definitions/UpdateViewJSON")) :: pathParameters//22	TODO V220 mixed V121 /banks/BANK_ID/accounts/ACCOUNT_ID/views/VIEW_ID
+                case "addPermissionForUserForBankAccountForMultipleViews" => OperationParameterBodyJson(schema=ResponseObjectSchemaJson("#/definitions/ViewIdsJson")) :: pathParameters//24	/banks/BANK_ID/accounts/ACCOUNT_ID/permissions/PROVIDER_ID/USER_ID/views
+                case "createCustomer" => OperationParameterBodyJson(schema=ResponseObjectSchemaJson("#/definitions/PostCustomerJson")) :: pathParameters//43	v210 v200 /banks/BANK_ID/customers
+                case _ => pathParameters
+              },
             responses = Map("200" -> ResponseObjectJson(Some("Success"), setReferenceObject(rd)), 
                             "400" -> ResponseObjectJson(Some("Error"), Some(ResponseObjectSchemaJson("#/definitions/Error"))))))
       ).toMap
@@ -458,32 +464,32 @@ object SwaggerJSONFactory {
         case Some(i: Boolean)              => "\""  + key + """": {"type":"boolean", "example":"""" +i+"\"}"
         case List(i: Boolean, _*)          => "\""  + key + """": {"type":"array", "items":{"type": "boolean"}}"""
         case Some(List(i: Boolean, _*))    => "\""  + key + """": {"type":"array", "items":{"type": "boolean"}}"""
-        case i: String                     => "\""  + key + """": {"type":"string","example":" """ +i+"\"}"
-        case Some(i: String)               => "\""  + key + """": {"type":"string","example":" """ +i+"\"}"
+        case i: String                     => "\""  + key + """": {"type":"string","example":"""" +i+"\"}"
+        case Some(i: String)               => "\""  + key + """": {"type":"string","example":"""" +i+"\"}"
         case List(i: String, _*)           => "\""  + key + """": {"type":"array", "items":{"type": "string"}}"""
         case Some(List(i: String, _*))     => "\""  + key + """": {"type":"array", "items":{"type": "string"}}"""
-        case i: Int                        => "\""  + key + """": {"type":"integer", "format":"int32","example":" """ +i+"\"}"
-        case Some(i: Int)                  => "\""  + key + """": {"type":"integer", "format":"int32","example":" """ +i+"\"}"
+        case i: Int                        => "\""  + key + """": {"type":"integer", "format":"int32","example":"""" +i+"\"}"
+        case Some(i: Int)                  => "\""  + key + """": {"type":"integer", "format":"int32","example":"""" +i+"\"}"
         case List(i: Long, _*)             => "\""  + key + """": {"type":"array", "items":{"type":"integer", "format":"int32"}}"""
         case Some(List(i: Long, _*))       => "\""  + key + """": {"type":"array", "items":{"type":"integer", "format":"int32"}}"""
-        case i: Long                       => "\""  + key + """": {"type":"integer", "format":"int64","example":" """ +i+"\"}"
-        case Some(i: Long)                 => "\""  + key + """": {"type":"integer", "format":"int64","example":" """ +i+"\"}"
+        case i: Long                       => "\""  + key + """": {"type":"integer", "format":"int64","example":"""" +i+"\"}"
+        case Some(i: Long)                 => "\""  + key + """": {"type":"integer", "format":"int64","example":"""" +i+"\"}"
         case List(i: Long, _*)             => "\""  + key + """": {"type":"array", "items":{"type":"integer", "format":"int64"}}"""
         case Some(List(i: Long, _*))       => "\""  + key + """": {"type":"array", "items":{"type":"integer", "format":"int64"}}"""
-        case i: Float                      => "\""  + key + """": {"type":"number", "format":"float","example":" """ +i+"\"}"
-        case Some(i: Float)                => "\""  + key + """": {"type":"number", "format":"float","example":" """ +i+"\"}"
+        case i: Float                      => "\""  + key + """": {"type":"number", "format":"float","example":"""" +i+"\"}"
+        case Some(i: Float)                => "\""  + key + """": {"type":"number", "format":"float","example":"""" +i+"\"}"
         case List(i: Float, _*)            => "\""  + key + """": {"type":"array", "items":{"type": "float"}}"""
         case Some(List(i: Float, _*))      => "\""  + key + """": {"type":"array", "items":{"type": "float"}}"""
-        case i: Double                     => "\""  + key + """": {"type":"number", "format":"double","example":" """ +i+"\"}"
-        case Some(i: Double)               => "\""  + key + """": {"type":"number", "format":"double","example":" """ +i+"\"}"
+        case i: Double                     => "\""  + key + """": {"type":"number", "format":"double","example":"""" +i+"\"}"
+        case Some(i: Double)               => "\""  + key + """": {"type":"number", "format":"double","example":"""" +i+"\"}"
         case List(i: Double, _*)           => "\""  + key + """": {"type":"array", "items":{"type": "double"}}"""
         case Some(List(i: Double, _*))     => "\""  + key + """": {"type":"array", "items":{"type": "double"}}"""
-        case i: Date                       => "\""  + key + """": {"type":"string", "format":"date","example":" """ +i+"\"}"
-        case Some(i: Date)                 => "\""  + key + """": {"type":"string", "format":"date","example":" """ +i+"\"}"
+        case i: Date                       => "\""  + key + """": {"type":"string", "format":"date","example":"""" +i+"\"}"
+        case Some(i: Date)                 => "\""  + key + """": {"type":"string", "format":"date","example":"""" +i+"\"}"
         case List(i: Date, _*)             => "\""  + key + """": {"type":"array", "items":{"type":"string", "format":"date"}}"""
         case Some(List(i: Date, _*))       => "\""  + key + """": {"type":"array", "items":{"type":"string", "format":"date"}}"""
         //TODO this should be improved, matching the JValue,now just support the default value
-        case APIUtil.defaultJValue                 => "\""  + key + """": {"type":"string","example":" "}"""
+        case APIUtil.defaultJValue                 => "\""  + key + """": {"type":"string","example":""}"""
         //the case classes.  
         case List(f)                        => "\""  + key + """": {"type": "array", "items":{"$ref": "#/definitions/""" +f.getClass.getSimpleName ++"\"}}"
         case Some(f)                              => "\""  + key + """": {"$ref":"#/definitions/""" +f.getClass.getSimpleName +"\"}"

--- a/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONFactory.scala
+++ b/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONFactory.scala
@@ -1,6 +1,6 @@
 package code.api.ResourceDocs1_4_0
 
-import java.util.Date
+import java.util.{Date, UUID}
 
 import code.api.Constant._
 import code.api.util.APIUtil
@@ -351,7 +351,12 @@ object SwaggerJSONFactory {
             tags = List(s"${rd.apiVersion.toString}"), 
             summary = rd.summary,
             description = pegDownProcessor.markdownToHtml(rd.description.stripMargin).replaceAll("\n", ""),
-            operationId = s"${rd.apiVersion.toString}-${rd.apiFunction.toString}",
+            operationId =
+              rd.apiFunction match {
+                //TODO, the UUID is just a temporory way, need fix 
+                case "createTransactionRequest" => s"${rd.apiVersion.toString }-${rd.apiFunction.toString}-${UUID.randomUUID().toString}"
+                case _ => s"${rd.apiVersion.toString }-${rd.apiFunction.toString }"
+              },
             parameters =
               rd.apiFunction match {
                 case "createTransactionRequest" => OperationParameterBodyJson(schema=ResponseObjectSchemaJson("#/definitions/TransactionRequestBodyJSON")) :: pathParameters//15	v210, v200,v140/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/TRANSACTION_REQUEST_TYPE/transaction-requests

--- a/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONFactory.scala
+++ b/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONFactory.scala
@@ -3,9 +3,9 @@ package code.api.ResourceDocs1_4_0
 import java.util.Date
 
 import code.api.Constant._
+import code.api.util.APIUtil
 import code.api.util.APIUtil.ResourceDoc
-import code.api.v1_2.{BankJSON, BanksJSON, UserJSON}
-import code.model._
+import code.api.v2_2_0.BankJSON
 import net.liftweb
 import net.liftweb.json._
 import net.liftweb.util.Props
@@ -16,56 +16,199 @@ import scala.reflect.runtime.currentMirror
 import scala.reflect.runtime.universe._
 
 object SwaggerJSONFactory {
-
-  case class ContactJson(
-                          name: String,
-                          url: String
-                          )
-
+  //Info Object
+  //link ->https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#infoObject
   case class InfoJson(
-                       title: String,
-                       description: String,
-                       contact: ContactJson,
-                       version: String
-                       )
-
-  case class ResponseObjectSchemaJson(`$ref`: String)
-  case class ResponseObjectJson(description: Option[String], schema: Option[ResponseObjectSchemaJson])
-
-  case class MethodJson(tags: List[String],
-                        summary: String,
-                        description: String,
-                        operationId: String,
-                        responses: Map[String, ResponseObjectJson])
-
-  case class PathsJson(get: MethodJson)
-
-  case class MessageJson(`type`: String)
-
-  case class CodeJson(`type`: String, format: String)
-
-  case class PropertiesJson(code: CodeJson, message: MessageJson)
-
-  case class ErrorDefinitionJson(`type`: String, required: List[String], properties: PropertiesJson)
-
+    title: String,
+    description: String,
+    contact: InfoContactJson,
+    version: String
+  )
+  //Contact Object
+  //https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#contactObject
+  case class InfoContactJson(
+    name: String,
+    url: String,
+    email: String
+  )
+  
+  // Security Definitions Object
+  // link->https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityDefinitionsObject
+  case class SecurityDefinitionsJson(
+    directLogin: DirectLoginJson
+  )
+  case class DirectLoginJson(
+    `type`: String = "apiKey",
+    description: String = "https://github.com/OpenBankProject/OBP-API/wiki/Direct-Login",
+    in: String = "header",
+    name: String = "Authorization"
+  )
+  
+  //Security Requirement Object
+  //link -> https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityRequirementObject
+  case class SecurityJson(
+    directLogin: List[String] = Nil
+  )
+  
+  case class ResponseObjectSchemaJson(
+    `$ref`: String
+  )
+  //Response Object 
+  // links -> https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responsesObject
+  case class ResponseObjectJson(
+    description: Option[String],
+    schema: Option[ResponseObjectSchemaJson]
+  )
+  // Operation Object 
+  // links -> https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operation-object
+  case class OperationObjectJson(
+    tags: List[String],
+    summary: String,
+    security: List[SecurityJson] = SecurityJson()::Nil,
+    description: String,
+    operationId: String,
+    parameters: List[OperationParameterJson],
+    responses: Map[String, ResponseObjectJson]
+  )
+  //Parameter Object
+  //link -> https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
+  case class OperationParameterJson(
+    in: String = "path",
+    name: String = "BANK_ID",
+    description: String = "BANK_ID",
+    required: Boolean = true,
+    `type`: String ="string"
+  )
+  
+  case class ErrorPropertiesMessageJson(
+    `type`: String
+  )
+  case class ErrorPropertiesCodeJson(
+    `type`: String,
+    format: String
+  )
+  case class ErrorPropertiesJson(
+    code: ErrorPropertiesCodeJson,
+    message: ErrorPropertiesMessageJson
+  )
+  case class ErrorDefinitionJson(
+    `type`: String,
+    required: List[String],
+    properties: ErrorPropertiesJson
+  )
+  
+  //in Swagger Definitions part, there are many sub-definitions, here just set the Error field.
+  //other fields are set in "def loadDefinitions(resourceDocList: List[ResourceDoc])" method
+  // Definitions Object
+  // link ->https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#definitionsObject
   case class DefinitionsJson(Error: ErrorDefinitionJson)
-
-  case class SwaggerResourceDoc(swagger: String,
-                                info: InfoJson,
-                                host: String,
-                                basePath: String,
-                                schemes: List[String],
-                                paths: Map[String, Map[String, MethodJson]],
-                                definitions: DefinitionsJson
-                                 )
-
+  
+  case class SwaggerResourceDoc(
+    swagger: String,
+    info: InfoJson,
+    host: String,
+    basePath: String,
+    schemes: List[String],
+    securityDefinitions: SecurityDefinitionsJson,
+    security: List[SecurityJson],
+    paths: Map[String, Map[String, OperationObjectJson]],
+    definitions: DefinitionsJson
+  )
+  
+  /**
+    *Package the SwaggerResourceDoc with the ResourceDoc.
+    * Note: the definitions of SwaggerResourceDoc only contains Error part,
+    *       other specific OBP JSON part is filled by def "loadDefinitions(resourceDocList: List[ResourceDoc])"
+    * case class ResourceDoc(
+    *   partialFunction : PartialFunction[Req, Box[User] => Box[JsonResponse]],
+    *   apiVersion: String, 
+    *   apiFunction: String, 
+    *   requestVerb: String, 
+    *   requestUrl: String, 
+    *   summary: String, 
+    *   description: String, 
+    *   exampleRequestBody: JValue, 
+    *   successResponseBody: JValue, 
+    *   errorResponseBodies: List[JValue], 
+    *   catalogs: Catalogs,
+    *   tags: List[ResourceDocTag]
+    * )
+    * 
+    * -->
+    * case class SwaggerResourceDoc(
+    *   swagger: String,
+    *   info: InfoJson,
+    *   host: String,
+    *   basePath: String,
+    *   schemes: List[String],
+    *   securityDefinitions: SecurityDefinitionsJson,
+    *   security: List[SecurityJson],
+    *   paths: Map[String, Map[String, OperationObjectJson]],
+    *   definitions: DefinitionsJson
+    * )
+    *
+    * @param resourceDocList     list of ResourceDoc
+    * @param requestedApiVersion eg: 2_2_0
+    * @return
+    */
   def createSwaggerResourceDoc(resourceDocList: List[ResourceDoc], requestedApiVersion: String): SwaggerResourceDoc = {
-
-    def getName(rd: ResourceDoc) = {
+    
+    //reference to referenceObject: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#referenceObject  
+    //according to the apiFunction name, prepare the reference 
+    // eg: set the following "$ref" field: 
+    //    "path": "/banks/BANK_ID": {
+    //      "get": {
+    //      "responses": {
+    //      "200": {
+    //      "schema": {
+    //         "$ref": "#/definitions/BankJSON"
+    def setReferenceObject(rd: ResourceDoc) = {
       rd.apiFunction match {
-        case "allBanks" => Some(ResponseObjectSchemaJson("#/definitions/BanksJSON"))
-        case "bankById" => Some(ResponseObjectSchemaJson("#/definitions/BankJSON"))
-        case "getTransactionRequestTypes" => Some(ResponseObjectSchemaJson("#/definitions/TransactionReponseTypes"))
+        case "allAccountsAllBanks" => Some(ResponseObjectSchemaJson("#/definitions/code.api.v2_0_0.BasicAccountJSON")) //1	/accounts
+//        case "corePrivateAccountsAllBanks" => Some(ResponseObjectSchemaJson("#/definitions/CoreAccountJSON")) //2	TODO List[CoreAccountJSON] /my/accounts
+//        case "allAccountsAtOneBank" => Some(ResponseObjectSchemaJson("#/definitions/AccountsJSON")) //3	V121 TODO List[BasicAccountJSON] /banks/BANK_ID/accounts
+////        case "allAccountsAtOneBank" => Some(ResponseObjectSchemaJson("#/definitions/BasicAccountJSON")) //3	V200 TODO List[BasicAccountJSON] /banks/BANK_ID/accounts
+//        case "privateAccountsAtOneBank" => Some(ResponseObjectSchemaJson("#/definitions/AccountsJSON")) //4	V121 /banks/BANK_ID/accounts/private 
+////        case "privateAccountsAtOneBank" => Some(ResponseObjectSchemaJson("#/definitions/BasicAccountsJSON")) //4	V200(used),V121 /banks/BANK_ID/accounts/private 
+//        case "getCoreAccountById" => Some(ResponseObjectSchemaJson("#/definitions/ModeratedCoreAccountJSON")) //5	/my/banks/BANK_ID/accounts/ACCOUNT_ID/account
+//        case "accountById" => Some(ResponseObjectSchemaJson("#/definitions/ModeratedAccountJSON")) //6 v200 ,v121 /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/account
+//        case "getCurrentUser" => Some(ResponseObjectSchemaJson("#/definitions/UserJSON")) //7	/users/current
+//        case "getBanks" => Some(ResponseObjectSchemaJson("#/definitions/BanksJSON"))//8	/banks
+//        case "bankById" => Some(ResponseObjectSchemaJson("#/definitions/BankJSON")) //9	/banks/BANK_ID
+//        case "getCustomer" => Some(ResponseObjectSchemaJson("#/definitions/CustomerJson")) //10	V210 V140 /banks/BANK_ID/customer 
+////        case "getTransactionsForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/TransactionsJSON")) //11	/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions
+//        case "getTransactionByIdForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/TransactionJSON")) //12	/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions/TRANSACTION_ID/transaction
+//        case "getCoreTransactionsForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/CoreTransactionsJSON"))//13	/my/banks/BANK_ID/accounts/ACCOUNT_ID/transactions
+//        case "getTransactionRequestTypes" => Some(ResponseObjectSchemaJson("#/definitions/TransactionRequestWithChargeJSON210"))//14	v210, v200,v140 /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types
+//        case "createTransactionRequest" => Some(ResponseObjectSchemaJson("#/definitions/TransactionRequestTypeJSONs"))//15	v210, v200,v140/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/TRANSACTION_REQUEST_TYPE/transaction-requests
+//        case "answerTransactionRequestChallenge" => Some(ResponseObjectSchemaJson("#/definitions/TransactionRequestTypeJSONs"))//16	v210, v200,v140 /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/TRANSACTION_REQUEST_TYPE/transaction-requests/TRANSACTION_REQUEST_ID/challenge
+//        case "getTransactionRequests" => Some(ResponseObjectSchemaJson("#/definitions/TransactionRequestWithChargeJSONs210"))//17	/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-requests
+//        case "getCounterpartiesForAccount" => Some(ResponseObjectSchemaJson("#/definitions/CounterpartiesJSON"))//v220 ,v210 ,v200 18	/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/counterparties
+//        case "updateAccountLabel" => Some(ResponseObjectSchemaJson("#/definitions/SuccessMessage"))//19	/banks/BANK_ID/accounts/ACCOUNT_ID
+//        case "getViewsForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/ViewsJSON"))//20	TODO V220 mixed V121 /banks/BANK_ID/accounts/ACCOUNT_ID/views
+//        case "getViewsForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/ViewsJSON"))//21	TODO V220 mixed V121 /banks/BANK_ID/accounts/ACCOUNT_ID/views
+//        case "updateViewForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/ViewJSON"))//22	TODO V220 mixed V121 /banks/BANK_ID/accounts/ACCOUNT_ID/views/VIEW_ID
+//        case "updateViewForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/ViewJSON"))//23	TODO V220 mixed V121 /banks/BANK_ID/accounts/ACCOUNT_ID/views/VIEW_ID
+//        case "addPermissionForUserForBankAccountForMultipleViews" => Some(ResponseObjectSchemaJson("#/definitions/ViewsJSON"))//24	/banks/BANK_ID/accounts/ACCOUNT_ID/permissions/PROVIDER_ID/USER_ID/views
+//        case "addPermissionForUserForBankAccountForOneView" => Some(ResponseObjectSchemaJson("#/definitions/ViewJSON"))//25	/banks/BANK_ID/accounts/ACCOUNT_ID/permissions/PROVIDER_ID/USER_ID/views/VIEW_ID
+//        case "removePermissionForUserForBankAccountForOneView" => Some(ResponseObjectSchemaJson(""))//26	TODO Wrong output for delete /banks/BANK_ID/accounts/ACCOUNT_ID/permissions/PROVIDER_ID/USER_ID/views/VIEW_ID
+//        case "removePermissionForUserForBankAccountForAllViews" => Some(ResponseObjectSchemaJson(""))//27	TODO Wrong output for delete /banks/BANK_ID/accounts/ACCOUNT_ID/permissions/PROVIDER_ID/USER_ID/views
+//        case "getCounterpartiesForAccount" => Some(ResponseObjectSchemaJson("#/definitions/CounterpartiesJSON"))//28	V220, V210 /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/counterparties
+//        case "getOtherAccountsForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/OtherAccountsJSON"))//29	/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/other_accounts
+//        case "getOtherAccountByIdForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/OtherAccountJSON"))//30	/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/other_accounts/OTHER_ACCOUNT_ID
+//        case "getTransactionNarrative" => Some(ResponseObjectSchemaJson("#/definitions/TransactionNarrativeJSON"))//31 /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions/TRANSACTION_ID/metadata/narrative
+//        case "getCommentsForViewOnTransaction" => Some(ResponseObjectSchemaJson("#/definitions/TransactionCommentsJSON"))//32 /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions/TRANSACTION_ID/metadata/comments
+//        case "deleteCommentForViewOnTransaction" => Some(ResponseObjectSchemaJson(""))//33 TODO Wrong output for delete /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions/TRANSACTION_ID/metadata/comments/COMMENT_ID
+//        case "getTagsForViewOnTransaction" => Some(ResponseObjectSchemaJson("#/definitions/TransactionTagsJSON"))//34	/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions/TRANSACTION_ID/metadata/tags
+//        case "deleteTagForViewOnTransaction" => Some(ResponseObjectSchemaJson(""))//35 TODO Wrong output for delete /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions/TRANSACTION_ID/metadata/tags/TAG_ID
+//        case "getImagesForViewOnTransaction" => Some(ResponseObjectSchemaJson("#/definitions/TransactionImagesJSON"))//36 /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions/TRANSACTION_ID/metadata/images
+//        case "deleteImageForViewOnTransaction" => Some(ResponseObjectSchemaJson(""))//37 TODO Wrong output for delete /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions/TRANSACTION_ID/metadata/images/IMAGE_ID
+//        case "getWhereTagForViewOnTransaction" => Some(ResponseObjectSchemaJson("#/definitions/TransactionWhereJSON"))//38 /banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions/TRANSACTION_ID/metadata/where
+//        case "getOtherAccountForTransaction" => Some(ResponseObjectSchemaJson("#/definitions/OtherAccountJSON"))//39	/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transactions/TRANSACTION_ID/other_account
+//        case "getCurrentFxRate" => Some(ResponseObjectSchemaJson("#/definitions/FXRateJSON"))//40	/fx/FROM_CURRENCY_CODE/TO_CURRENCY_CODE
+//        case "getPermissionsForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/PermissionsJSON"))//41	V200 v121/banks/BANK_ID/accounts/ACCOUNT_ID/permissions
+//        case "getPermissionForUserForBankAccount" => Some(ResponseObjectSchemaJson("#/definitions/ViewsJSON"))//42	/banks/BANK_ID/accounts/ACCOUNT_ID/permissions/PROVIDER_ID/USER_ID
+//        case "createCustomer" => Some(ResponseObjectSchemaJson("#/definitions/CustomerJson"))//43	v210 v200 /banks/BANK_ID/customers
         case _ => None
       }
     }
@@ -74,95 +217,143 @@ object SwaggerJSONFactory {
 
     val pegDownProcessor : PegDownProcessor = new PegDownProcessor
 
-    val contact = ContactJson("TESOBE Ltd. / Open Bank Project", "https://openbankproject.com")
-    val apiVersion = requestedApiVersion
-    val title = "Open Bank Project API"
-    val description = "An Open Source API for Banks. (c) TESOBE Ltd. 2011 - 2016. Licensed under the AGPL and commercial licences."
-    val info = InfoJson(title, description, contact, apiVersion)
+    val infoTitle = "Open Bank Project API"
+    val infoDescription = "An Open Source API for Banks. (c) TESOBE Ltd. 2011 - 2016. Licensed under the AGPL and commercial licences."
+    val infoContact = InfoContactJson("TESOBE Ltd. / Open Bank Project", "https://openbankproject.com" ,"contact@tesobe.com")
+    val infoApiVersion = requestedApiVersion
+    val info = InfoJson(infoTitle, infoDescription, infoContact, infoApiVersion)
     val host = Props.get("hostname", "unknown host").replaceFirst("http://", "").replaceFirst("https://", "")
-    val basePath = s"/$ApiPathZero/" + apiVersion
+    val basePath = s"/$ApiPathZero/" + infoApiVersion
     val schemas = List("http", "https")
-    val paths: ListMap[String, Map[String, MethodJson]] = resourceDocList.groupBy(x => x.requestUrl).toSeq.sortBy(x => x._1).map { mrd =>
-      val methods: Map[String, MethodJson] = mrd._2.map(rd =>
+    // Paths Object
+    // link ->https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#paths-object
+    // setting up the following fileds of swagger json,eg apiFunction = bankById
+    //  "paths": {
+    //    "/banks/BANK_ID": --> mrd._1
+    //      "get": {        --> all following from mrd._2
+    //      "tags": [ "1_2_1"],
+    //      "summary": "Get Bank",
+    //      "description": "<p>Get the bank specified by BANK_ID....
+    //      "operationId": "1_2_1-bankById",
+    //      "responses": {
+    //        "200": {
+    //          "description": "Success",
+    //          "schema": { "$ref": "#/definitions/BankJSON" }
+    //        },
+    //        "400": {
+    //          "description": "Error",
+    //          "schema": {"$ref": "#/definitions/Error"
+    val paths: ListMap[String, Map[String, OperationObjectJson]] = resourceDocList.groupBy(x => x.requestUrl).toSeq.sortBy(x => x._1).map { mrd =>
+      
+      //TODO here can extract to  a method
+      val path = mrd._1
+                 .replaceAll("/BANK_ID","/{BANK_ID}")
+                 .replaceAll("/ACCOUNT_ID","/{ACCOUNT_ID}")
+                 .replaceAll("/VIEW_ID","/{VIEW_ID}")
+                 .replaceAll("/USER_ID","/{USER_ID}")
+                 .replaceAll("/TRANSACTION_ID","/{TRANSACTION_ID}")
+                 .replaceAll("/TRANSACTION_REQUEST_TYPE","/{TRANSACTION_REQUEST_TYPE}")
+                 .replaceAll("/TRANSACTION_REQUEST_ID","/{TRANSACTION_REQUEST_ID}")
+                 .replaceAll("/PROVIDER_ID","/{PROVIDER_ID}")
+                 .replaceAll("/OTHER_ACCOUNT_ID","/{OTHER_ACCOUNT_ID}")
+                 .replaceAll("/FROM_CURRENCY_CODE","/{FROM_CURRENCY_CODE}")
+                 .replaceAll("/TO_CURRENCY_CODE","/{TO_CURRENCY_CODE}")
+                 .replaceAll("/COMMENT_ID","/{COMMENT_ID}")
+                 .replaceAll("/TAG_ID","/{TAG_ID}")
+                 .replaceAll("/IMAGE_ID","/{IMAGE_ID}")
+                 .replaceAll("/CUSTOMER_ID","/{CUSTOMER_ID}")
+      
+      var pathParameters = List.empty[OperationParameterJson]
+      if(path.contains("/{BANK_ID}"))
+        pathParameters = OperationParameterJson(name="BANK_ID",description="The bank id") :: pathParameters
+      if(path.contains("/{ACCOUNT_ID}"))
+        pathParameters = OperationParameterJson(name="ACCOUNT_ID",description="The account id")::pathParameters
+      if(path.contains("/{VIEW_ID}"))
+        pathParameters = OperationParameterJson(name="VIEW_ID",description="The view id")::pathParameters
+      if(path.contains("/{USER_ID}"))
+        pathParameters = OperationParameterJson(name="USER_ID",description="The user id")::pathParameters
+      if(path.contains("/{TRANSACTION_ID}"))
+        pathParameters = OperationParameterJson(name="TRANSACTION_ID",description="The transaction id")::pathParameters
+      if(path.contains("/{TRANSACTION_REQUEST_TYPE}"))
+        pathParameters = OperationParameterJson(name="TRANSACTION_REQUEST_TYPE",description="The transaction request type")::pathParameters
+      if(path.contains("/{TRANSACTION_REQUEST_ID}"))
+        pathParameters = OperationParameterJson(name="TRANSACTION_REQUEST_ID",description="The transaction request id")::pathParameters
+      if(path.contains("/{PROVIDER_ID}"))
+        pathParameters = OperationParameterJson(name="PROVIDER_ID",description="The provider id")::pathParameters
+      if(path.contains("/{OTHER_ACCOUNT_ID}"))
+        pathParameters = OperationParameterJson(name="OTHER_ACCOUNT_ID",description="The other account id")::pathParameters
+      if(path.contains("/{FROM_CURRENCY_CODE}"))
+        pathParameters = OperationParameterJson(name="FROM_CURRENCY_CODE",description="The from currency code")::pathParameters
+      if(path.contains("/{TO_CURRENCY_CODE}"))
+        pathParameters = OperationParameterJson(name="TO_CURRENCY_CODE",description="The to currency code")::pathParameters
+      if(path.contains("/{COMMENT_ID}"))
+        pathParameters = OperationParameterJson(name="COMMENT_ID",description="The comment id")::pathParameters
+      if(path.contains("/{TAG_ID}"))
+        pathParameters = OperationParameterJson(name="TAG_ID",description="The tag id")::pathParameters
+      if(path.contains("/{IMAGE_ID}"))
+        pathParameters = OperationParameterJson(name="IMAGE_ID",description="The image id")::pathParameters
+      if(path.contains("/{CUSTOMER_ID}"))
+        pathParameters = OperationParameterJson(name="CUSTOMER_ID",description="The customer id")::pathParameters
+  
+      val operationObjects: Map[String, OperationObjectJson] = mrd._2.map(rd =>
         (rd.requestVerb.toLowerCase,
-          MethodJson(
-            List(s"${rd.apiVersion.toString}"),
-            rd.summary,
+          OperationObjectJson(
+            tags = List(s"${rd.apiVersion.toString}"), 
+            summary = rd.summary,
             description = pegDownProcessor.markdownToHtml(rd.description.stripMargin).replaceAll("\n", ""),
-            s"${rd.apiVersion.toString}-${rd.apiFunction.toString}",
-            Map("200" -> ResponseObjectJson(Some("Success"), getName(rd)), "400" -> ResponseObjectJson(Some("Error"), Some(ResponseObjectSchemaJson("#/definitions/Error"))))))
+            operationId = s"${rd.apiVersion.toString}-${rd.apiFunction.toString}",
+            parameters = pathParameters,
+            responses = Map("200" -> ResponseObjectJson(Some("Success"), setReferenceObject(rd)), 
+                            "400" -> ResponseObjectJson(Some("Error"), Some(ResponseObjectSchemaJson("#/definitions/Error"))))))
       ).toMap
-      (mrd._1, methods.toSeq.sortBy(m => m._1).toMap)
+      (path, operationObjects.toSeq.sortBy(m => m._1).toMap)
     }(collection.breakOut)
 
-    val `type` = "object"
-    val required = List("code", "message")
-    val code = CodeJson("integer", "int32")
-    val message = MessageJson("string")
-    val properties = PropertiesJson(code, message)
-    val errorDef = ErrorDefinitionJson(`type`, required, properties)
-    val defs = DefinitionsJson(errorDef)
+    val errorRequired = List("code", "message")
+    val errorPropertiesCode = ErrorPropertiesCodeJson("integer", "int32")
+    val errorPropertiesMessage = ErrorPropertiesMessageJson("string")
+    val errorProperties = ErrorPropertiesJson(errorPropertiesCode, errorPropertiesMessage)
+    val errorDefinition = ErrorDefinitionJson("object", errorRequired, errorProperties)
+    val definitions = DefinitionsJson(errorDefinition)
 
-    SwaggerResourceDoc("2.0", info, host, basePath, schemas, paths, defs)
+    SwaggerResourceDoc(
+      swagger = "2.0",
+      info = info,
+      host = host,
+      basePath = basePath,
+      schemes = schemas,
+      securityDefinitions = SecurityDefinitionsJson(DirectLoginJson()), //default value
+      security = SecurityJson()::Nil, //default value
+      paths = paths,
+      definitions = definitions
+    )
   }
 
-
-  def translateEntity(entity: Any): String = {
-
-    //Get fields of runtime entities and put they into structure Map(nameOfField -> fieldAsObject)
-    val r = currentMirror.reflect(entity)
-    val mapOfFields = r.symbol.typeSignature.members.toStream
-      .collect { case s: TermSymbol if !s.isMethod => r.reflectField(s)}
-      .map(r => r.symbol.name.toString.trim -> r.get)
-      .toMap
-
-    //Iterate over Map and use pattern matching to extract type of field of runtime entity and make an appropriate swagger string for it
-    val properties = for ((key, value) <- mapOfFields) yield {
-      value match {
-        case i: Boolean                    => s""" """" + key + """": {"type":"boolean"}"""
-        case Some(i: Boolean)              => s""" """" + key + """": {"type":"boolean"}"""
-        case List(i: Boolean, _*)          => s""" """" + key + """": {"type":"array", "items":{"type": "boolean"}}"""
-        case Some(List(i: Boolean, _*))    => s""" """" + key + """": {"type":"array", "items":{"type": "boolean"}}"""
-        case i: String                     => s""" """" + key + """": {"type":"string"}"""
-        case Some(i: String)               => s""" """" + key + """": {"type":"string"}"""
-        case List(i: String, _*)           => s""" """" + key + """": {"type":"array", "items":{"type": "string"}}"""
-        case Some(List(i: String, _*))     => s""" """" + key + """": {"type":"array", "items":{"type": "string"}}"""
-        case i: Int                        => s""" """" + key + """": {"type":"integer", "format":"int32"}"""
-        case Some(i: Int)                  => s""" """" + key + """": {"type":"integer", "format":"int32"}"""
-        case List(i: Long, _*)             => s""" """" + key + """": {"type":"array", "items":{"type":"integer", "format":"int32"}}"""
-        case Some(List(i: Long, _*))       => s""" """" + key + """": {"type":"array", "items":{"type":"integer", "format":"int32"}}"""
-        case i: Long                       => s""" """" + key + """": {"type":"integer", "format":"int64"}"""
-        case Some(i: Long)                 => s""" """" + key + """": {"type":"integer", "format":"int64"}"""
-        case List(i: Long, _*)             => s""" """" + key + """": {"type":"array", "items":{"type":"integer", "format":"int64"}}"""
-        case Some(List(i: Long, _*))       => s""" """" + key + """": {"type":"array", "items":{"type":"integer", "format":"int64"}}"""
-        case i: Float                      => s""" """" + key + """": {"type":"number", "format":"float"}"""
-        case Some(i: Float)                => s""" """" + key + """": {"type":"number", "format":"float"}"""
-        case List(i: Float, _*)            => s""" """" + key + """": {"type":"array", "items":{"type": "float"}}"""
-        case Some(List(i: Float, _*))      => s""" """" + key + """": {"type":"array", "items":{"type": "float"}}"""
-        case i: Double                     => s""" """" + key + """": {"type":"number", "format":"double"}"""
-        case Some(i: Double)               => s""" """" + key + """": {"type":"number", "format":"double"}"""
-        case List(i: Double, _*)           => s""" """" + key + """": {"type":"array", "items":{"type": "double"}}"""
-        case Some(List(i: Double, _*))     => s""" """" + key + """": {"type":"array", "items":{"type": "double"}}"""
-        case i: Date                       => s""" """" + key + """": {"type":"string", "format":"date"}"""
-        case Some(i: Date)                 => s""" """" + key + """": {"type":"string", "format":"date"}"""
-        case List(i: Date, _*)             => s""" """" + key + """": {"type":"array", "items":{"type":"string", "format":"date"}}"""
-        case Some(List(i: Date, _*))       => s""" """" + key + """": {"type":"array", "items":{"type":"string", "format":"date"}}"""
-        case obj@BankJSON(_,_,_,_,_)       => s""" """" + key + """": {"$ref": "#/definitions/BankJSON"""" +"}"
-        case obj@List(BankJSON(_,_,_,_,_)) => s""" """" + key + """": {"type": "array", "items":{"$ref": "#/definitions/BankJSON"""" +"}}"
-        case obj@BanksJSON(_)              => s""" """" + key + """": {"$ref":"#/definitions/BanksJSON"""" +"}"
-        case obj@List(BanksJSON(_))        => s""" """" + key + """": {"type": "array", "items":{"$ref": "#/definitions/BanksJSON"""" +"}}"
-        case obj@UserJSON(_,_,_)           => s""" """" + key + """": {"$ref": "#/definitions/UserJSON"""" +"}"
-        case obj@List(UserJSON(_,_,_))     => s""" """" + key + """": {"type":"array", "items":{"$ref": "#/definitions/UserJSON"""" +"}}"
-
-          //now the TransactionRequestTypeJsons changed, it feed to update, so comment
-          //case obj@TransactionRequestTypeJson(_)       => s""" """" + key + """":{"$ref": "#/definitions/TransactionReponseTypes"""" +"}"
-          //case obj@List(TransactionRequestTypeJsons(_)) => s""" """" + key + """": {"type":"array", "items":{"$ref": "#/definitions/Transac*/tionReponseTypes"""" +"}}"
-        case _ => "unknown"
-      }
-    }
-    //Exclude all unrecognised fields and make part of fields definition
-    val fields: String = properties filter (_.contains("unknown") == false) mkString (",")
+  
+  /**
+    * @param entity - Any, maybe a case class, maybe a list ,maybe a string
+    *               ExampleJSON (
+    *               id = 5,
+    *               name = "Tesobe",
+    *               bank = Bank("gh.29.uk")
+    *               banks = List(Bank("gh.29.uk"))
+    *               )
+    * @return - String, with Swagger format  
+    *         "ExampleJSON":
+    *         { 
+    *           "required": ["id","name","bank","banks"],    
+    *           "properties":
+    *           { 
+    *             "id": {"type":"integer", "format":"int32"}, 
+    *             "Tesobe": {"type":"string"},
+    *             "bank": {"$ref": "#/definitions/BankJSON"},
+    *             "banks": {"type": "array", "items":{"$ref": "#/definitions/BanksJSON"}}
+    *         }
+    */
+  def translateEntity(className:String, entity: Any): String = {
+  
     //Collect all mandatory fields and make an appropriate string
+    // eg return :  "required": ["id","name","bank","banks"],  
     val required =
       for {
         f <- entity.getClass.getDeclaredFields
@@ -174,42 +365,121 @@ object SwaggerJSONFactory {
     //Make part of mandatory fields
     val requiredFieldsPart = if (required.length > 0) """"required": """ + requiredFields + "," else ""
     //Make whole swagger definition of an entity
-    val definition = "\"" + entity.getClass.getSimpleName + "\":{" + requiredFieldsPart + """"properties": {""" + fields + """}}"""
+    
+    //Get fields of runtime entities and put they into structure Map(nameOfField -> fieldAsObject)
+    //eg: 
+    //  ExampleJSON (                   
+    //   id = 5,                         
+    //   name = "Tesobe",                
+    //   bank = Bank("gh.29.uk")        
+    //   banks = List(Bank("gh.29.uk")) 
+    //  )                               
+    // -->
+    //   mapOfFields = Map(
+    //     id -> 5,
+    //     name -> Tesobe,
+    //     bank -> Bank(gh.29.uk),
+    //     banks -> List(Bank(gh.29.uk))
+    //   )
+    val r = currentMirror.reflect(entity)
+    val mapOfFields = r.symbol.typeSignature.members.toStream
+      .collect { case s: TermSymbol if !s.isMethod => r.reflectField(s)}
+      .map(r => r.symbol.name.toString.trim -> r.get)
+      .toMap
 
+    //Iterate over Map and use pattern matching to extract type of field of runtime entity and make an appropriate swagger Data Types for it
+    //reference to https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+    // two pattern matching here: 
+    //     Swagger Data Types, eg: (name -> Tesobe) Boolean --> "name": {"type":"string"}
+    //     Specific OBP JSON Classes,(bank -> Bank(gh.29.uk)) --> "bank": {"$ref":"#/definitions/Bank"}
+    // from up mapOfFields[String, Any]  --> List[String]
+    //      id -> 5                      --> "id" : {"type":"integer", "format":"int32"}             
+    //      name -> Tesobe,              --> "name" : {"type":"string"}              
+    //      bank -> Bank(gh.29.uk),      --> "bank": {"$ref":"#/definitions/Bank"}    
+    //      banks -> List(Bank(gh.29.uk) --> "banks": {"type": "array", "items":{"$ref": "#/definitions/Bank"}}  
+    val properties = for ((key, value) <- mapOfFields) yield {
+      value match {
+        case i: Boolean                    => "\""  + key + """": {"type":"boolean", "example":"""" +i+"\"}"
+        case Some(i: Boolean)              => "\""  + key + """": {"type":"boolean", "example":"""" +i+"\"}"
+        case List(i: Boolean, _*)          => "\""  + key + """": {"type":"array", "items":{"type": "boolean"}}"""
+        case Some(List(i: Boolean, _*))    => "\""  + key + """": {"type":"array", "items":{"type": "boolean"}}"""
+        case i: String                     => "\""  + key + """": {"type":"string","example":" """ +i+"\"}"
+        case Some(i: String)               => "\""  + key + """": {"type":"string","example":" """ +i+"\"}"
+        case List(i: String, _*)           => "\""  + key + """": {"type":"array", "items":{"type": "string"}}"""
+        case Some(List(i: String, _*))     => "\""  + key + """": {"type":"array", "items":{"type": "string"}}"""
+        case i: Int                        => "\""  + key + """": {"type":"integer", "format":"int32","example":" """ +i+"\"}"
+        case Some(i: Int)                  => "\""  + key + """": {"type":"integer", "format":"int32","example":" """ +i+"\"}"
+        case List(i: Long, _*)             => "\""  + key + """": {"type":"array", "items":{"type":"integer", "format":"int32"}}"""
+        case Some(List(i: Long, _*))       => "\""  + key + """": {"type":"array", "items":{"type":"integer", "format":"int32"}}"""
+        case i: Long                       => "\""  + key + """": {"type":"integer", "format":"int64","example":" """ +i+"\"}"
+        case Some(i: Long)                 => "\""  + key + """": {"type":"integer", "format":"int64","example":" """ +i+"\"}"
+        case List(i: Long, _*)             => "\""  + key + """": {"type":"array", "items":{"type":"integer", "format":"int64"}}"""
+        case Some(List(i: Long, _*))       => "\""  + key + """": {"type":"array", "items":{"type":"integer", "format":"int64"}}"""
+        case i: Float                      => "\""  + key + """": {"type":"number", "format":"float","example":" """ +i+"\"}"
+        case Some(i: Float)                => "\""  + key + """": {"type":"number", "format":"float","example":" """ +i+"\"}"
+        case List(i: Float, _*)            => "\""  + key + """": {"type":"array", "items":{"type": "float"}}"""
+        case Some(List(i: Float, _*))      => "\""  + key + """": {"type":"array", "items":{"type": "float"}}"""
+        case i: Double                     => "\""  + key + """": {"type":"number", "format":"double","example":" """ +i+"\"}"
+        case Some(i: Double)               => "\""  + key + """": {"type":"number", "format":"double","example":" """ +i+"\"}"
+        case List(i: Double, _*)           => "\""  + key + """": {"type":"array", "items":{"type": "double"}}"""
+        case Some(List(i: Double, _*))     => "\""  + key + """": {"type":"array", "items":{"type": "double"}}"""
+        case i: Date                       => "\""  + key + """": {"type":"string", "format":"date","example":" """ +i+"\"}"
+        case Some(i: Date)                 => "\""  + key + """": {"type":"string", "format":"date","example":" """ +i+"\"}"
+        case List(i: Date, _*)             => "\""  + key + """": {"type":"array", "items":{"type":"string", "format":"date"}}"""
+        case Some(List(i: Date, _*))       => "\""  + key + """": {"type":"array", "items":{"type":"string", "format":"date"}}"""
+        case code.api.v1_2_1.BankJSON(_,_,_,_,_,_)       => "\""  + key + """": {"$ref": "#/definitions/code.api.v1_2_1.BankJSON"}"""
+        case List(code.api.v1_2_1.BankJSON(_,_,_,_,_,_),_*) => "\""  + key + """": {"type": "array", "items":{"$ref": "#/definitions/BankJSON"}}"""
+        case code.api.v1_2_1.BanksJSON(_)   => "\""  + key + """": {"$ref":"#/definitions/code.api.v1_2_1.BanksJSON"}"""
+        case List(code.api.v1_2_1.BanksJSON(_),_*)  => "\""  + key + """": {"type": "array", "items":{"$ref": "#/definitions/BanksJSON"}}""" 
+        case List(code.api.v2_0_0.BasicViewJSON(_,_,_),_*)  => "\""  + key + """": {"type": "array", "items":{"$ref": "#/definitions/BasicViewJSON"}}""" 
+        case _ => "unknown"
+      }
+    }
+    //Exclude all unrecognised fields and make part of fields definition
+    // add comment and filter unknow
+    // fields --> "id" : {"type":"integer", "format":"int32"} ,"name" : {"type":"string"} ,"bank": {"$ref":"#/definitions/Bank"} ,"banks": {"type": "array", "items":{"$ref": "#/definitions/Bank"}}  
+    val fields: String = properties filter (_.contains("unknown") == false) mkString (",")
+    //val definition = "\"" + entity.getClass.getSimpleName + "\":{" + requiredFieldsPart + """"properties": {""" + fields + """}}"""
+    val definition = "\"" + className + "\":{" +requiredFieldsPart+ """"properties": {""" + fields + """}}"""
     definition
-
   }
-
+       
+  /**
+    * @param resourceDocList 
+    * @return - JValue, with Swagger format, many following Strings
+    *         {
+    *         "definitions":{
+    *           "ExampleJSON":
+    *           { 
+    *             "required": ["id","name","bank","banks"],    
+    *             "properties":
+    *             { 
+    *               "id": {"type":"integer", "format":"int32"}, 
+    *               "Tesobe": {"type":"string"},
+    *               "bank": {"$ref": "#/definitions/BankJSON"},
+    *               "banks": {"type": "array", "items":{"$ref": "#/definitions/BanksJSON"}
+    *             }
+    *           }
+    *         } ...
+    */
   def loadDefinitions(resourceDocList: List[ResourceDoc]): liftweb.json.JValue = {
-
+  
     implicit val formats = DefaultFormats
-
-    //Translate a jsonAST to an appropriate case class entity
-    val successResponseBodies: List[Any] =
-      for (rd <- resourceDocList)
-      yield {
-        rd match {
-          case u if u.apiFunction.contains("allBanks") => rd.successResponseBody.extract[BanksJSON]
-          case u if u.apiFunction.contains("bankById") => rd.successResponseBody.extract[BankJSON]
-          //now the TransactionRequestTypeJsons changed, it feed to update, so comment
-          //case u if u.apiFunction.contains("getTransactionRequestTypes") => rd.successResponseBody.extract[TransactionRequestTypesSwaggerJsons]
-          case _ => "Not defined"
-        }
-      }
-
-    val successResponseBodiesForProcessing = successResponseBodies filter (_.toString().contains("Not defined") == false)
-    //Translate every entity in a list to appropriate swagger format
+  
+    val allNeededCaseClasses = SwaggerJSONsV220.allFieldsAndValues
+    //Translate every entity(JSON Case Class) in a list to appropriate swagger format
     val listOfParticularDefinition =
-      for (e <- successResponseBodiesForProcessing)
-      yield {
-        translateEntity(e)
-      }
-    //Add a comma between elements of a list and make a string
+    // just ommit the base class -- code.api.ResourceDocs1_4_0.SwaggerJSONsV220$
+      for (e <- allNeededCaseClasses if (APIUtil.notExstingBaseClass(e._1)))
+        yield {
+          translateEntity(e._1, e._2)
+        }
+    //Add a comma between elements of a list and make a string 
     val particularDefinitionsPart = listOfParticularDefinition mkString (",")
     //Make a final string
     val definitions = "{\"definitions\":{" + particularDefinitionsPart + "}}"
     //Make a jsonAST from a string
     parse(definitions)
   }
-
+ 
 }

--- a/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONsV220.scala
+++ b/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONsV220.scala
@@ -1,0 +1,617 @@
+package code.api.ResourceDocs1_4_0
+
+import code.api.util.APIUtil
+import code.api.util.APIUtil._
+/**
+  * Created by zhanghongwei on 07/04/2017.
+  * This object prepare all the JSON case classes for Swagger .
+  * For now, just support all the endpoints for V220.
+  * Because different versions, has different case classes.
+  * It is hard to mapping all these case class dynamicly for now.
+  * May be it can be fixed later.
+  *
+  */
+object SwaggerJSONsV220 {
+  
+  val basicViewJSON = code.api.v2_0_0.BasicViewJSON(
+    id = "1",
+    short_name = "HHH",
+    is_public = true
+  )
+  
+  val basicAccountJSON =
+    code.api.v2_0_0.BasicAccountJSON(
+      id = "8ca8a7e4-6d02-48e3-a029-0b2bf89de9f0",
+      label = "NoneLabel",
+      bank_id = "gh.29.uk",
+      views_available = List(basicViewJSON)
+    )
+  
+  val coreAccountJSON = code.api.v2_0_0.CoreAccountJSON(
+    id = "8ca8a7e4-6d02-48e3-a029-0b2bf89de9f0",
+    label = "NoneLabel",
+    bank_id = "gh.29.uk",
+    _links = defaultJValue
+  )
+  
+  
+  val basicAccountsJSON =
+    code.api.v2_0_0.BasicAccountsJSON(
+      accounts = List(basicAccountJSON)
+    )
+  val accountRoutingJSON =
+    code.api.v1_2_1.AccountRoutingJSON(
+      scheme = "swftcode",
+      address = "UKTF3049auf"
+    )
+  
+  val amountOfMoneyJSON =
+    code.api.v1_2_1.AmountOfMoneyJSON(
+      currency = "EUR",
+      amount = "10"
+    )
+  
+  val userJSONV121 =
+    code.api.v1_2_1.UserJSON(
+      id = "5995d6a2-01b3-423c-a173-5481df49bdaf",
+      provider = "OBP",
+      display_name = "OBP"
+    )
+  val moderatedCoreAccountJSON =
+    code.api.v2_0_0.JSONFactory200.ModeratedCoreAccountJSON(
+      id = "8ca8a7e4-6d02-48e3-a029-0b2bf89de9f0",
+      label = "NoneLabel",
+      number = "123",
+      owners = List(userJSONV121),
+      `type` = "OBP",
+      balance = amountOfMoneyJSON,
+      IBAN = "GR1301720530005053000582373",
+      swift_bic = "UKTF3049auf",
+      bank_id = "gh.29.uk",
+      account_routing = accountRoutingJSON
+    )
+  
+  val viewJSON =
+    code.api.v1_2_1.ViewJSON(
+      id = "123",
+      short_name = "short_name",
+      description = "description",
+      is_public = true,
+      alias = "None",
+      hide_metadata_if_alias_used = true,
+      can_add_comment = true,
+      can_add_corporate_location = true,
+      can_add_image = true,
+      can_add_image_url = true,
+      can_add_more_info = true,
+      can_add_open_corporates_url = true,
+      can_add_physical_location = true,
+      can_add_private_alias = true,
+      can_add_public_alias = true,
+      can_add_tag = true,
+      can_add_url = true,
+      can_add_where_tag = true,
+      can_delete_comment = true,
+      can_delete_corporate_location = true,
+      can_delete_image = true,
+      can_delete_physical_location = true,
+      can_delete_tag = true,
+      can_delete_where_tag = true,
+      can_edit_owner_comment = true,
+      can_see_bank_account_balance = true,
+      can_see_bank_account_bank_name = true,
+      can_see_bank_account_currency = true,
+      can_see_bank_account_iban = true,
+      can_see_bank_account_label = true,
+      can_see_bank_account_national_identifier = true,
+      can_see_bank_account_number = true,
+      can_see_bank_account_owners = true,
+      can_see_bank_account_swift_bic = true,
+      can_see_bank_account_type = true,
+      can_see_comments = true,
+      can_see_corporate_location = true,
+      can_see_image_url = true,
+      can_see_images = true,
+      can_see_more_info = true,
+      can_see_open_corporates_url = true,
+      can_see_other_account_bank_name = true,
+      can_see_other_account_iban = true,
+      can_see_other_account_kind = true,
+      can_see_other_account_metadata = true,
+      can_see_other_account_national_identifier = true,
+      can_see_other_account_number = true,
+      can_see_other_account_swift_bic = true,
+      can_see_owner_comment = true,
+      can_see_physical_location = true,
+      can_see_private_alias = true,
+      can_see_public_alias = true,
+      can_see_tags = true,
+      can_see_transaction_amount = true,
+      can_see_transaction_balance = true,
+      can_see_transaction_currency = true,
+      can_see_transaction_description = true,
+      can_see_transaction_finish_date = true,
+      can_see_transaction_metadata = true,
+      can_see_transaction_other_bank_account = true,
+      can_see_transaction_start_date = true,
+      can_see_transaction_this_bank_account = true,
+      can_see_transaction_type = true,
+      can_see_url = true,
+      can_see_where_tag = true
+    )
+  
+  val viewsJSON =
+    code.api.v1_2_1.ViewsJSON(
+      views = List(viewJSON)
+    )
+  
+  val moderatedAccountJSON =
+    code.api.v1_2_1.ModeratedAccountJSON(
+      id = "5995d6a2-01b3-423c-a173-5481df49bdaf",
+      label = "NoneLabel",
+      number = "123",
+      owners = List(userJSONV121),
+      `type` = "OBP",
+      balance = amountOfMoneyJSON,
+      IBAN = "GR1301720530005053000582373",
+      swift_bic = "UKTF3049auf",
+      views_available = List(viewJSON),
+      bank_id = "gh.29.uk",
+      account_routing = accountRoutingJSON
+    )
+  
+  val entitlementJSON =
+    code.api.v2_0_0.EntitlementJSON(
+      entitlement_id = "6fb17583-1e49-4435-bb74-a14fe0996723",
+      role_name = "CanQueryOtherUser",
+      bank_id = "gh.29.uk"
+    )
+  val entitlementJSONs =
+    code.api.v2_0_0.EntitlementJSONs(
+      list = List(entitlementJSON)
+    )
+  
+  val userJSONV200 =
+    code.api.v2_0_0.JSONFactory200.UserJSON(
+      user_id = "5995d6a2-01b3-423c-a173-5481df49bdaf",
+      email = "robert.x.0.gh@example.com",
+      provider_id = "OBP",
+      provider = "OBP",
+      username = "robert.x.0.gh",
+      entitlements = entitlementJSONs
+    )
+  
+  val bankRoutingJSON =
+    code.api.v1_2_1.BankRoutingJSON(
+      scheme = "Bank_ID",
+      address = "gh.29.uk"
+    )
+  
+  val bankJSON =
+    code.api.v1_2_1.BankJSON(
+      id = "gh.29.uk",
+      short_name = "short_name ",
+      full_name = "full_name",
+      logo = "logo",
+      website = "www.openbankproject.com",
+      bank_routing = bankRoutingJSON
+    )
+  
+  val banksJSON =
+    code.api.v1_2_1.BanksJSON(
+      banks = List(bankJSON)
+    )
+  
+  val customerFaceImageJson =
+    code.api.v1_4_0.JSONFactory1_4_0.CustomerFaceImageJson(
+      url = "www.openbankproject",
+      date = exampleDate
+    )
+  
+  val customerCreditRatingJSON = code.api.v2_1_0.CustomerCreditRatingJSON(
+    rating = "OBP",
+    source = "OBP"
+  )
+  
+  val customerJson =
+    code.api.v2_1_0.CustomerJson(
+      customer_id = "123",
+      customer_number = "123",
+      legal_name = "legal_name",
+      mobile_phone_number = "123",
+      email = "contact@tesobe.com",
+      face_image = customerFaceImageJson,
+      date_of_birth = exampleDate,
+      relationship_status = "123",
+      dependants = 123,
+      dob_of_dependants = List(exampleDate),
+      credit_rating = Option(customerCreditRatingJSON),
+      credit_limit = Option(amountOfMoneyJSON),
+      highest_education_attained = "123",
+      employment_status = "123",
+      kyc_status = true,
+      last_ok_date = exampleDate
+    )
+  
+  val accountHolderJSON =
+    code.api.v1_2_1.AccountHolderJSON(
+      name = "OBP",
+      is_alias = true
+    )
+  
+  val minimalBankJSON =
+    code.api.v1_2_1.MinimalBankJSON(
+      national_identifier = "OBP",
+      name = "OBP"
+    )
+  
+  val locationJSON =
+    code.api.v1_2_1.LocationJSON(
+      latitude = 11.45,
+      longitude = 11.45,
+      date = exampleDate,
+      user = userJSONV121
+    )
+  
+  val thisAccountJSON =
+    code.api.v1_2_1.ThisAccountJSON(
+      id = "5995d6a2-01b3-423c-a173-5481df49bdaf",
+      holders = List(accountHolderJSON),
+      number = "123",
+      kind = "AC",
+      IBAN = "UK1234AD",
+      swift_bic = "UK1234AD",
+      bank = minimalBankJSON
+    )
+  
+  val otherAccountMetadataJSON =
+    code.api.v1_2_1.OtherAccountMetadataJSON(
+      public_alias = "NONE",
+      private_alias = "NONE",
+      more_info = "www.openbankproject.com",
+      URL = "www.openbankproject.com",
+      image_URL = "www.openbankproject.com",
+      open_corporates_URL = "www.openbankproject.com",
+      corporate_location = locationJSON,
+      physical_location = locationJSON
+    )
+  
+  val otherAccountJSON =
+    code.api.v1_2_1.OtherAccountJSON(
+      id = "5995d6a2-01b3-423c-a173-5481df49bdaf",
+      holder = accountHolderJSON,
+      number = "123",
+      kind = "3456",
+      IBAN = "UK234DB",
+      swift_bic = "UK12321DB",
+      bank = minimalBankJSON,
+      metadata = otherAccountMetadataJSON
+    )
+  
+  val transactionDetailsJSON =
+    code.api.v1_2_1.TransactionDetailsJSON(
+      `type` = "AC",
+      description = "GOOD",
+      posted = exampleDate,
+      completed = exampleDate,
+      new_balance = amountOfMoneyJSON,
+      value = amountOfMoneyJSON
+    )
+  
+  val transactionImageJSON =
+    code.api.v1_2_1.TransactionImageJSON(
+      id = "5995d6a2-01b3-423c-a173-5481df49bdaf",
+      label = "NONE",
+      URL = "www.openbankproject.com",
+      date = exampleDate,
+      user = userJSONV121
+    )
+  
+  val transactionImagesJSON =
+    code.api.v1_2_1.TransactionImagesJSON(
+      images = List(transactionImageJSON)
+    )
+  
+  val transactionCommentJSON =
+    code.api.v1_2_1.TransactionCommentJSON(
+      id = "5995d6a2-01b3-423c-a173-5481df49bdaf",
+      value = "OBP",
+      date = exampleDate,
+      user = userJSONV121
+    )
+  
+  val transactionTagJSON =
+    code.api.v1_2_1.TransactionTagJSON(
+      id = "5995d6a2-01b3-423c-a173-5481df49bdaf",
+      value = "OBP",
+      date = exampleDate,
+      user = userJSONV121
+    )
+  
+  val transactionTagsJSON =
+    code.api.v1_2_1.TransactionTagsJSON(
+      tags = List(transactionTagJSON)
+    )
+  
+  val transactionMetadataJSON =
+    code.api.v1_2_1.TransactionMetadataJSON(
+      narrative = "NONE",
+      comments = List(transactionCommentJSON),
+      tags = List(transactionTagJSON),
+      images = List(transactionImageJSON),
+      where = locationJSON
+    )
+  
+  val transactionJSON =
+    code.api.v1_2_1.TransactionJSON(
+      id = "5995d6a2-01b3-423c-a173-5481df49bdaf",
+      this_account = thisAccountJSON,
+      other_account = otherAccountJSON,
+      details = transactionDetailsJSON,
+      metadata = transactionMetadataJSON
+    )
+  
+  val transactionsJSON =
+    code.api.v1_2_1.TransactionsJSON(
+      transactions = List(transactionJSON)
+    )
+  
+  val coreTransactionDetailsJSON =
+    code.api.v2_0_0.JSONFactory200.CoreTransactionDetailsJSON(
+      `type` = "AC",
+      description = "OBP",
+      posted = exampleDate,
+      completed = exampleDate,
+      new_balance = amountOfMoneyJSON,
+      value = amountOfMoneyJSON
+    )
+  
+  val coreAccountHolderJSON =
+    code.api.v2_0_0.JSONFactory200.CoreAccountHolderJSON(
+      name = "ZACK"
+    )
+  
+  
+  val coreCounterpartyJSON =
+    code.api.v2_0_0.JSONFactory200.CoreCounterpartyJSON(
+      id = "123",
+      holder = coreAccountHolderJSON,
+      number = "1234",
+      kind = "AV",
+      IBAN = "UK12344DB",
+      swift_bic = "UK12344DB",
+      bank = minimalBankJSON
+    )
+  
+  val coreTransactionJSON =
+    code.api.v2_0_0.JSONFactory200.CoreTransactionJSON(
+      id = "123",
+      account = thisAccountJSON,
+      counterparty = coreCounterpartyJSON,
+      details = coreTransactionDetailsJSON
+    )
+  
+  val coreTransactionsJSON =
+    code.api.v2_0_0.JSONFactory200.CoreTransactionsJSON(
+      transactions = List(coreTransactionJSON)
+    )
+  
+  val transactionRequestChargeJSON =
+    code.api.v2_0_0.TransactionRequestChargeJSON(
+      summary = "Good",
+      value = amountOfMoneyJSON
+    )
+  
+  val transactionRequestTypeJSON =
+    code.api.v1_4_0.JSONFactory1_4_0.TransactionRequestTypeJSON(
+      value = "10",
+      charge = transactionRequestChargeJSON
+    )
+  
+  val transactionRequestTypeJSONs =
+    code.api.v1_4_0.JSONFactory1_4_0.TransactionRequestTypeJSONs(
+      transaction_request_types = List(transactionRequestTypeJSON)
+    )
+  
+  val transactionRequestAccountJSON =
+    code.api.v1_4_0.JSONFactory1_4_0.TransactionRequestAccountJSON(
+      bank_id = "gh.29.uk",
+      account_id = "8ca8a7e4-6d02-48e3-a029-0b2bf89de9f0"
+    )
+  
+  val challengeJSON =
+    code.api.v1_4_0.JSONFactory1_4_0.ChallengeJSON(
+      id = "be1a183d-b301-4b83-b855-5eeffdd3526f",
+      allowed_attempts = 3,
+      challenge_type = "SANDBOX_TAN"
+    )
+  
+  val transactionRequestWithChargeJSON210 =
+    code.api.v2_1_0.TransactionRequestWithChargeJSON210(
+      id = "4050046c-63b3-4868-8a22-14b4181d33a6",
+      `type` = "SANDBOX_TAN",
+      from = transactionRequestAccountJSON,
+      details = defaultJValue,
+      transaction_ids = List("902ba3bb-dedd-45e7-9319-2fd3f2cd98a1"),
+      status = "COMPLETED",
+      start_date = exampleDate,
+      end_date = exampleDate,
+      challenge = challengeJSON,
+      charge = transactionRequestChargeJSON
+    )
+  
+  val transactionRequestWithChargeJSON =
+    code.api.v2_0_0.TransactionRequestWithChargeJSON(
+      id = "82f92531-9c63-4246-abfc-96c20ec46188",
+      `type` = "SANDBOX_TAN",
+      from = transactionRequestAccountJSON,
+      details = defaultJValue,
+      transaction_ids = "666666-9c63-4246-abfc-96c20ec46188",
+      status = "COMPLETED",
+      start_date = exampleDate,
+      end_date = exampleDate,
+      challenge = challengeJSON,
+      charge = transactionRequestChargeJSON
+    )
+  
+  val counterpartyJSON =
+    code.api.v2_2_0.CounterpartyJSON(
+      name = "b2dd6c2c-7ebd-4014-9c73-b7d28cc71fe1",
+      created_by_user_id = "49e1e147-64c1-4823-ad9f-89efcd02a9fa",
+      this_bank_id = "gh.29.uk",
+      this_account_id = "8ca8a7e4-6d02-48e3-a029-0b2bf89de9f0",
+      this_view_id = "owner",
+      counterparty_id = "1d65db7c-a7b2-4839-af41-958276ab7790",
+      other_bank_routing_scheme = "test",
+      other_bank_routing_address = "test",
+      other_branch_routing_scheme = "OBP",
+      other_branch_routing_address = "Berlin",
+      other_account_routing_scheme = "IBAN",
+      other_account_routing_address = "829b116f-027c-4508-a537-6b15ed6fbaaa",
+      is_beneficiary = true
+    )
+  
+  val counterpartiesJSON =
+    code.api.v2_2_0.CounterpartiesJSON(
+      counterparties = List(counterpartyJSON)
+    )
+  
+  val successMessage =
+    code.api.v1_2_1.SuccessMessage(
+      success = "Success"
+    )
+  
+  
+  val viewJSONV220 =
+    code.api.v2_2_0.ViewJSONV220(
+      id = "1234",
+      short_name = "short_name",
+      description = "description",
+      is_public = true,
+      alias = "No",
+      hide_metadata_if_alias_used = true,
+      can_add_comment = true,
+      can_add_corporate_location = true,
+      can_add_image = true,
+      can_add_image_url = true,
+      can_add_more_info = true,
+      can_add_open_corporates_url = true,
+      can_add_physical_location = true,
+      can_add_private_alias = true,
+      can_add_public_alias = true,
+      can_add_tag = true,
+      can_add_url = true,
+      can_add_where_tag = true,
+      can_delete_comment = true,
+      can_add_counterparty = true,
+      can_delete_corporate_location = true,
+      can_delete_image = true,
+      can_delete_physical_location = true,
+      can_delete_tag = true,
+      can_delete_where_tag = true,
+      can_edit_owner_comment = true,
+      can_see_bank_account_balance = true,
+      can_see_bank_account_bank_name = true,
+      can_see_bank_account_currency = true,
+      can_see_bank_account_iban = true,
+      can_see_bank_account_label = true,
+      can_see_bank_account_national_identifier = true,
+      can_see_bank_account_number = true,
+      can_see_bank_account_owners = true,
+      can_see_bank_account_swift_bic = true,
+      can_see_bank_account_type = true,
+      can_see_comments = true,
+      can_see_corporate_location = true,
+      can_see_image_url = true,
+      can_see_images = true,
+      can_see_more_info = true,
+      can_see_open_corporates_url = true,
+      can_see_other_account_bank_name = true,
+      can_see_other_account_iban = true,
+      can_see_other_account_kind = true,
+      can_see_other_account_metadata = true,
+      can_see_other_account_national_identifier = true,
+      can_see_other_account_number = true,
+      can_see_other_account_swift_bic = true,
+      can_see_owner_comment = true,
+      can_see_physical_location = true,
+      can_see_private_alias = true,
+      can_see_public_alias = true,
+      can_see_tags = true,
+      can_see_transaction_amount = true,
+      can_see_transaction_balance = true,
+      can_see_transaction_currency = true,
+      can_see_transaction_description = true,
+      can_see_transaction_finish_date = true,
+      can_see_transaction_metadata = true,
+      can_see_transaction_other_bank_account = true,
+      can_see_transaction_start_date = true,
+      can_see_transaction_this_bank_account = true,
+      can_see_transaction_type = true,
+      can_see_url = true,
+      can_see_where_tag = true
+    )
+  
+//  val viewsJSONV220 =
+//    code.api.v2_2_0.ViewsJSONV220(
+//      views = List(viewJSONV220)
+//    )
+  
+  val otherAccountsJSON =
+    code.api.v1_2_1.OtherAccountsJSON(
+      other_accounts = List(otherAccountJSON)
+    )
+  
+  val transactionNarrativeJSON =
+    code.api.v1_2_1.TransactionNarrativeJSON(
+      narrative = "narative"
+    )
+  
+  val transactionCommentsJSON =
+    code.api.v1_2_1.TransactionCommentsJSON(
+      comments = List(transactionCommentJSON)
+    )
+  
+  val transactionWhereJSON =
+    code.api.v1_2_1.TransactionWhereJSON(
+    where=  locationJSON
+  )
+  
+  val fXRateJSON =
+    code.api.v2_2_0.FXRateJSON(
+      from_currency_code = "EUR",
+      to_currency_code = "GBP",
+      conversion_value = 1.001,
+      inverse_conversion_value = 0.998,
+      effective_date = exampleDate
+    )
+  
+  val permissionJSON =
+    code.api.v1_2_1.PermissionJSON(
+      user = userJSONV121,
+      views = List(viewJSON)
+    )
+  
+  val permissionsJSON =
+    code.api.v1_2_1.PermissionsJSON(
+      permissions = List(permissionJSON)
+    )
+  
+  val TransactionRequestWithChargeJSONs210 =
+    code.api.v2_1_0.TransactionRequestWithChargeJSONs210(
+      transaction_requests_with_charges = List(
+        transactionRequestWithChargeJSON210
+      )
+    )
+  
+  val allFieldsAndValues =
+    for (
+      v <- this.getClass.getDeclaredFields
+      //add guard, ignore the SwaggerJSONsV220.this and allFieldsAndValues fields
+      if (APIUtil.notExstingBaseClass(v.getName()))
+    )
+      yield {
+        v.setAccessible(true)
+        v.get(this).getClass.getSimpleName -> v.get(this)
+      }
+}

--- a/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONsV220.scala
+++ b/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONsV220.scala
@@ -552,10 +552,10 @@ object SwaggerJSONsV220 {
       can_see_where_tag = true
     )
   
-//  val viewsJSONV220 =
-//    code.api.v2_2_0.ViewsJSONV220(
-//      views = List(viewJSONV220)
-//    )
+  //  val viewsJSONV220 =
+  //    code.api.v2_2_0.ViewsJSONV220(
+  //      views = List(viewJSONV220)
+  //    )
   
   val otherAccountsJSON =
     code.api.v1_2_1.OtherAccountsJSON(
@@ -574,8 +574,8 @@ object SwaggerJSONsV220 {
   
   val transactionWhereJSON =
     code.api.v1_2_1.TransactionWhereJSON(
-    where=  locationJSON
-  )
+      where = locationJSON
+    )
   
   val fXRateJSON =
     code.api.v2_2_0.FXRateJSON(
@@ -602,6 +602,70 @@ object SwaggerJSONsV220 {
       transaction_requests_with_charges = List(
         transactionRequestWithChargeJSON210
       )
+    )
+  
+  val transactionRequestBodyJSON =
+    code.api.v2_0_0.TransactionRequestBodyJSON(
+      to = transactionRequestAccountJSON,
+      value = amountOfMoneyJSON,
+      description = "Good"
+    )
+  
+  val challengeAnswerJSON =
+    code.api.v1_4_0.JSONFactory1_4_0.ChallengeAnswerJSON(
+      id = "b20dd004-93e3-494f-8773-69e3ff8c205e",
+      answer = "good"
+    )
+  
+  val updateAccountJSON =
+    code.api.v1_2_1.UpdateAccountJSON(
+      id = "123123",
+      label = "label",
+      bank_id = "gh.29.uk"
+    )
+  
+  val createViewJSON =
+    code.model.CreateViewJSON(
+      name = "test",
+      description = "good",
+      is_public = true,
+      which_alias_to_use = "good",
+      hide_metadata_if_alias_used = true,
+      allowed_actions = List("good")
+    )
+  
+  val updateViewJSON =
+    code.model.UpdateViewJSON(
+      description = "good",
+      is_public = true,
+      which_alias_to_use = "good",
+      hide_metadata_if_alias_used = true,
+      allowed_actions = List("good")
+    )
+  
+  val viewIdsJson =
+    code.api.v1_2_1.ViewIdsJson(
+      views = List("good")
+    )
+  
+  val postCustomerJson =
+    code.api.v2_1_0.PostCustomerJson(
+      user_id = "user_id to attach this customer to e.g. 123213",
+      customer_number = "new customer number 687687678",
+      legal_name = "NONE",
+      mobile_phone_number = "+44 07972 444 876",
+      email = "person@example.com",
+      face_image = customerFaceImageJson,
+      date_of_birth = exampleDate,
+      relationship_status = "Single",
+      dependants = 5,
+      dob_of_dependants = List(exampleDate),
+      credit_rating = customerCreditRatingJSON,
+      credit_limit = amountOfMoneyJSON,
+      highest_education_attained = "Bachelor’s Degree",
+      employment_status = "Employed",
+      kyc_status = true,
+      last_ok_date = exampleDate
     )
   
   val allFieldsAndValues =

--- a/src/main/scala/code/api/util/APIUtil.scala
+++ b/src/main/scala/code/api/util/APIUtil.scala
@@ -33,11 +33,12 @@
 package code.api.util
 
 import java.io.InputStream
+import java.text.SimpleDateFormat
 
 import code.api.Constant._
 import code.api.DirectLogin
 import code.api.OAuthHandshake._
-import code.api.v1_2.ErrorMessage
+import code.api.v1_2.{ErrorMessage, SuccessMessage}
 import code.consumer.Consumers
 import code.customer.Customer
 import code.entitlement.Entitlement
@@ -193,6 +194,10 @@ object APIUtil extends Loggable {
   implicit val formats = net.liftweb.json.DefaultFormats
   implicit def errorToJson(error: ErrorMessage): JValue = Extraction.decompose(error)
   val headers = ("Access-Control-Allow-Origin","*") :: Nil
+  val defaultJValue = Extraction.decompose(Nil)(APIUtil.formats)
+  val exampleDateString: String = "22/08/2013"
+  val simpleDateFormat: SimpleDateFormat = new SimpleDateFormat("dd/mm/yyyy")
+  val exampleDate = simpleDateFormat.parse(exampleDateString)
 
   def httpMethod : String =
     S.request match {
@@ -305,7 +310,7 @@ object APIUtil extends Loggable {
   }
 
   def noContentJsonResponse : JsonResponse =
-    JsonResponse(JsRaw(""), headers, Nil, 204)
+    JsonResponse(Extraction.decompose(SuccessMessage("Success")), headers, Nil, 204)
 
   def successJsonResponse(json: JsExp, httpCode : Int = 200) : JsonResponse =
     JsonResponse(json, headers, Nil, httpCode)
@@ -904,7 +909,7 @@ Returns a string showed to the developer
   // eg: MODULE$ is not the useful input.
   // eg2: allFieldsAndValues is just for SwaggerJSONsV220.allFieldsAndValues,it is not useful.
   def notExstingBaseClass(input: String): Boolean = {
-    !input.contains("$") && !input.contains("allFieldsAndValues")
+    !input.contains("$") && !input.equalsIgnoreCase("allFieldsAndValues")
   }
 
 }

--- a/src/main/scala/code/api/util/APIUtil.scala
+++ b/src/main/scala/code/api/util/APIUtil.scala
@@ -899,5 +899,12 @@ Returns a string showed to the developer
       case _       => "off"
     }
   }
+  
+  // check is there a "$" in the input value.
+  // eg: MODULE$ is not the useful input.
+  // eg2: allFieldsAndValues is just for SwaggerJSONsV220.allFieldsAndValues,it is not useful.
+  def notExstingBaseClass(input: String): Boolean = {
+    !input.contains("$") && !input.contains("allFieldsAndValues")
+  }
 
 }

--- a/src/main/scala/code/api/v1_2_1/JSONFactory1.2.1.scala
+++ b/src/main/scala/code/api/v1_2_1/JSONFactory1.2.1.scala
@@ -77,7 +77,7 @@ case class BankRoutingJSON(
 case class ViewsJSON(
   views : List[ViewJSON]
 )
-class ViewJSON(
+case class ViewJSON(
   val id: String,
   val short_name: String,
   val description: String,
@@ -158,6 +158,11 @@ case class UpdateAccountJSON(
   id : String,
   label : String,
   bank_id : String
+)
+
+case class AccountRoutingJSON(
+  scheme: String,
+  address: String
 )
 
 case class ModeratedAccountJSON(

--- a/src/main/scala/code/api/v2_0_0/APIMethods200.scala
+++ b/src/main/scala/code/api/v2_0_0/APIMethods200.scala
@@ -10,7 +10,7 @@ import code.api.util.APIUtil._
 import code.api.util.ApiRole._
 import code.api.util.{APIUtil, ApiRole, ErrorMessages}
 import code.api.v1_2_1.OBPAPI1_2_1._
-import code.api.v1_2_1.{APIMethods121, AmountOfMoneyJSON => AmountOfMoneyJSON121, JSONFactory => JSONFactory121}
+import code.api.v1_2_1.{APIMethods121, SuccessMessage, AmountOfMoneyJSON => AmountOfMoneyJSON121, JSONFactory => JSONFactory121}
 import code.api.v1_4_0.JSONFactory1_4_0
 import code.api.v1_4_0.JSONFactory1_4_0.{ChallengeAnswerJSON, CustomerFaceImageJson, TransactionRequestAccountJSON}
 
@@ -1031,9 +1031,9 @@ trait APIMethods200 {
       apiVersion,
       "createAccount",
       "PUT",
-      "/banks/BANK_ID/accounts/NEW_ACCOUNT_ID",
+      "/banks/BANK_ID/accounts/ACCOUNT_ID",
       "Create Account",
-      """Create Account at bank specified by BANK_ID with Id specified by NEW_ACCOUNT_ID.
+      """Create Account at bank specified by BANK_ID with Id specified by ACCOUNT_ID.
         |
         |
         |The User can create an Account for themself or an Account for another User if they have CanCreateAccount role.

--- a/src/main/scala/code/api/v2_0_0/JSONFactory2.0.0.scala
+++ b/src/main/scala/code/api/v2_0_0/JSONFactory2.0.0.scala
@@ -130,7 +130,7 @@ case class UserCustomerLinkJSONs(l: List[UserCustomerLinkJSON])
 
 case class CreateUserCustomerLinkJSON(user_id: String, customer_id: String)
 
-class BasicViewJSON(
+case class BasicViewJSON(
   val id: String,
   val short_name: String,
   val is_public: Boolean

--- a/src/main/scala/code/api/v2_0_0/JSONFactory2.0.0.scala
+++ b/src/main/scala/code/api/v2_0_0/JSONFactory2.0.0.scala
@@ -35,7 +35,7 @@ import java.net.URL
 import java.util.Date
 
 import code.TransactionTypes.TransactionType.TransactionType
-import code.api.v1_2_1.ViewJSON
+import code.api.v1_2_1.{AccountRoutingJSON, ViewJSON}
 import code.api.v2_2_0.{AccountJSON, AccountsJSON}
 import code.entitlement.Entitlement
 import code.meetings.Meeting

--- a/src/main/scala/code/api/v2_1_0/APIMethods210.scala
+++ b/src/main/scala/code/api/v2_1_0/APIMethods210.scala
@@ -246,60 +246,61 @@ trait APIMethods210 {
       Catalogs(Core, PSD2, OBWG),
       List(apiTagTransactionRequest))
 
-    // COUNTERPARTY
-    resourceDocs += ResourceDoc(
-      createTransactionRequest,
-      apiVersion,
-      "createTransactionRequest",
-      "POST",
-      "/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/COUNTERPARTY/transaction-requests",
-      "Create Transaction Request (COUNTERPARTY)",
-      s"""$transactionRequestGeneralText
-         |
-         |Special instructions for COUNTERPARTY:
-         |
-         |When using a COUNTERPARTY to create a Transaction Request, specificy the counterparty_id in the body of the request.
-         |The routing details of the counterparty will be forwarded for the transfer.
-         |
-       """.stripMargin,
-      Extraction.decompose(TransactionRequestBodyCounterpartyJSON(
-        CounterpartyIdJson("lalalalwieuryi79878987fds"),
-        AmountOfMoneyJSON("EUR", "100.53"),
-        "A description for the transaction to the counterparty",
-      "SHARED"
-      )
-      ),
-      emptyObjectJson,
-      emptyObjectJson :: Nil,
-      Catalogs(Core, PSD2, OBWG),
-      List(apiTagTransactionRequest))
+    //TODO CM just comment it, Swagger mess up
+//    // COUNTERPARTY
+//    resourceDocs += ResourceDoc(
+//      createTransactionRequest,
+//      apiVersion,
+//      "createTransactionRequest",
+//      "POST",
+//      "/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/COUNTERPARTY/transaction-requests",
+//      "Create Transaction Request (COUNTERPARTY)",
+//      s"""$transactionRequestGeneralText
+//         |
+//         |Special instructions for COUNTERPARTY:
+//         |
+//         |When using a COUNTERPARTY to create a Transaction Request, specificy the counterparty_id in the body of the request.
+//         |The routing details of the counterparty will be forwarded for the transfer.
+//         |
+//       """.stripMargin,
+//      Extraction.decompose(TransactionRequestBodyCounterpartyJSON(
+//        CounterpartyIdJson("lalalalwieuryi79878987fds"),
+//        AmountOfMoneyJSON("EUR", "100.53"),
+//        "A description for the transaction to the counterparty",
+//      "SHARED"
+//      )
+//      ),
+//      emptyObjectJson,
+//      emptyObjectJson :: Nil,
+//      Catalogs(Core, PSD2, OBWG),
+//      List(apiTagTransactionRequest))
 
 
     val lowAmount  = AmountOfMoneyJSON("EUR", "12.50")
     val sharedChargePolicy = ChargePolicy.withName("SHARED")
 
-    // Transaction Request (SEPA)
-    resourceDocs += ResourceDoc(
-      createTransactionRequest,
-      apiVersion,
-      "createTransactionRequest",
-      "POST",
-      "/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/SEPA/transaction-requests",
-      "Create Transaction Request (SEPA)",
-      s"""$transactionRequestGeneralText
-         |
-         |Special instructions for SEPA:
-         |
-         |When using a SEPA Transaction Request, you specify the IBAN of a Counterparty in the body of the request.
-         |The routing details (IBAN) of the counterparty will be forwarded to the core banking system for the transfer.
-         |
-       """.stripMargin,
-      Extraction.decompose(TransactionRequestBodySEPAJSON(lowAmount, IbanJson("IBAN-798789873234"), "This is a SEPA Transaction Request", sharedChargePolicy.toString)
-      ),
-      emptyObjectJson,
-      emptyObjectJson :: Nil,
-      Catalogs(Core, PSD2, OBWG),
-      List(apiTagTransactionRequest))
+//    // Transaction Request (SEPA)
+//    resourceDocs += ResourceDoc(
+//      createTransactionRequest,
+//      apiVersion,
+//      "createTransactionRequest",
+//      "POST",
+//      "/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/SEPA/transaction-requests",
+//      "Create Transaction Request (SEPA)",
+//      s"""$transactionRequestGeneralText
+//         |
+//         |Special instructions for SEPA:
+//         |
+//         |When using a SEPA Transaction Request, you specify the IBAN of a Counterparty in the body of the request.
+//         |The routing details (IBAN) of the counterparty will be forwarded to the core banking system for the transfer.
+//         |
+//       """.stripMargin,
+//      Extraction.decompose(TransactionRequestBodySEPAJSON(lowAmount, IbanJson("IBAN-798789873234"), "This is a SEPA Transaction Request", sharedChargePolicy.toString)
+//      ),
+//      emptyObjectJson,
+//      emptyObjectJson :: Nil,
+//      Catalogs(Core, PSD2, OBWG),
+//      List(apiTagTransactionRequest))
 
 
     lazy val createTransactionRequest: PartialFunction[Req, Box[User] => Box[JsonResponse]] = {

--- a/src/main/scala/code/api/v2_1_0/APIMethods210.scala
+++ b/src/main/scala/code/api/v2_1_0/APIMethods210.scala
@@ -246,61 +246,60 @@ trait APIMethods210 {
       Catalogs(Core, PSD2, OBWG),
       List(apiTagTransactionRequest))
 
-    //TODO CM just comment it, Swagger mess up
-//    // COUNTERPARTY
-//    resourceDocs += ResourceDoc(
-//      createTransactionRequest,
-//      apiVersion,
-//      "createTransactionRequest",
-//      "POST",
-//      "/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/COUNTERPARTY/transaction-requests",
-//      "Create Transaction Request (COUNTERPARTY)",
-//      s"""$transactionRequestGeneralText
-//         |
-//         |Special instructions for COUNTERPARTY:
-//         |
-//         |When using a COUNTERPARTY to create a Transaction Request, specificy the counterparty_id in the body of the request.
-//         |The routing details of the counterparty will be forwarded for the transfer.
-//         |
-//       """.stripMargin,
-//      Extraction.decompose(TransactionRequestBodyCounterpartyJSON(
-//        CounterpartyIdJson("lalalalwieuryi79878987fds"),
-//        AmountOfMoneyJSON("EUR", "100.53"),
-//        "A description for the transaction to the counterparty",
-//      "SHARED"
-//      )
-//      ),
-//      emptyObjectJson,
-//      emptyObjectJson :: Nil,
-//      Catalogs(Core, PSD2, OBWG),
-//      List(apiTagTransactionRequest))
+    // COUNTERPARTY
+    resourceDocs += ResourceDoc(
+      createTransactionRequest,
+      apiVersion,
+      "createTransactionRequest",
+      "POST",
+      "/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/COUNTERPARTY/transaction-requests",
+      "Create Transaction Request (COUNTERPARTY)",
+      s"""$transactionRequestGeneralText
+         |
+         |Special instructions for COUNTERPARTY:
+         |
+         |When using a COUNTERPARTY to create a Transaction Request, specificy the counterparty_id in the body of the request.
+         |The routing details of the counterparty will be forwarded for the transfer.
+         |
+       """.stripMargin,
+      Extraction.decompose(TransactionRequestBodyCounterpartyJSON(
+        CounterpartyIdJson("lalalalwieuryi79878987fds"),
+        AmountOfMoneyJSON("EUR", "100.53"),
+        "A description for the transaction to the counterparty",
+      "SHARED"
+      )
+      ),
+      emptyObjectJson,
+      emptyObjectJson :: Nil,
+      Catalogs(Core, PSD2, OBWG),
+      List(apiTagTransactionRequest))
 
 
     val lowAmount  = AmountOfMoneyJSON("EUR", "12.50")
     val sharedChargePolicy = ChargePolicy.withName("SHARED")
 
-//    // Transaction Request (SEPA)
-//    resourceDocs += ResourceDoc(
-//      createTransactionRequest,
-//      apiVersion,
-//      "createTransactionRequest",
-//      "POST",
-//      "/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/SEPA/transaction-requests",
-//      "Create Transaction Request (SEPA)",
-//      s"""$transactionRequestGeneralText
-//         |
-//         |Special instructions for SEPA:
-//         |
-//         |When using a SEPA Transaction Request, you specify the IBAN of a Counterparty in the body of the request.
-//         |The routing details (IBAN) of the counterparty will be forwarded to the core banking system for the transfer.
-//         |
-//       """.stripMargin,
-//      Extraction.decompose(TransactionRequestBodySEPAJSON(lowAmount, IbanJson("IBAN-798789873234"), "This is a SEPA Transaction Request", sharedChargePolicy.toString)
-//      ),
-//      emptyObjectJson,
-//      emptyObjectJson :: Nil,
-//      Catalogs(Core, PSD2, OBWG),
-//      List(apiTagTransactionRequest))
+    // Transaction Request (SEPA)
+    resourceDocs += ResourceDoc(
+      createTransactionRequest,
+      apiVersion,
+      "createTransactionRequest",
+      "POST",
+      "/banks/BANK_ID/accounts/ACCOUNT_ID/VIEW_ID/transaction-request-types/SEPA/transaction-requests",
+      "Create Transaction Request (SEPA)",
+      s"""$transactionRequestGeneralText
+         |
+         |Special instructions for SEPA:
+         |
+         |When using a SEPA Transaction Request, you specify the IBAN of a Counterparty in the body of the request.
+         |The routing details (IBAN) of the counterparty will be forwarded to the core banking system for the transfer.
+         |
+       """.stripMargin,
+      Extraction.decompose(TransactionRequestBodySEPAJSON(lowAmount, IbanJson("IBAN-798789873234"), "This is a SEPA Transaction Request", sharedChargePolicy.toString)
+      ),
+      emptyObjectJson,
+      emptyObjectJson :: Nil,
+      Catalogs(Core, PSD2, OBWG),
+      List(apiTagTransactionRequest))
 
 
     lazy val createTransactionRequest: PartialFunction[Req, Box[User] => Box[JsonResponse]] = {

--- a/src/main/scala/code/api/v2_1_0/JSONFactory2.1.0.scala
+++ b/src/main/scala/code/api/v2_1_0/JSONFactory2.1.0.scala
@@ -34,8 +34,8 @@ package code.api.v2_1_0
 import java.util.Date
 
 import code.api.util.ApiRole
-import code.api.v1_2_1.AmountOfMoneyJSON
-import code.api.v1_4_0.JSONFactory1_4_0.{DriveUpJson,LicenseJson,ChallengeJSON, CustomerFaceImageJson, MetaJson, TransactionRequestAccountJSON,AddressJson,LocationJson,LobbyJson}
+import code.api.v1_2_1.{AccountRoutingJSON, AmountOfMoneyJSON}
+import code.api.v1_4_0.JSONFactory1_4_0.{AddressJson, ChallengeJSON, CustomerFaceImageJson, DriveUpJson, LicenseJson, LobbyJson, LocationJson, MetaJson, TransactionRequestAccountJSON}
 import code.api.v2_0_0.TransactionRequestChargeJSON
 import code.branches.Branches.BranchId
 import code.common.{License, Meta}
@@ -231,11 +231,6 @@ case class CounterpartyMetadataJSON(
                                      corporate_location: LocationJSON,
                                      physical_location: LocationJSON
                                    )
-
-case class AccountRoutingJSON(
-                               scheme: String,
-                               address: String
-                             )
 
 case class BankRoutingJSON(
                                scheme: String,

--- a/src/main/scala/code/api/v2_2_0/APIMethods220.scala
+++ b/src/main/scala/code/api/v2_2_0/APIMethods220.scala
@@ -5,7 +5,7 @@ import java.text.SimpleDateFormat
 import code.api.util.APIUtil.isValidCurrencyISOCode
 import code.api.util.ApiRole.{CanCreateAccount, CanCreateBank, CanCreateBranch}
 import code.api.util.ErrorMessages
-import code.api.v1_2_1.AmountOfMoneyJSON
+import code.api.v1_2_1.{AccountRoutingJSON, AmountOfMoneyJSON}
 import code.api.v1_4_0.JSONFactory1_4_0
 import code.api.v1_4_0.JSONFactory1_4_0._
 import code.api.v2_0_0.JSONFactory200
@@ -414,9 +414,9 @@ trait APIMethods220 {
       apiVersion,
       "createAccount",
       "PUT",
-      "/banks/BANK_ID/accounts/NEW_ACCOUNT_ID",
+      "/banks/BANK_ID/accounts/ACCOUNT_ID",
       "Create Account",
-      """Create Account at bank specified by BANK_ID with Id specified by NEW_ACCOUNT_ID.
+      """Create Account at bank specified by BANK_ID with Id specified by ACCOUNT_ID.
         |
         |
         |The User can create an Account for themself or an Account for another User if they have CanCreateAccount role.

--- a/src/main/scala/code/api/v2_2_0/JSONFactory2.2.0.scala
+++ b/src/main/scala/code/api/v2_2_0/JSONFactory2.2.0.scala
@@ -34,7 +34,7 @@ package code.api.v2_2_0
 //import code.api.v1_2_1.JSONFactory
 import java.util.Date
 
-import code.api.v1_2_1.AmountOfMoneyJSON
+import code.api.v1_2_1.{AccountRoutingJSON, AmountOfMoneyJSON}
 import code.api.v1_4_0.JSONFactory1_4_0._
 import code.branches.Branches.Branch
 import code.fx.FXRate
@@ -45,10 +45,10 @@ import code.model._
 //import net.liftweb.json.JsonAST.JValue
 
 
-case class ViewsJSON(
-                      views : List[ViewJSON]
+case class ViewsJSONV220(
+                      views : List[ViewJSONV220]
                     )
-class ViewJSON(
+case class ViewJSONV220(
                 val id: String,
                 val short_name: String,
                 val description: String,
@@ -123,7 +123,7 @@ case class AccountsJSON(
 case class AccountJSON(
                         id : String,
                         label : String,
-                        views_available : List[ViewJSON],
+                        views_available : List[ViewJSONV220],
                         bank_id : String
                       )
 
@@ -204,11 +204,6 @@ case class CreateAccountJSON(
   account_routing: AccountRoutingJSON
 )
 
-case class AccountRoutingJSON(
-  scheme: String,
-  address: String
-)
-
 object JSONFactory220{
 
   def stringOrNull(text : String) =
@@ -217,12 +212,12 @@ object JSONFactory220{
     else
       text
 
-  def createViewsJSON(views : List[View]) : ViewsJSON = {
-    val list : List[ViewJSON] = views.map(createViewJSON)
-    new ViewsJSON(list)
+  def createViewsJSON(views : List[View]) : ViewsJSONV220 = {
+    val list : List[ViewJSONV220] = views.map(createViewJSON)
+    new ViewsJSONV220(list)
   }
 
-  def createViewJSON(view : View) : ViewJSON = {
+  def createViewJSON(view : View) : ViewJSONV220 = {
     val alias =
       if(view.usePublicAliasIfOneExists)
         "public"
@@ -231,7 +226,7 @@ object JSONFactory220{
       else
         ""
 
-    new ViewJSON(
+    new ViewJSONV220(
       id = view.viewId.value,
       short_name = stringOrNull(view.name),
       description = stringOrNull(view.description),

--- a/src/main/scala/code/bankconnectors/ObpJvmMappedConnector.scala
+++ b/src/main/scala/code/bankconnectors/ObpJvmMappedConnector.scala
@@ -375,6 +375,7 @@ object ObpJvmMappedConnector extends Connector with Loggable {
     val primaryUserIdentifier = AccountHolders.accountHolders.vend.getAccountHolders(bankId, accountId).toList.length match {
        //For now just make it in the log, not throw new RuntimeException("wrong userId, set it in MapperAccountHolders table first!")
       case 0 => "xxxxxxxxxxxxx, wrong userId, set it in MapperAccountHolders table first!"
+        //TODO CM this is a super vital sercurity problem, a serious attack vector,Never put Bank specific code in OBP
       case _ => MapperAccountHolders.getAccountHolders(bankId, accountId).toList(0).name
     }
 

--- a/src/main/scala/code/model/ModeratedBankingData.scala
+++ b/src/main/scala/code/model/ModeratedBankingData.scala
@@ -180,10 +180,6 @@ object ModeratedTransactionMetadata {
   }
 }
 
-case class AccountRoutingJSON(
-  scheme: String,
-  address: String
-)
 
 class ModeratedBankAccount(
   val accountId : AccountId,

--- a/src/test/scala/code/api/v2_2_0/API2_2_0Test.scala
+++ b/src/test/scala/code/api/v2_2_0/API2_2_0Test.scala
@@ -113,7 +113,7 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
 
   def randomViewsIdsToGrant(bankId : String, accountId : String) : List[String]= {
     //get the view ids of the available views on the bank accounts
-    val viewsIds = getAccountViews(bankId, accountId, user1).body.extract[ViewsJSON].views.map(_.id)
+    val viewsIds = getAccountViews(bankId, accountId, user1).body.extract[ViewsJSONV220].views.map(_.id)
     //choose randomly some view ids to grant
     val (viewsIdsToGrant, _) = viewsIds.splitAt(nextInt(viewsIds.size) + 1)
     viewsIdsToGrant
@@ -218,12 +218,12 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
     }
   }
 
-  def assertViewExistsWithCondition(accJson: AccountsJSON, cond: ViewJSON => Boolean): Unit = {
+  def assertViewExistsWithCondition(accJson: AccountsJSON, cond: ViewJSONV220 => Boolean): Unit = {
     val exists = accJson.accounts.exists(acc => acc.views_available.exists(cond))
     exists should equal(true)
   }
 
-  def assertAllAccountsHaveAViewWithCondition(accJson: AccountsJSON, cond: ViewJSON => Boolean): Unit = {
+  def assertAllAccountsHaveAViewWithCondition(accJson: AccountsJSON, cond: ViewJSONV220 => Boolean): Unit = {
     val forAll = accJson.accounts.forall(acc => acc.views_available.exists(cond))
     forAll should equal(true)
   }
@@ -257,7 +257,7 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
       val reply = getAccountViews(bankId, bankAccount.id, user1)
       Then("we should get a 200 ok code")
       reply.code should equal (200)
-      reply.body.extract[ViewsJSON]
+      reply.body.extract[ViewsJSONV220]
     }
 
     scenario("We will not get the list of the available views on a bank account due to missing token", API2_2, GetViews) {
@@ -289,15 +289,15 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
       Given("We will use an access token")
       val bankId = randomBank
       val bankAccount : code.api.v1_2.AccountJSON = randomPrivateAccount(bankId)
-      val viewsBefore = getAccountViews(bankId, bankAccount.id, user1).body.extract[ViewsJSON].views
+      val viewsBefore = getAccountViews(bankId, bankAccount.id, user1).body.extract[ViewsJSONV220].views
       val view = randomView(true, "")
       When("the request is sent")
       val reply = postView(bankId, bankAccount.id, view, user1)
       Then("we should get a 201 code")
       reply.code should equal (201)
-      reply.body.extract[ViewJSON]
+      reply.body.extract[ViewJSONV220]
       And("we should get a new view")
-      val viewsAfter = getAccountViews(bankId, bankAccount.id, user1).body.extract[ViewsJSON].views
+      val viewsAfter = getAccountViews(bankId, bankAccount.id, user1).body.extract[ViewsJSONV220].views
       viewsBefore.size should equal (viewsAfter.size -1)
     }
 
@@ -360,7 +360,7 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
     val updatedAliasToUse = "public"
     val allowedActions = List("can_see_images", "can_delete_comment")
 
-    def viewUpdateJson(originalView : ViewJSON) = {
+    def viewUpdateJson(originalView : ViewJSONV220) = {
       //it's not perfect, assumes too much about originalView (i.e. randomView(true, ""))
       new UpdateViewJSON(
         description = updatedViewDescription,
@@ -388,7 +388,7 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
       val view = randomView(true, "")
       val creationReply = postView(bankId, bankAccount.id, view, user1)
       creationReply.code should equal (201)
-      val createdView : ViewJSON = creationReply.body.extract[ViewJSON]
+      val createdView : ViewJSONV220 = creationReply.body.extract[ViewJSONV220]
       createdView.can_see_images should equal(true)
       createdView.can_delete_comment should equal(true)
       createdView.can_delete_physical_location should equal(true)
@@ -401,7 +401,7 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
       val reply = putView(bankId, bankAccount.id, createdView.id, viewUpdateJson(createdView), user1)
       Then("We should get back the updated view")
       reply.code should equal (200)
-      val updatedView = reply.body.extract[ViewJSON]
+      val updatedView = reply.body.extract[ViewJSONV220]
       updatedView.can_see_images should equal(true)
       updatedView.can_delete_comment should equal(true)
       updatedView.can_delete_physical_location should equal(false)
@@ -419,7 +419,7 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
       val nonExistantViewId = "asdfasdfasdfasdfasdf"
       val getReply = getAccountViews(bankId, bankAccount.id, user1)
       getReply.code should equal (200)
-      val views : ViewsJSON = getReply.body.extract[ViewsJSON]
+      val views : ViewsJSONV220 = getReply.body.extract[ViewsJSONV220]
       views.views.foreach(v => v.id should not equal(nonExistantViewId))
 
       When("we try to update that view")
@@ -435,7 +435,7 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
       val view = randomView(true, "")
       val creationReply = postView(bankId, bankAccount.id, view, user1)
       creationReply.code should equal (201)
-      val createdView : ViewJSON = creationReply.body.extract[ViewJSON]
+      val createdView : ViewJSONV220 = creationReply.body.extract[ViewJSONV220]
 
       When("we don't use an access token")
       val reply = putView(bankId, bankAccount.id, createdView.id, viewUpdateJson(createdView), None)
@@ -453,7 +453,7 @@ class API2_2_0Test extends User1AllPrivileges with V220ServerSetup with DefaultU
       val view = randomView(true, "")
       val creationReply = postView(bankId, bankAccount.id, view, user1)
       creationReply.code should equal (201)
-      val createdView : ViewJSON = creationReply.body.extract[ViewJSON]
+      val createdView : ViewJSONV220 = creationReply.body.extract[ViewJSONV220]
 
       When("we try to update a view without having sufficient privileges to do so")
       val reply = putView(bankId, bankAccount.id, createdView.id, viewUpdateJson(createdView), user3)


### PR DESCRIPTION
#471

Note1: 
For swagger, I need rename all the JSON Case Class according to the Version.
For example as what I did :
code.api.v2_2_0.ViewJSON —>code.api.v2_2_0.ViewJSONV220

Note2:
I just commented the “Create Transaction Request” resourceDoc. (Commented SEPA and COUNTERPART)
Only one resourceDoc one endpoint. 
