### PR TITLE
Feature/filter endpoint private accounts at one bank

### DIFF
--- a/obp-api/src/main/scala/code/api/v2_0_0/AccountsHelper.scala
+++ b/obp-api/src/main/scala/code/api/v2_0_0/AccountsHelper.scala
@@ -1,0 +1,65 @@
+package code.api.v2_0_0
+
+import code.api.util.ErrorMessages.InvalidFilterParameterFormat
+import code.api.util.{CallContext, NewStyle}
+import code.util.Helper
+import com.openbankproject.commons.model.{BankIdAccountId, CoreAccount}
+import net.liftweb.http.Req
+
+import scala.collection.immutable.{List, Nil}
+import scala.concurrent.Future
+
+/**
+  * this helper is make sure some common value or function can be used by different APIMethodsXxx
+  * because they are in different scope, any value defined in one trait, can't be access by others, just copy
+  * pass cause duplicated code.
+  */
+object AccountsHelper {
+  // accountTypeFilter doc part text
+  val accountTypeFilterText =
+    """
+      |optional request parameters:
+      |
+      |* account_type_filter: one or many accountType value, split by comma
+      |* account_type_filter_operation: the filter type of account_type_filter, value must be INCLUDE or EXCLUDE
+      |
+      |whole url example:
+      |/banks/BANK_ID/accounts/private?account_type_filter=330,CURRENT+PLUS&account_type_filter_operation=INCLUDE
+    """.stripMargin
+
+
+  /**
+    * get parameter of account_type_filter_operation and account_type_filter_operation, do filter with CoreAccount#accountType
+    * @param coreAccounts list of CoreAccount, to do filter
+    * @param req request
+    * @return result after do filter
+    */
+  private def filterWithAccountType(coreAccounts: List[CoreAccount], req: Req): List[CoreAccount] = {
+    val filters = req.params.get("account_type_filter").map(_.flatMap(_.split(","))).getOrElse(Nil)
+    val filtersOperation = req.params.get("account_type_filter_operation").flatMap(_.headOption).getOrElse("INCLUDE")
+    Helper.booleanToFuture(failMsg = s"""$InvalidFilterParameterFormat request parameter account_type_filter_operation is: ${filtersOperation} """) {
+      filtersOperation == "INCLUDE" || filtersOperation == "EXCLUDE"
+    }
+    coreAccounts.filter({ account =>
+      (filters, filtersOperation) match {
+        case (f, "INCLUDE") if f.nonEmpty => filters.contains(account.accountType)
+        case (f, "EXCLUDE") if f.nonEmpty => !filters.contains(account.accountType)
+        case _ => true
+      }
+    })
+  }
+
+  /**
+    * get CoreAccount and the result is filtered according request parameter: account_type_filter_operation and account_type_filter_operatio
+    * @param bankIdAcountIds list of BankIdAccountId
+    * @param req http request
+    * @param callContext callContext
+    * @return list of CoreAccount Future
+    */
+  def getFilteredCoreAccounts(bankIdAcountIds: List[BankIdAccountId], req: Req, callContext: Option[CallContext]): Future[(List[CoreAccount], Option[CallContext])] = {
+    NewStyle.function.getCoreBankAccountsFuture(bankIdAcountIds, callContext) map { it =>
+      val (coreAccounts, cc) = it
+      (filterWithAccountType(coreAccounts, req), cc)
+    }
+  }
+}

--- a/obp-api/src/main/scala/code/api/v2_0_0/AccountsHelper.scala
+++ b/obp-api/src/main/scala/code/api/v2_0_0/AccountsHelper.scala
@@ -9,6 +9,8 @@ import net.liftweb.http.Req
 import scala.collection.immutable.{List, Nil}
 import scala.concurrent.Future
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 /**
   * this helper is make sure some common value or function can be used by different APIMethodsXxx
   * because they are in different scope, any value defined in one trait, can't be access by others, just copy

--- a/obp-api/src/main/scala/code/api/v3_0_0/APIMethods300.scala
+++ b/obp-api/src/main/scala/code/api/v3_0_0/APIMethods300.scala
@@ -30,7 +30,7 @@ import com.github.dwickern.macros.NameOf.nameOf
 import com.grum.geocalc.{Coordinate, EarthCalc, Point}
 import com.openbankproject.commons.model._
 import net.liftweb.common._
-import net.liftweb.http.S
+import net.liftweb.http.{Req, S}
 import net.liftweb.http.js.JE.JsRaw
 import net.liftweb.http.rest.RestHelper
 import net.liftweb.json.{Extraction, compactRender}
@@ -40,6 +40,8 @@ import scala.collection.immutable.{List, Nil}
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+
+import code.api.v2_0_0.AccountsHelper._
 
 
 trait APIMethods300 {
@@ -423,7 +425,9 @@ trait APIMethods300 {
       s"""Returns the list of accounts containing private views for the user.
          |Each account lists the views available to the user.
          |
-        |${authenticationRequiredMessage(true)}
+         |$accountTypeFilterText
+         |
+         |${authenticationRequiredMessage(true)}
          |""",
       emptyObjectJson,
       coreAccountsJsonV300,
@@ -439,12 +443,12 @@ trait APIMethods300 {
 
     lazy val corePrivateAccountsAllBanks : OBPEndpoint = {
       //get private accounts for all banks
-      case "my" :: "accounts" :: Nil JsonGet _ => {
+      case "my" :: "accounts" :: Nil JsonGet req => {
         cc =>
           for {
             (Full(u), callContext) <- authorizedAccess(cc)
             availablePrivateAccounts <- Views.views.vend.getPrivateBankAccountsFuture(u)
-            (coreAccounts, callContext) <- NewStyle.function.getCoreBankAccountsFuture(availablePrivateAccounts, callContext)
+            (coreAccounts, callContext) <- getFilteredCoreAccounts(availablePrivateAccounts, req, callContext)
           } yield {
             (JSONFactory300.createCoreAccountsByCoreAccountsJSON(coreAccounts), HttpCode.`200`(callContext))
           }
@@ -1568,7 +1572,7 @@ trait APIMethods300 {
         }
       }
     }
-  
+
     resourceDocs += ResourceDoc(
       privateAccountsAtOneBank,
       implementedInApiVersion,
@@ -1581,13 +1585,7 @@ trait APIMethods300 {
          |
          |If you want to see more information on the Views, use the Account Detail call.
          |
-         |optional request parameters:
-         |
-         |* account_type_filter: one or many accountType value, split by comma
-         |* account_type_filter_operation: the filter type of account_type_filter, value must be INCLUDE or EXCLUDE
-         |
-         |whole url example:
-         |/banks/BANK_ID/accounts/private?account_type_filter=330,CURRENT+PLUS&account_type_filter_operation=INCLUDE
+         |$accountTypeFilterText
          |
          |${authenticationRequiredMessage(true)}""",
       emptyObjectJson,
@@ -1604,26 +1602,10 @@ trait APIMethods300 {
           for {
             (Full(u), callContext) <- authorizedAccess(cc)
             (_, callContext) <- NewStyle.function.getBank(bankId, callContext)
-
-            accountTypeFilter = req.params.get("account_type_filter").map(_.flatMap(_.split(",")))
-            accountTypeFilterOperation = req.params.get("account_type_filter_operation").flatMap(_.headOption).getOrElse("INCLUDE")
-            _ <- Helper.booleanToFuture(failMsg = s"""$InvalidFilterParameterFormat request parameter account_type_filter_operation is: ${accountTypeFilterOperation} """) {
-              accountTypeFilterOperation == "INCLUDE" || accountTypeFilterOperation == "EXCLUDE"
-            }
-
             availablePrivateAccounts <- Views.views.vend.getPrivateBankAccountsFuture(u, bankId)
-            ((accounts, callContext)) <- Connector.connector.vend.getCoreBankAccounts(availablePrivateAccounts, callContext) map {
-              connectorEmptyResponse(_, callContext)
-            }
+            (accounts, callContext) <- getFilteredCoreAccounts(availablePrivateAccounts, req, callContext)
           } yield {
-            val filteredAccounts = accounts.filter(account => {
-              (accountTypeFilter, accountTypeFilterOperation) match {
-                case (Some(filters), "INCLUDE") if filters.nonEmpty => filters.contains(account.accountType)
-                case (Some(filters), "EXCLUDE") if filters.nonEmpty => !filters.contains(account.accountType)
-                case _ => true
-              }
-            })
-            (JSONFactory300.createCoreAccountsByCoreAccountsJSON(filteredAccounts), HttpCode.`200`(callContext))
+            (JSONFactory300.createCoreAccountsByCoreAccountsJSON(accounts), HttpCode.`200`(callContext))
           }
       }
     }
@@ -1643,6 +1625,7 @@ trait APIMethods300 {
          |
          |If you want to see more information on the Views, use the Account Detail call.
          |
+         |$accountTypeFilterText
          |
          |${authenticationRequiredMessage(true)}""",
       emptyObjectJson,
@@ -1660,8 +1643,12 @@ trait APIMethods300 {
             (Full(u), callContext) <- authorizedAccess(cc)
              (_, callContext)<- NewStyle.function.getBank(bankId, callContext)
             bankAccountIds <- Views.views.vend.getPrivateBankAccountsFuture(u, bankId)
+            bankIdAccountIds <- getFilteredCoreAccounts(bankAccountIds, req, callContext).map { it=>
+              val accountIds = it._1.map(_.id)
+              accountIds.map(accountId => BankIdAccountId(bankId, AccountId(accountId)))
+            }
           } yield {
-            (JSONFactory300.createAccountsIdsByBankIdAccountIds(bankAccountIds), HttpCode.`200`(callContext))
+            (JSONFactory300.createAccountsIdsByBankIdAccountIds(bankIdAccountIds), HttpCode.`200`(callContext))
           }
       }
     }
@@ -2042,6 +2029,7 @@ trait APIMethods300 {
         |
         |Can be used to onboard the account to the API - since all other account and transaction endpoints require views to be assigned.
         |
+        |$accountTypeFilterText
         |
         |${authenticationRequiredMessage(true)}
       """,
@@ -2060,8 +2048,13 @@ trait APIMethods300 {
             (_, callContext) <- NewStyle.function.getBank(bankId, callContext)
             availableAccounts <- Future{ AccountHolders.accountHolders.vend.getAccountsHeld(bankId, u)}
             (accounts, callContext) <- NewStyle.function.getBankAccountsHeldFuture(availableAccounts.toList, callContext)
+
+            accountHelds <- getFilteredCoreAccounts(availableAccounts.toList, req, callContext).map { it =>
+              val coreAccountIds: List[String] = it._1.map(_.id)
+              accounts.filter(accountHeld =>coreAccountIds.contains(accountHeld.id))
+            }
           } yield {
-            (JSONFactory300.createCoreAccountsByCoreAccountsJSON(accounts), HttpCode.`200`(callContext))
+            (JSONFactory300.createCoreAccountsByCoreAccountsJSON(accountHelds), HttpCode.`200`(callContext))
           }
       }
     }

--- a/obp-api/src/main/scala/code/api/v3_1_0/JSONFactory3.1.0.scala
+++ b/obp-api/src/main/scala/code/api/v3_1_0/JSONFactory3.1.0.scala
@@ -34,9 +34,9 @@ import code.api.util.APIUtil.{stringOptionOrNull, stringOrNull}
 import code.api.util.RateLimitPeriod.LimitCallPeriod
 import code.api.util.{APIUtil, RateLimitPeriod}
 import code.api.v1_2_1.JSONFactory.{createAmountOfMoneyJSON, createOwnersJSON}
-import code.api.v1_2_1.{ModeratedAccountJSON, RateLimiting, UserJSONV121, ViewJSONV121}
+import code.api.v1_2_1.{RateLimiting, UserJSONV121, ViewJSONV121}
 import code.api.v1_3_0.JSONFactory1_3_0._
-import code.api.v1_3_0.{PhysicalCardJSON, PinResetJSON, ReplacementJSON}
+import code.api.v1_3_0.{PinResetJSON, ReplacementJSON}
 import com.openbankproject.commons.model.AmountOfMoneyJsonV121
 import code.api.v1_4_0.JSONFactory1_4_0.{CustomerFaceImageJson, MetaJsonV140}
 import code.api.v2_0_0.{MeetingKeysJson, MeetingPresentJson}
@@ -44,7 +44,7 @@ import code.api.v2_1_0.JSONFactory210.createLicenseJson
 import code.api.v2_1_0.{CustomerCreditRatingJSON, ResourceUserJSON}
 import code.api.v2_2_0._
 import code.api.v3_0_0.JSONFactory300.{createAccountRoutingsJSON, createAccountRulesJSON}
-import code.api.v3_0_0.{AccountRuleJsonV300, ModeratedCoreAccountJsonV300}
+import code.api.v3_0_0.{AccountRuleJsonV300}
 import code.consent.MappedConsent
 import code.context.UserAuthContextUpdate
 import code.entitlement.Entitlement


### PR DESCRIPTION
Add the filter to the other endpoints that return a list of accounts: https://apiexplorersandbox.openbankproject.com/?tags=#OBPv3_0_0-getPrivateAccountIdsbyBankId
https://apiexplorersandbox.openbankproject.com/?tags=#OBPv3_0_0-privateAccountsAtOneBank
https://apiexplorersandbox.openbankproject.com/?tags=#OBPv2_0_0-getPrivateAccountsAtOneBank

https://apiexplorersandbox.openbankproject.com/?tags=#OBPv3_0_0-corePrivateAccountsAllBanks
https://apiexplorersandbox.openbankproject.com/?tags=#OBPv3_0_0-getAccountsHeld

[here is jenkins job ](https://jenkins.tesobe.com/job/Build-OBP-API-shuang/67/)

and passed manual test