### PR TITLE
create direct login tokens for dummy customers

### DIFF
--- a/obp-api/src/main/resources/props/sample.props.template
+++ b/obp-api/src/main/resources/props/sample.props.template
@@ -423,6 +423,9 @@ webui_dummy_customer_logins = Customer Logins\
                               \
                               Please ask a member of the Open Bank Project team for more logins if you require. You can use this [application](https://sofit.openbankproject.com) which also uses OAuth to browse your transaction data (use the above username/password).\
 
+# when this value is set to true and webui_dummy_customer_logins value not empty, the register consumer key success page will show dummy customers Direct Login tokens.
+webui_show_dummy_customer_tokens=false
+
 # when developer register the consumer successfully, it will show this message to developer on the webpage or email. 
 webui_register_consumer_success_message_webpage = Thanks for registering your consumer with the Open Bank Project API! Here is your developer information. Please save it in a secure location.
 webui_register_consumer_success_message_email = Thank you for registering to use the Open Bank Project API.

--- a/obp-api/src/main/scala/code/api/OBPRestHelper.scala
+++ b/obp-api/src/main/scala/code/api/OBPRestHelper.scala
@@ -266,7 +266,7 @@ trait OBPRestHelper extends RestHelper with MdcLoggable {
           fn(cc.copy(user = Full(u), consumer=consumer))
         }// Authentication is successful
         case _ => {
-          var (httpCode, message, directLoginParameters) = DirectLogin.validator("protectedResource", DirectLogin.getHttpMethod)
+          var (httpCode, message, directLoginParameters) = DirectLogin.validator("protectedResource")
           Full(errorJsonResponse(message, httpCode))
         }
       }

--- a/obp-api/src/main/webapp/consumer-registration.html
+++ b/obp-api/src/main/webapp/consumer-registration.html
@@ -134,10 +134,14 @@ Berlin 13359, Germany
 				<div class="col-xs-12 col-sm-4">Direct Login Endpoint</div>
 				<div class="col-xs-12 col-sm-8"><span id="directlogin-endpoint"><a href="#">endpoint</a></span></div>
 			</div>
+			<div class="row preparedTokens">
+				<div class="col-xs-12 col-sm-4">Prepared user tokens</div>
+				<div class="col-xs-12 col-sm-8" id="preparedTokens"></div>
+			</div>
 			<div class="row">
 				<div class="col-xs-12 col-sm-4">Direct Login Documentation</div>
 				<div class="col-xs-12 col-sm-8"><a href="https://github.com/OpenBankProject/OBP-API/wiki/Direct-Login">How to use Direct Login</a>
-</div>
+			</div>
 			</div>
 			<div class="row">
 				<div class="col-xs-12 col-sm-4"></div>


### PR DESCRIPTION
This is for hackathon, to create direct login tokens for dummy customers.
when the
1.  `webui_dummy_customer_logins` property value is not empty
2. `webui_show_dummy_customer_tokens=true`, 
the  consumer-registration.html page will shown direct login tokens for dummy customers.