### PR TITLE
update kafka scripts to work with kafka >= 0.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ src/main/resources/
 src/test/resources/
 *.iml
 src/main/resources/log4j.properties
+src/main/scripts/kafka/kafka_*
+src/main/scripts/kafka/logs/
+src/main/scripts/kafka/tmp/

--- a/src/main/scripts/kafka/config/kafka.properties
+++ b/src/main/scripts/kafka/config/kafka.properties
@@ -19,6 +19,9 @@
 # The id of the broker. This must be set to a unique integer for each broker.
 broker.id=0
 
+# With Kafka  >= 0.11 offsets.topic.replication will default to 3, it must be set to 1 for a single broker.
+offsets.topic.replication.factor=1
+
 ############################# Socket Server Settings #############################
 
 # The address the socket server listens on. It will get the value returned from 


### PR DESCRIPTION
this configures kafka topic replication factor to the default value of kafka < 0.11.
needed for a single broker (dev machine).