### PR TITLE
bugfix, fix dynamicEntity example type validation

### DIFF
--- a/obp-api/src/main/scala/code/api/util/ExampleValue.scala
+++ b/obp-api/src/main/scala/code/api/util/ExampleValue.scala
@@ -2,7 +2,7 @@ package code.api.util
 
 
 import code.api.util.Glossary.{glossaryItems, makeGlossaryItem}
-import code.dynamicEntity.{DynamicEntityDefinition, DynamicEntityFooBar, DynamicEntityFullBarFields, DynamicEntityTypeExample}
+import code.dynamicEntity.{DynamicEntityDefinition, DynamicEntityFooBar, DynamicEntityFullBarFields, DynamicEntityIntTypeExample, DynamicEntityStringTypeExample}
 import com.openbankproject.commons.model.enums.DynamicEntityFieldType
 
 case class ConnectorField(value: String, description: String) {
@@ -311,8 +311,8 @@ object ExampleValue {
     DynamicEntityDefinition(
       List("name"),
       DynamicEntityFullBarFields(
-        DynamicEntityTypeExample(DynamicEntityFieldType.string, "James Brown"),
-        DynamicEntityTypeExample(DynamicEntityFieldType.integer, "698761728934")
+        DynamicEntityStringTypeExample(DynamicEntityFieldType.string, "James Brown"),
+        DynamicEntityIntTypeExample(DynamicEntityFieldType.integer, 698761728)
       )
     )
   )

--- a/obp-api/src/main/scala/code/dynamicEntity/DynamicEntityProvider.scala
+++ b/obp-api/src/main/scala/code/dynamicEntity/DynamicEntityProvider.scala
@@ -168,19 +168,15 @@ object DynamicEntityCommons extends Converter[DynamicEntityT, DynamicEntityCommo
       // example is exists
       val fieldExample = value \ "example"
       checkFormat(fieldExample != JNothing, s"$InvalidJsonFormat The property of $fieldName's 'example' field should be exists")
+      // example type is correct
+      val dEntityFieldType: DynamicEntityFieldType = DynamicEntityFieldType.withName(fieldType.asInstanceOf[JString].s)
+      checkFormat(dEntityFieldType.isJValueValid(fieldExample), s"$InvalidJsonFormat The property of $fieldName's 'example' field should be type $dEntityFieldType")
     })
 
     DynamicEntityCommons(entityName, compactRender(jsonObject), dynamicEntityId)
   }
 
-  private val allowedFieldType: Set[String] = Set(
-      "string",
-      "number",
-      "integer",
-      "boolean",
-      "array",
-//      "object",
-  )
+  private val allowedFieldType: Set[String] = DynamicEntityFieldType.values.map(_.toString).toSet
 }
 
 /**
@@ -189,8 +185,9 @@ object DynamicEntityCommons extends Converter[DynamicEntityT, DynamicEntityCommo
  */
 case class DynamicEntityFooBar(FooBar: DynamicEntityDefinition, dynamicEntityId: Option[String] = None)
 case class DynamicEntityDefinition(required: List[String],properties: DynamicEntityFullBarFields)
-case class DynamicEntityFullBarFields(name: DynamicEntityTypeExample, number: DynamicEntityTypeExample)
-case class DynamicEntityTypeExample(`type`: DynamicEntityFieldType, example: String)
+case class DynamicEntityFullBarFields(name: DynamicEntityStringTypeExample, number: DynamicEntityIntTypeExample)
+case class DynamicEntityStringTypeExample(`type`: DynamicEntityFieldType, example: String)
+case class DynamicEntityIntTypeExample(`type`: DynamicEntityFieldType, example: Int)
 //-------------------example case class end
 
 

--- a/obp-api/src/test/scala/code/api/v4_0_0/DynamicEntityTest.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/DynamicEntityTest.scala
@@ -66,7 +66,7 @@ class DynamicEntityTest extends V400ServerSetup {
       |            },
       |            "number": {
       |                "type": "integer",
-      |                "example": "698761728934"
+      |                "example": 69876172
       |            }
       |        }
       |    }
@@ -87,7 +87,7 @@ class DynamicEntityTest extends V400ServerSetup {
       |           },
       |           "number": {
       |               "type": "integer",
-      |               "example": "698761728934"
+      |               "example": 69876172
       |           }
       |       }
       |   }

--- a/obp-commons/src/main/scala/com/openbankproject/commons/model/enums/Enumerations.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/model/enums/Enumerations.scala
@@ -1,6 +1,11 @@
 package com.openbankproject.commons.model.enums
 
 import com.openbankproject.commons.util.{EnumValue, OBPEnumeration}
+import net.liftweb.json.{JArray, JBool, JDouble, JInt, JObject, JValue}
+import net.liftweb.json.JsonAST.JString
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
 
 sealed trait AccountAttributeType extends EnumValue
 object AccountAttributeType extends OBPEnumeration[AccountAttributeType]{
@@ -46,14 +51,17 @@ object PemCertificateRole extends OBPEnumeration[PemCertificateRole] {
 }
 //------api enumerations end ----
 
-sealed trait DynamicEntityFieldType extends EnumValue
+sealed trait DynamicEntityFieldType extends EnumValue {
+  val jValueType: Class[_]
+  def isJValueValid(jValue: JValue): Boolean = jValueType.isInstance(jValue)
+}
 object DynamicEntityFieldType extends OBPEnumeration[DynamicEntityFieldType]{
- object string  extends Value
- object number extends Value
- object integer extends Value
- object boolean extends Value
-// object array extends Value
-// object `object` extends Value //TODO in the future, we consider support nested type
+ object string  extends Value{val jValueType = classOf[JString]}
+ object number  extends Value{val jValueType = classOf[JDouble]}
+ object integer extends Value{val jValueType = classOf[JInt]}
+ object boolean extends Value{val jValueType = classOf[JBool]}
+ //object array extends Value{val jValueType = classOf[JArray]}
+ //object `object` extends Value{val jValueType = classOf[JObject]} //TODO in the future, we consider support nested type
 }
 
 /**


### PR DESCRIPTION
Fix bug of `The following dynamic entity with incompatible type and example causes resource doc endpoint failure and thus API Explorer failure. `:

```
{
    "dynamic_entities": [
        {
            "LendingClub": {
                "required": [
                    "FICO"
                ],
                "properties": {
                    "FICO": {
                        "type": "integer",
                        "example": "James Brown"
                    },
                    "Amount": {
                        "type": "integer",
                        "example": "698761728934"
                    }
                }
            },
            "dynamicEntityId": "85787b7f-e809-4867-b7c0-02ad77319c0d"
        }
    ]
}
```
the "FICO" example is not integer.


waiting for jenkins job pass.