### PR TITLE
feature, make compatible with JDK 8, 10, 11, 12, 13

### DIFF
--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -410,7 +410,6 @@
         <!-- enable the scalatest plugin -->
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>1.0</version>
         <configuration>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
             <forkMode>once</forkMode>

--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -450,7 +450,6 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>3.4.6</version>
           <configuration>
             <charset>${project.build.sourceEncoding}</charset>
             <jvmArgs>
@@ -592,8 +591,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
     </plugins>
@@ -603,7 +601,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.4.6</version>
         <configuration>
           <charset>${project.build.sourceEncoding}</charset>
           <jvmArgs>

--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>9.4.1211</version>
+      <version>42.2.8</version>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
@@ -150,14 +150,15 @@
       <version>${lift.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-java</artifactId>
-      <version>2.52.0</version>
+      <groupId>cglib</groupId>
+      <artifactId>cglib</artifactId>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
-      <artifactId>selenium-htmlunit-driver</artifactId>
-      <version>2.52.0</version>
+      <artifactId>htmlunit-driver</artifactId>
+      <version>2.36.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -165,9 +166,15 @@
       <version>4.5.2</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
       <groupId>net.sourceforge.htmlunit</groupId>
       <artifactId>htmlunit</artifactId>
-      <version>2.21</version>
+      <version>2.36.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.liftmodules</groupId>
@@ -580,7 +587,16 @@
             <failOnNoGitDirectory>false</failOnNoGitDirectory>
           </configuration>
         </plugin>
-      </plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
   <reporting>
     <plugins>

--- a/obp-api/src/main/scala/code/api/util/CustomJsonFormats.scala
+++ b/obp-api/src/main/scala/code/api/util/CustomJsonFormats.scala
@@ -1,7 +1,5 @@
 package code.api.util
 
-import java.util.regex.Pattern
-
 import code.api.util.ApiRole.rolesMappedToClasses
 import code.api.v3_1_0.ListResult
 import com.openbankproject.commons.model.JsonFieldReName

--- a/obp-commons/pom.xml
+++ b/obp-commons/pom.xml
@@ -60,7 +60,6 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.2</version>
                 <configuration>
                     <charset>${project.build.sourceEncoding}</charset>
                     <jvmArgs>

--- a/obp-commons/pom.xml
+++ b/obp-commons/pom.xml
@@ -97,7 +97,6 @@
                 <!-- enable the scalatest plugin -->
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
-                <version>1.0</version>
                 <configuration>
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <forkMode>once</forkMode>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
           <artifactId>scala-maven-plugin</artifactId>
           <version>4.2.4</version>
         </plugin>
+        <plugin>
+          <groupId>org.scalatest</groupId>
+          <artifactId>scalatest-maven-plugin</artifactId>
+          <version>2.0.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <inceptionYear>2011</inceptionYear>
   <properties>
     <scala.version>2.12</scala.version>
-    <scala.compiler>2.12.4</scala.compiler>
+    <scala.compiler>2.12.10</scala.compiler>
     <akka.version>2.5.19</akka.version>
     <akka-streams-kafka.version>0.22</akka-streams-kafka.version>
     <kafka.version>1.1.0</kafka.version>
@@ -102,6 +102,15 @@
   </dependencyManagement>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>net.alchim31.maven</groupId>
+          <artifactId>scala-maven-plugin</artifactId>
+          <version>4.2.4</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -114,7 +123,6 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>3.4.6</version>
           <configuration>
             <charset>${project.build.sourceEncoding}</charset>
             <jvmArgs>
@@ -232,7 +240,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.4.6</version>
         <configuration>
           <charset>${project.build.sourceEncoding}</charset>
           <jvmArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,11 @@
     <maven.scaladoc.vscaladocVersion>1.2-m1</maven.scaladoc.vscaladocVersion>
     <vscaladoc.links.liftweb.pathsufix>scaladocs/</vscaladoc.links.liftweb.pathsufix>
     <vscaladoc.links.liftweb.baseurl>http://scala-tools.org/mvnsites/liftweb</vscaladoc.links.liftweb.baseurl>
+
+    <!--java version, can be: [8,9,10,11,12,13]-->
+    <java.version>13</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
   </properties>
 
   <modules>


### PR DESCRIPTION
This makes much bigger modify, make obp-api compatible with JDK8, 10, 11, 12, 13.
[JKD8 Jenkins job passed](https://jenkins.tesobe.com/job/Build-OBP-API-shuang/151/).
[JDK13 Jenkins job passed](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13/16/).

And fix some bugs in unit test: code.api.v3_1_0.ResourceDocsTest