### PR TITLE
Remove "" appearing on default install 

### DIFF
--- a/src/main/resources/props/sample.props.template
+++ b/src/main/resources/props/sample.props.template
@@ -260,7 +260,7 @@ webui_index_page_about_section_text = <p class="about-text"> \
                                       </p>
 
 # Top text appears on default.html For branding next to logo(s)
-webui_top_text=""
+webui_top_text=
 
 
 


### PR DESCRIPTION
(props webui_top_text was set to `webui_top_text=""`, which is unnecessary, it simply needs to be `webui_top_text=`)