### PR TITLE
Make generated code by swagger create tag itself

### DIFF
--- a/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -270,7 +270,7 @@ class Boot extends MdcLoggable {
     }
 
     // Add the various API versions
-    ScannedApis.versionMapScannedApis.keys.foreach(enableVersionIfAllowed)
+    ScannedApis.versionMapScannedApis.keys.foreach(enableVersionIfAllowed) // process all scanned apis versions
     enableVersionIfAllowed(ApiVersion.v1_2_1)
     enableVersionIfAllowed(ApiVersion.v1_3_0)
     enableVersionIfAllowed(ApiVersion.v1_4_0)

--- a/src/main/scala/code/api/berlin/group/v1_3/AccountInformationServiceAISApi.scala
+++ b/src/main/scala/code/api/berlin/group/v1_3/AccountInformationServiceAISApi.scala
@@ -5,7 +5,7 @@ import code.api.berlin.group.v1_3.{JSONFactory_BERLIN_GROUP_1_3, JvalueCaseClass
 import net.liftweb.json
 import net.liftweb.json._
 import code.api.util.APIUtil.{defaultBankId, _}
-import code.api.util.{ApiVersion, NewStyle}
+import code.api.util.{ApiTag, ApiVersion, NewStyle}
 import code.api.util.ErrorMessages._
 import code.api.util.ApiTag._
 import code.api.util.NewStyle.HttpCode
@@ -162,7 +162,7 @@ As a last option, an ASPSP might in addition accept a command with access rights
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val createConsent : OBPEndpoint = {
@@ -216,7 +216,7 @@ As a last option, an ASPSP might in addition accept a command with access rights
        json.parse(""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val deleteConsent : OBPEndpoint = {
@@ -299,7 +299,7 @@ of the PSU at this ASPSP.
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getAccountList : OBPEndpoint = {
@@ -354,7 +354,7 @@ The account-id is constant at least throughout the lifecycle of a given consent.
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getBalances : OBPEndpoint = {
@@ -431,7 +431,7 @@ respectively the OAuth2 access token.
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getCardAccount : OBPEndpoint = {
@@ -514,7 +514,7 @@ This account-id then can be retrieved by the
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getCardAccountBalances : OBPEndpoint = {
@@ -576,7 +576,7 @@ Reads account data from a given card account addressed by "account-id".
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getCardAccountTransactionList : OBPEndpoint = {
@@ -632,7 +632,7 @@ This function returns an array of hyperlinks to all generated authorisation sub-
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getConsentAuthorisation : OBPEndpoint = {
@@ -719,7 +719,7 @@ where the consent was directly managed between ASPSP and PSU e.g. in a re-direct
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getConsentInformation : OBPEndpoint = {
@@ -804,7 +804,7 @@ This method returns the SCA status of a consent initiation's authorisation sub-r
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getConsentScaStatus : OBPEndpoint = {
@@ -835,7 +835,7 @@ This method returns the SCA status of a consent initiation's authorisation sub-r
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getConsentStatus : OBPEndpoint = {
@@ -911,7 +911,7 @@ This call is only available on transactions as reported in a JSON format.
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getTransactionDetails : OBPEndpoint = {
@@ -1008,7 +1008,7 @@ The ASPSP might add balance information, if transaction lists without balances a
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val getTransactionList : OBPEndpoint = {
@@ -1090,7 +1090,7 @@ Give detailed information about the addressed account together with balance info
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val readAccountDetails : OBPEndpoint = {
@@ -1159,7 +1159,7 @@ access token.
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val readCardAccount : OBPEndpoint = {
@@ -1258,7 +1258,7 @@ This applies in the following scenarios:
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val startConsentAuthorisation : OBPEndpoint = {
@@ -1348,7 +1348,7 @@ There are the following request types on this access path:
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagAccountInformationServiceAIS :: apiTagMockedData :: Nil
+       ApiTag("Account Information Service (AIS)")  :: apiTagMockedData :: Nil
      )
 
      lazy val updateConsentsPsuData : OBPEndpoint = {

--- a/src/main/scala/code/api/berlin/group/v1_3/CommonServicesApi.scala
+++ b/src/main/scala/code/api/berlin/group/v1_3/CommonServicesApi.scala
@@ -5,7 +5,7 @@ import code.api.berlin.group.v1_3.{JSONFactory_BERLIN_GROUP_1_3, JvalueCaseClass
 import net.liftweb.json
 import net.liftweb.json._
 import code.api.util.APIUtil.{defaultBankId, _}
-import code.api.util.{ApiVersion, NewStyle}
+import code.api.util.{ApiTag, ApiVersion, NewStyle}
 import code.api.util.ErrorMessages._
 import code.api.util.ApiTag._
 import code.api.util.NewStyle.HttpCode
@@ -67,7 +67,7 @@ Nevertheless, single transactions might be cancelled on an individual basis on t
        json.parse(""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val deleteSigningBasket : OBPEndpoint = {
@@ -97,7 +97,7 @@ This method returns the SCA status of a consent initiation's authorisation sub-r
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val getConsentScaStatus : OBPEndpoint = {
@@ -129,7 +129,7 @@ This method returns the SCA status of a payment initiation's authorisation sub-r
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val getPaymentCancellationScaStatus : OBPEndpoint = {
@@ -163,7 +163,7 @@ This function returns an array of hyperlinks to all generated authorisation sub-
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val getPaymentInitiationAuthorisation : OBPEndpoint = {
@@ -195,7 +195,7 @@ This method returns the SCA status of a payment initiation's authorisation sub-r
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val getPaymentInitiationScaStatus : OBPEndpoint = {
@@ -229,7 +229,7 @@ This function returns an array of hyperlinks to all generated authorisation sub-
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val getSigningBasketAuthorisation : OBPEndpoint = {
@@ -261,7 +261,7 @@ This method returns the SCA status of a signing basket's authorisation sub-resou
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val getSigningBasketScaStatus : OBPEndpoint = {
@@ -293,7 +293,7 @@ Returns the status of a signing basket object.
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val getSigningBasketStatus : OBPEndpoint = {
@@ -376,7 +376,7 @@ This applies in the following scenarios:
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val startConsentAuthorisation : OBPEndpoint = {
@@ -481,7 +481,7 @@ This applies in the following scenarios:
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val startPaymentAuthorisation : OBPEndpoint = {
@@ -586,7 +586,7 @@ This applies in the following scenarios:
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val startPaymentInitiationCancellationAuthorisation : OBPEndpoint = {
@@ -691,7 +691,7 @@ This applies in the following scenarios:
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val startSigningBasketAuthorisation : OBPEndpoint = {
@@ -781,7 +781,7 @@ There are the following request types on this access path:
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val updateConsentsPsuData : OBPEndpoint = {
@@ -848,7 +848,7 @@ There are the following request types on this access path:
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val updatePaymentCancellationPsuData : OBPEndpoint = {
@@ -913,7 +913,7 @@ There are the following request types on this access path:
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val updatePaymentPsuData : OBPEndpoint = {
@@ -980,7 +980,7 @@ There are the following request types on this access path:
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagCommonServices :: apiTagMockedData :: Nil
+       ApiTag("Common Services") :: apiTagMockedData :: Nil
      )
 
      lazy val updateSigningBasketPsuData : OBPEndpoint = {

--- a/src/main/scala/code/api/berlin/group/v1_3/ConfirmationOfFundsServicePIISApi.scala
+++ b/src/main/scala/code/api/berlin/group/v1_3/ConfirmationOfFundsServicePIISApi.scala
@@ -5,7 +5,7 @@ import code.api.berlin.group.v1_3.{JSONFactory_BERLIN_GROUP_1_3, JvalueCaseClass
 import net.liftweb.json
 import net.liftweb.json._
 import code.api.util.APIUtil.{defaultBankId, _}
-import code.api.util.{ApiVersion, NewStyle}
+import code.api.util.{ApiTag, ApiVersion, NewStyle}
 import code.api.util.ErrorMessages._
 import code.api.util.ApiTag._
 import code.api.util.NewStyle.HttpCode
@@ -63,7 +63,7 @@ Creates a confirmation of funds request at the ASPSP. Checks whether a specific 
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagConfirmationOfFundsServicePIIS :: apiTagMockedData :: Nil
+       ApiTag("Confirmation of Funds Service (PIIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val checkAvailabilityOfFunds : OBPEndpoint = {

--- a/src/main/scala/code/api/berlin/group/v1_3/PaymentInitiationServicePISApi.scala
+++ b/src/main/scala/code/api/berlin/group/v1_3/PaymentInitiationServicePISApi.scala
@@ -5,7 +5,7 @@ import code.api.berlin.group.v1_3.{JSONFactory_BERLIN_GROUP_1_3, JvalueCaseClass
 import net.liftweb.json
 import net.liftweb.json._
 import code.api.util.APIUtil.{defaultBankId, _}
-import code.api.util.{ApiVersion, NewStyle}
+import code.api.util.{ApiTag, ApiVersion, NewStyle}
 import code.api.util.ErrorMessages._
 import code.api.util.ApiTag._
 import code.api.util.NewStyle.HttpCode
@@ -88,7 +88,7 @@ The response to this DELETE command will tell the TPP whether the
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val cancelPayment : OBPEndpoint = {
@@ -137,7 +137,7 @@ This method returns the SCA status of a payment initiation's authorisation sub-r
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val getPaymentCancellationScaStatus : OBPEndpoint = {
@@ -166,7 +166,7 @@ Returns the content of a payment object""",
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val getPaymentInformation : OBPEndpoint = {
@@ -198,7 +198,7 @@ This function returns an array of hyperlinks to all generated authorisation sub-
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val getPaymentInitiationAuthorisation : OBPEndpoint = {
@@ -228,7 +228,7 @@ Retrieve a list of all created cancellation authorisation sub-resources.
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val getPaymentInitiationCancellationAuthorisationInformation : OBPEndpoint = {
@@ -258,7 +258,7 @@ This method returns the SCA status of a payment initiation's authorisation sub-r
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val getPaymentInitiationScaStatus : OBPEndpoint = {
@@ -289,7 +289,7 @@ Check the transaction status of a payment initiation.""",
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val getPaymentInitiationStatus : OBPEndpoint = {
@@ -363,7 +363,7 @@ In these cases, first an authorisation sub-resource has to be generated followin
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val initiatePayment : OBPEndpoint = {
@@ -445,7 +445,7 @@ This applies in the following scenarios:
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val startPaymentAuthorisation : OBPEndpoint = {
@@ -550,7 +550,7 @@ This applies in the following scenarios:
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val startPaymentInitiationCancellationAuthorisation : OBPEndpoint = {
@@ -640,7 +640,7 @@ There are the following request types on this access path:
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val updatePaymentCancellationPsuData : OBPEndpoint = {
@@ -705,7 +705,7 @@ There are the following request types on this access path:
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagPaymentInitiationServicePIS :: apiTagMockedData :: Nil
+       ApiTag("Payment Initiation Service (PIS)") :: apiTagMockedData :: Nil
      )
 
      lazy val updatePaymentPsuData : OBPEndpoint = {

--- a/src/main/scala/code/api/berlin/group/v1_3/SigningBasketsApi.scala
+++ b/src/main/scala/code/api/berlin/group/v1_3/SigningBasketsApi.scala
@@ -5,7 +5,7 @@ import code.api.berlin.group.v1_3.{JSONFactory_BERLIN_GROUP_1_3, JvalueCaseClass
 import net.liftweb.json
 import net.liftweb.json._
 import code.api.util.APIUtil.{defaultBankId, _}
-import code.api.util.{ApiVersion, NewStyle}
+import code.api.util.{ApiTag, ApiVersion, NewStyle}
 import code.api.util.ErrorMessages._
 import code.api.util.ApiTag._
 import code.api.util.NewStyle.HttpCode
@@ -96,7 +96,7 @@ The resource identifications of these transactions are contained in the  payload
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagSigningBaskets :: apiTagMockedData :: Nil
+       ApiTag("Signing Baskets") :: apiTagMockedData :: Nil
      )
 
      lazy val createSigningBasket : OBPEndpoint = {
@@ -166,7 +166,7 @@ Nevertheless, single transactions might be cancelled on an individual basis on t
        json.parse(""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagSigningBaskets :: apiTagMockedData :: Nil
+       ApiTag("Signing Baskets") :: apiTagMockedData :: Nil
      )
 
      lazy val deleteSigningBasket : OBPEndpoint = {
@@ -197,7 +197,7 @@ Returns the content of an signing basket object.""",
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagSigningBaskets :: apiTagMockedData :: Nil
+       ApiTag("Signing Baskets") :: apiTagMockedData :: Nil
      )
 
      lazy val getSigningBasket : OBPEndpoint = {
@@ -233,7 +233,7 @@ This function returns an array of hyperlinks to all generated authorisation sub-
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagSigningBaskets :: apiTagMockedData :: Nil
+       ApiTag("Signing Baskets") :: apiTagMockedData :: Nil
      )
 
      lazy val getSigningBasketAuthorisation : OBPEndpoint = {
@@ -265,7 +265,7 @@ This method returns the SCA status of a signing basket's authorisation sub-resou
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagSigningBaskets :: apiTagMockedData :: Nil
+       ApiTag("Signing Baskets") :: apiTagMockedData :: Nil
      )
 
      lazy val getSigningBasketScaStatus : OBPEndpoint = {
@@ -297,7 +297,7 @@ Returns the status of a signing basket object.
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagSigningBaskets :: apiTagMockedData :: Nil
+       ApiTag("Signing Baskets") :: apiTagMockedData :: Nil
      )
 
      lazy val getSigningBasketStatus : OBPEndpoint = {
@@ -381,7 +381,7 @@ This applies in the following scenarios:
 }"""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagSigningBaskets :: apiTagMockedData :: Nil
+       ApiTag("Signing Baskets") :: apiTagMockedData :: Nil
      )
 
      lazy val startSigningBasketAuthorisation : OBPEndpoint = {
@@ -471,7 +471,7 @@ There are the following request types on this access path:
        json.parse(""""""""),
        List(UserNotLoggedIn, UnknownError),
        Catalogs(notCore, notPSD2, notOBWG),
-       apiTagSigningBaskets :: apiTagMockedData :: Nil
+       ApiTag("Signing Baskets") :: apiTagMockedData :: Nil
      )
 
      lazy val updateSigningBasketPsuData : OBPEndpoint = {

--- a/src/main/scala/code/api/util/ApiTag.scala
+++ b/src/main/scala/code/api/util/ApiTag.scala
@@ -1,5 +1,7 @@
 package code.api.util
 
+import scala.collection.mutable.{Map => MutableMap}
+
 object ApiTag {
   // Used to tag Resource Docs
   case class ResourceDocTag(tag: String)
@@ -52,16 +54,7 @@ object ApiTag {
   val apiTagNewStyle = ResourceDocTag("New-Style")
   val apiTagWebhook = ResourceDocTag("Webhook")
   val apiTagMockedData = ResourceDocTag("Mocked-Data")
-  
-  
-  
-  
-  //Note: the followings are for the code generator -- BerlinGroupV1.3
-  val apiTagPaymentInitiationServicePIS = ResourceDocTag("Payment Initiation Service (PIS)")
-  val apiTagConfirmationOfFundsServicePIIS = ResourceDocTag("Confirmation of Funds Service (PIIS)")
-  val apiTagAccountInformationServiceAIS = ResourceDocTag("Account Information Service (AIS)")
-  val apiTagSigningBaskets = ResourceDocTag("Signing Baskets")
-  val apiTagCommonServices = ResourceDocTag("Common Services")
+
   
   //Note: the followings are for the code generator -- UKOpenBankingV3.1.0
   val apiTagAccountAccess = ResourceDocTag("UK-AccountAccess")
@@ -84,7 +77,16 @@ object ApiTag {
   val apiTagStandingOrders = ResourceDocTag("UK-StandingOrders")
   val apiTagStatements = ResourceDocTag("UK-Statements")
   val apiTagTransactions = ResourceDocTag("UK-Transactions")
-  
+
+  private[this] val tagNameSymbolMapTag: MutableMap[String, ResourceDocTag] = MutableMap()
+
+  /**
+    * get a ResourceDocTag by tag symbol string, if not exists, create one with the symbol
+    * @param tagSymbol tag content
+    * @return exists or created ResourceDocTags
+    */
+  def apply(tagSymbol: String): ResourceDocTag =  this.tagNameSymbolMapTag.getOrElseUpdate(tagSymbol, ResourceDocTag(tagSymbol))
+
 }
 
 

--- a/src/main/scala/code/api/util/ApiVersion.scala
+++ b/src/main/scala/code/api/util/ApiVersion.scala
@@ -10,12 +10,21 @@ sealed trait ApiVersion {
   }
 }
 
+/**
+  * this version object created according swagger file info.title and info.version
+  * @param urlPrefix api url prefix part, not include "/"
+  * @param appName parsed from swagger file info.title, is appName variable in swagger-codegen
+  * @param appVersion parsed from swagger file infor.version, is version variable in wagger-codegen
+  */
 case class ScannedApiVersion(urlPrefix: String, appName: String, appVersion: String) extends ApiVersion{
   override def toString() = {
+    // extract number part of version, e.g "here is version 1.3 final" -> "1.3"
     val version = appVersion.replaceAll(".*?(\\b\\d+\\..+?\\b).*", "$1")
+    // extract name from appName, e.g: "The customer api" -> "The_customer"
     val name = appName.replaceFirst("(?i)api", "").trim.replaceAll("\\s+", "_")
     //TODO the version name role will cooperate with API-Explorer, current name role is temporary.
-    (name+"_"+version).replaceAll("^_|_$|(v)_", "$1") // avoid starts with _ or end with _, and avoid v_ e.g: v_1.3
+    // avoid starts with _ or end with _, and avoid v_ e.g: v_1.3
+    (name+"_"+version).replaceAll("^_|_$|(v)_", "$1")
   }
 }
 
@@ -101,7 +110,7 @@ object ApiVersion {
       ukOpenBankingV200 ::
       ukOpenBankingV310 ::
       apiBuilder::
-      ScannedApis.versionMapScannedApis.keysIterator.toList
+      ScannedApis.versionMapScannedApis.keysIterator.toList // all the scanned version
 
   def valueOf(value: String): ApiVersion = {
     versions.filter(_.vDottedApiVersion == value) match {

--- a/src/main/scala/code/api/util/ScannedApis.scala
+++ b/src/main/scala/code/api/util/ScannedApis.scala
@@ -6,6 +6,9 @@ import net.liftweb.http.LiftRules
 
 import scala.collection.mutable.ArrayBuffer
 
+/**
+  * any object extends this trait will be scanned and register the allResourceDocs and routes
+  */
 trait ScannedApis extends LiftRules.DispatchPF {
   val apiVersion: ScannedApiVersion
   lazy val version: ApiVersion = this.apiVersion
@@ -15,5 +18,8 @@ trait ScannedApis extends LiftRules.DispatchPF {
 }
 
 object ScannedApis {
-  lazy val versionMapScannedApis: Map[ScannedApiVersion, ScannedApis] = ClassScanUtils.getImplementClass(classOf[ScannedApis]).map(it=> (it.apiVersion, it)).toMap
+  /**
+    * this map value are all scanned objects those extends ScannedApiVersion, the key is it apiVersion field
+    */
+  lazy val versionMapScannedApis: Map[ScannedApiVersion, ScannedApis] = ClassScanUtils.getSubTypeObjects(classOf[ScannedApis]).map(it=> (it.apiVersion, it)).toMap
 }


### PR DESCRIPTION
1.  every swagger api have tag, so the tag should create dynamic.
2. add doc comments for class scan related methods.
