### PR TITLE
remove bankId in the json body for `createProduct`.

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -2439,7 +2439,6 @@ object SwaggerDefinitionsJSON {
     meta = metaJson
   )
   val postPutProductJsonV310 = PostPutProductJsonV310(
-    bank_id = bankIdExample.value,
     name = "product name",
     parent_product_code = "parent product name",
     category = "category",

--- a/obp-api/src/main/scala/code/api/v3_1_0/APIMethods310.scala
+++ b/obp-api/src/main/scala/code/api/v3_1_0/APIMethods310.scala
@@ -2524,7 +2524,7 @@ trait APIMethods310 {
                 }
             }
             success <- Future(Connector.connector.vend.createOrUpdateProduct(
-              bankId = product.bank_id,
+              bankId = bankId.value,
               code = productCode.value,
               parentProductCode = parentProductCode.map(_.code.value).toOption,
               name = product.name,

--- a/obp-api/src/main/scala/code/api/v3_1_0/JSONFactory3.1.0.scala
+++ b/obp-api/src/main/scala/code/api/v3_1_0/JSONFactory3.1.0.scala
@@ -410,7 +410,7 @@ case class AccountApplicationsJsonV310(account_applications: List[AccountApplica
 
 case class RateLimitingInfoV310(enabled: Boolean, technology: String, service_available: Boolean, is_active: Boolean)
 
-case class PostPutProductJsonV310(bank_id: String,
+case class PostPutProductJsonV310(
                                   name : String,
                                   parent_product_code : String,
                                   category: String,

--- a/obp-api/src/test/scala/code/api/v3_1_0/ProductCollectionTest.scala
+++ b/obp-api/src/test/scala/code/api/v3_1_0/ProductCollectionTest.scala
@@ -59,7 +59,7 @@ class ProductCollectionTest extends V310ServerSetup {
   lazy val testBankId = randomBankId
   lazy val putProductCollectionsV310 = SwaggerDefinitionsJSON.putProductCollectionsV310.copy(parent_product_code = "A", children_product_codes = List("B", "C", "D"))
 
-  lazy val parentPostPutProductJsonV310: PostPutProductJsonV310 = SwaggerDefinitionsJSON.postPutProductJsonV310.copy(bank_id = testBankId, parent_product_code ="")
+  lazy val parentPostPutProductJsonV310: PostPutProductJsonV310 = SwaggerDefinitionsJSON.postPutProductJsonV310.copy(parent_product_code ="")
   def createProduct(code: String, json: PostPutProductJsonV310) = {
     When("We try to create a product v3.1.0")
     val request310 = (v3_1_0_Request / "banks" / testBankId / "products" / code).PUT <@ (user1)
@@ -69,7 +69,7 @@ class ProductCollectionTest extends V310ServerSetup {
     val product = response310.body.extract[ProductJsonV310]
     product.code shouldBe code
     product.parent_product_code shouldBe json.parent_product_code
-    product.bank_id shouldBe json.bank_id
+    product.bank_id shouldBe testBankId
     product.name shouldBe json.name
     product.category shouldBe json.category
     product.super_family shouldBe json.super_family

--- a/obp-api/src/test/scala/code/api/v3_1_0/ProductTest.scala
+++ b/obp-api/src/test/scala/code/api/v3_1_0/ProductTest.scala
@@ -64,7 +64,7 @@ class ProductTest extends V310ServerSetup {
   object ApiEndpoint4 extends Tag(nameOf(Implementations3_1_0.getProductTree))
 
   lazy val testBankId = randomBankId
-  lazy val parentPostPutProductJsonV310: PostPutProductJsonV310 = SwaggerDefinitionsJSON.postPutProductJsonV310.copy(bank_id = testBankId, parent_product_code ="")
+  lazy val parentPostPutProductJsonV310: PostPutProductJsonV310 = SwaggerDefinitionsJSON.postPutProductJsonV310.copy(parent_product_code ="")
 
   feature("Create Product v3.1.0") {
     scenario("We will call the Add endpoint without a user credentials", ApiEndpoint1, VersionOfApi) {
@@ -97,7 +97,7 @@ class ProductTest extends V310ServerSetup {
       val product = response310.body.extract[ProductJsonV310]
       product.code shouldBe code
       product.parent_product_code shouldBe json.parent_product_code
-      product.bank_id shouldBe json.bank_id
+      product.bank_id shouldBe testBankId
       product.name shouldBe json.name
       product.category shouldBe json.category
       product.super_family shouldBe json.super_family


### PR DESCRIPTION
#before, the bankId both in URL and Json body. But we only check the role
#for the bankId in the URL, not in the json body. So once we create a role
#for one bank, we can create the products for all banks. it is a issue.