### PR TITLE
Updated README.md for roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Our tag line is: Bank as a Platform. Transparency as an Asset.
 
 The API uses OAuth 1.0 authentication.
 
-The project roadmap is available [here.](https://openbankproject.com/roadmap/)
+The project roadmap is available [here.](https://github.com/OpenBankProject/OBP-API/blob/develop/roadmap.md)
 
 ## DOCUMENTATION 
 


### PR DESCRIPTION
The roadmap link looks broken to pass it on to the OBP Website which links it back to the project source page of roadmap.md.
It will be good if the link can be made directly to the roadmap.md file