### PR TITLE
feature/dynamic_endpoint_path_variable_and_error_message

### DIFF
--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
@@ -74,7 +74,7 @@ object DynamicEndpointHelper extends RestHelper {
     private val ExpressionRegx = """\{(.+?)\}""".r
     /**
      * unapply Request to (request url, json, http method, request parameters, path parameters, role)
-     * request url is  current request url
+     * request url is  current request target url to remote server
      * json is request body
      * http method is request http method
      * request parameters is http request parameters

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
@@ -220,7 +220,6 @@ object DynamicEndpointHelper extends RestHelper {
           ApiRole.getOrCreateDynamicApiRole(roleName)
         ))
       }
-      val connectorMethods = Some(List("dynamicEndpointProcess"))
       val doc = ResourceDoc(
         partialFunction,
         implementedInApiVersion,
@@ -234,8 +233,7 @@ object DynamicEndpointHelper extends RestHelper {
         errorResponseBodies,
         catalogs,
         tags,
-        roles,
-        connectorMethods = connectorMethods
+        roles
       )
       (doc, path)
     }

--- a/obp-api/src/main/scala/code/bankconnectors/package.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/package.scala
@@ -104,10 +104,16 @@ package object bankconnectors extends MdcLoggable {
         NewStyle.function.getMethodRoutings(Some(methodName))
           .find(routing => {
             routing.parameters.exists(it => it.key == "http_method" && it.value.equalsIgnoreCase(method.value)) &&
-              routing.parameters.exists(it => it.key == "url")&&
+              routing.parameters.exists(it => it.key == "url") &&
               routing.parameters.exists(
-                it => it.key == "url_pattern" &&
-                  (it.value == url || Pattern.compile(it.value).matcher(url).matches())
+                it => {
+                  val value = it.value
+                  it.key == "url_pattern" &&  // url_pattern is equals with current target url to remote server or as regex match
+                    (value == url || {
+                      val regexStr = value.replaceAll("""\{[^/]+?\}""", "[^/]+?")
+                      Pattern.compile(regexStr).matcher(url).matches()
+                    })
+                }
               )
           })
       }


### PR DESCRIPTION
Make the support path variable, e.g:
 ```
{
    "method_name":"dynamicEndpointProcess",
    "connector_name":"rest_vMar2019",
    "is_bank_id_exact_match":false,
    "bank_id_pattern":".*",
    "parameters":[{
      "key":"url_pattern",
      "value":"http://baishuang.space:3000/user/getById/{userId}"
    },{
      "key":"http_method",
      "value":"GET"
    },{
      "key":"url",
      "value":"http://baishuang.space:3000/user/{:userId}"
    }],
    "method_routing_id":"43412e79-3de8-4d82-9485-44d7f7b3a8dc"
  }
```
expression `{:userId}` will reference a real value in the url.
