### PR TITLE
Enabled support for Elasticsearch 5.3.0 #505

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,12 +203,12 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>2.3.0</version>
+      <version>5.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.sksamuel.elastic4s</groupId>
-      <artifactId>elastic4s-core_2.11</artifactId>
-      <version>2.3.0</version>
+      <artifactId>elastic4s-tcp_2.11</artifactId>
+      <version>5.3.0</version>
     </dependency>
     <!-- for LiftConsole -->
     <dependency>

--- a/src/main/resources/props/sample.props.template
+++ b/src/main/resources/props/sample.props.template
@@ -55,6 +55,7 @@ write_metrics=true
 #allow_elasticsearch=true
 #allow_elasticsearch_warehouse=true
 #allow_elasticsearch_metrics=true
+#es.cluster.name=elasticsearch
 
 ## ElasticSearch warehouse
 #es.warehouse.index=warehouse

--- a/src/main/scala/code/api/openidconnect.scala
+++ b/src/main/scala/code/api/openidconnect.scala
@@ -214,7 +214,7 @@ object OpenIdConnect extends OBPRestHelper with Loggable {
         connection.getOutputStream.write(dataBytes)
       }
       val inputStream = connection.getInputStream
-      content = io.Source.fromInputStream(inputStream).mkString
+      content = scala.io.Source.fromInputStream(inputStream).mkString
       if (inputStream != null) inputStream.close()
     } catch {
       case e:Throwable => println(e)


### PR DESCRIPTION
openidconnect.scala had to be changed to specifically use scala.io
because otherwise netty.io would be used which does not have an
attribute called Source.