### PR TITLE
bugfix: Boot cant rest props path

### DIFF
--- a/obp-api/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/obp-api/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -105,6 +105,7 @@ import code.webhook.{MappedAccountWebhook, WebhookHelperActors}
 import code.webuiprops.WebUiProps
 import com.openbankproject.commons.model.ErrorMessage
 import com.openbankproject.commons.util.ApiVersion
+import com.openbankproject.commons.util.Functions.Implicits._
 import javax.mail.internet.MimeMessage
 import net.liftweb.common._
 import net.liftweb.db.DBLogEntry
@@ -119,22 +120,18 @@ import net.liftweb.util.{Helpers, Props, Schedule, _}
 
 import scala.concurrent.ExecutionContext
 
-
 /**
  * A class that's instantiated early and run.  It allows the application
  * to modify lift's environment
  */
 class Boot extends MdcLoggable {
-  
-  def boot {
 
-    val contextPath = LiftRules.context.path
-    val propsPath = tryo{Box.legacyNullTest(System.getProperty("props.resource.dir"))}.toIterable.flatten
-
-    if (Props.mode == Props.RunModes.Development) logger.info("OBP-API Props all fields : \n" + Props.props.mkString("\n"))
-    logger.info("external props folder: " + propsPath)
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
-    logger.info("Current Project TimeZone: " + TimeZone.getDefault)
+  /**
+   * For the project scope, most early initiate logic should in this method.
+   */
+  override protected def initiate(): Unit = {
+    val resourceDir = System.getProperty("props.resource.dir") ?: System.getenv("props.resource.dir")
+    val propsPath = tryo{Box.legacyNullTest(resourceDir)}.toList.flatten
 
     /**
      * Where this application looks for props files:
@@ -167,6 +164,7 @@ class Boot extends MdcLoggable {
     } yield {
       Props.toTry.map {
         f => {
+          val contextPath = LiftRules.context.path
           val name = propsPath + contextPath + f() + "props"
           name -> { () => tryo{new FileInputStream(new File(name))} }
         }
@@ -185,9 +183,17 @@ class Boot extends MdcLoggable {
     }
 
     Props.whereToLook = () => {
-      firstChoicePropsDir.flatten.toList ::: secondChoicePropsDir.flatten.toList
+      (firstChoicePropsDir ::: secondChoicePropsDir).flatten
     }
 
+    if (Props.mode == Props.RunModes.Development) logger.info("OBP-API Props all fields : \n" + Props.props.mkString("\n"))
+    logger.info("external props folder: " + propsPath)
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+    logger.info("Current Project TimeZone: " + TimeZone.getDefault)
+  }
+
+
+  def boot {
     // set up the way to connect to the relational DB we're using (ok if other connector than relational)
     if (!DB.jndiJdbcConnAvailable_?) {
       val driver =

--- a/obp-api/src/main/scala/code/util/Helper.scala
+++ b/obp-api/src/main/scala/code/util/Helper.scala
@@ -327,6 +327,9 @@ object Helper{
   }
 
   trait MdcLoggable extends Loggable {
+    protected def initiate(): Unit = ()
+
+    initiate()
     MDC.put("host" -> getHostname)
   }
 


### PR DESCRIPTION
The Boot.scala already has the code of reset props files path, but not work.
This pull request just fixed this bug.
By setting the VM parameter or we can reset the path of the props.
![image](https://user-images.githubusercontent.com/2577334/74544779-af15b680-4f82-11ea-9732-2e79e7502a98.png)
