### PR TITLE
bugfix/create_new_bank_not_create_corresponding_CanCreateEntitlementAtOneBank

### DIFF
--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -1584,7 +1584,8 @@ trait APIMethods400 {
               callContext
               )
             entitlements <- NewStyle.function.getEntitlementsByUserId(u.userId, callContext)
-            _ <- entitlements.filter(_.roleName == CanCreateEntitlementAtOneBank.toString()).size > 0 match {
+            entitlementsByBank = entitlements.filter(_.bankId==bank.id)
+            _ <- entitlementsByBank.filter(_.roleName == CanCreateEntitlementAtOneBank.toString()).size > 0 match {
               case true =>
                 // Already has entitlement
                 Future()


### PR DESCRIPTION
# bug description:
When current user have entitlement` CanCreateEntitlementAtOneBank`.
When create new bank, there is not create a new `CanCreateEntitlementAtOneBank` with the new `bank_id`.


[Jenkins job is passed](https://jenkins.tesobe.com/job/Build-OBP-API-shuang/166/), ready to merge.