### PR TITLE
caching getConsumerByConsumerKey for 6000 seconds by default

### DIFF
--- a/src/main/scala/code/remotedata/RemotedataConsumers.scala
+++ b/src/main/scala/code/remotedata/RemotedataConsumers.scala
@@ -4,18 +4,45 @@ import akka.pattern.ask
 import code.actorsystem.ObpActorInit
 import code.consumer.{ConsumersProvider, RemotedataConsumersCaseClasses}
 import code.model._
+import com.google.common.cache.CacheBuilder
 import net.liftweb.common._
+import net.liftweb.util.Props
+
+import scala.concurrent.duration._
+import scalacache.{Flags, ScalaCache}
+import scalacache.guava.GuavaCache
+import scalacache.memoization.{cacheKeyExclude, memoizeSync}
 
 
 object RemotedataConsumers extends ObpActorInit with ConsumersProvider {
+
+  val underlyingGuavaCache = CacheBuilder.newBuilder().maximumSize(10000L).build[String, Object]
+  implicit val scalaCache  = ScalaCache(GuavaCache(underlyingGuavaCache))
+
+  val getConsumerTTL  = Props.get("connector.cache.ttl.seconds.getConsumer", "6000").toInt * 1000 // Miliseconds
 
   val cc = RemotedataConsumersCaseClasses
 
   def getConsumerByConsumerId(consumerId: Long): Box[Consumer] =
     extractFutureToBox(actor ? cc.getConsumerByConsumerId(consumerId))
 
-  def getConsumerByConsumerKey(consumerKey: String): Box[Consumer] =
-    extractFutureToBox(actor ? cc.getConsumerByConsumerKey(consumerKey))
+  def getConsumerByConsumerKey(consumerKey: String): Box[Consumer] = {
+
+    def getConsumerByConsumerKey(consumerKey: String)(implicit @cacheKeyExclude flags: Flags): Box[Consumer] = memoizeSync(getConsumerTTL millisecond) {
+      extractFutureToBox(actor ? cc.getConsumerByConsumerKey(consumerKey))
+    }
+
+    def getConsumer(consumerKey: String, skipCache: Boolean): Box[Consumer] = {
+      implicit val flags = Flags(readsEnabled = !skipCache)
+      getConsumerByConsumerKey(consumerKey)
+    }
+
+    // First try to obtain cache value,
+    getConsumer(consumerKey, false) match {
+      case Full(x)  => Full(x) // Success
+      case _ => getConsumer(consumerKey, true) // Failure - make full round trip i.e. without caching
+    }
+  }
 
   def createConsumer(key: Option[String], secret: Option[String], isActive: Option[Boolean], name: Option[String], appType: Option[AppType.AppType], description: Option[String], developerEmail: Option[String], redirectURL: Option[String], createdByUserId: Option[String]): Box[Consumer] =
     extractFutureToBox(actor ? cc.createConsumer(key, secret, isActive, name, appType, description, developerEmail, redirectURL, createdByUserId))


### PR DESCRIPTION
@simonredfern Please consider the change.
Note that if there is no cached value we try to obtain it from database. And default cached time is 6000 second. It can be changed through connector.cache.ttl.seconds.getConsumer property. 