### PR TITLE
feature/add_dynamic_endpoints_to_generated_swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,3 +510,25 @@ The same as `Frozen APIs`, if related unit test fail, make sure whether the modi
 * Advanced architecture: http://exploring.liftweb.net/master/index-9.html
 
 * A good book on Lift: "Lift in Action" by Timothy Perrett published by Manning.
+
+## Be tested JDK Version
+* OracleJDK: 1.8, 13
+* OpenJdk: 11
+
+## Endpoint Request and Response Example
+    ResourceDoc#exampleRequestBody and ResourceDoc#successResponseBody can be the follow type
+* Any Case class
+* JObject
+* Wrapper JArray: JArrayBody(jArray)
+* Wrapper String: StringBody("Hello")
+* Wrapper primary type: IntBody(1), BooleanBody(true), FloatBody(1.2F)...
+* Empty: EmptyBody
+
+example: 
+```
+resourceDocs += ResourceDoc(
+      exampleRequestBody= EmptyBody,
+      successResponseBody= BooleanBody(true),
+      ...
+)
+```

--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
@@ -13,7 +13,6 @@ import code.api.v2_2_0.{APIMethods220, OBPAPI2_2_0}
 import code.api.v3_0_0.OBPAPI3_0_0
 import code.api.v3_1_0.OBPAPI3_1_0
 import code.api.v4_0_0.{APIMethods400, OBPAPI4_0_0}
-import APIMethods400.Implementations4_0_0.genericEndpoint
 import code.api.OBPRestHelper
 import code.api.util.ApiRole.{CanReadResourceDoc, canCreateAnyTransactionRequest}
 import code.util.Helper.MdcLoggable
@@ -130,7 +129,7 @@ trait ResourceDocsAPIMethods extends MdcLoggable with APIMethods220 with APIMeth
 
       val versionRoutes = requestedApiVersion match {
         case ApiVersion.`apiBuilder`     => OBP_APIBuilder.routes
-        case ApiVersion.v4_0_0 => OBPAPI4_0_0.routes
+        case ApiVersion.v4_0_0 => APIUtil.genericEndpointStub :: OBPAPI4_0_0.routes
         case ApiVersion.v3_1_0 => OBPAPI3_1_0.routes
         case ApiVersion.v3_0_0 => OBPAPI3_0_0.routes
         case ApiVersion.v2_2_0 => OBPAPI2_2_0.routes
@@ -517,7 +516,7 @@ trait ResourceDocsAPIMethods extends MdcLoggable with APIMethods220 with APIMeth
           val jsonOut = for {
             requestedApiVersion <- Full(ApiVersionUtils.valueOf(requestedApiVersionString)) ?~! InvalidApiVersionString
             _ <- booleanToBox(versionIsAllowed(requestedApiVersion), ApiVersionNotSupported)
-            rd <- getResourceDocsList(requestedApiVersion).map(_.filterNot(_.partialFunction == genericEndpoint)) // exclude all DynamicEntity endpoints
+            rd <- getResourceDocsList(requestedApiVersion)
           } yield {
             // Filter
             val rdFiltered = ResourceDocsAPIMethodsUtil.filterResourceDocs(rd, showCore, showPSD2, showOBWG, resourceDocTags, partialFunctionNames)

--- a/obp-api/src/main/scala/code/api/util/APIUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/APIUtil.scala
@@ -81,7 +81,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.{List, Nil}
 import scala.collection.mutable.ArrayBuffer
 import com.openbankproject.commons.ExecutionContext.Implicits.global
-import com.openbankproject.commons.util.{ApiVersion, JsonAble, ReflectUtils, ScannedApiVersion}
+import com.openbankproject.commons.util.{ApiVersion, Functions, JsonAble, ReflectUtils, ScannedApiVersion}
 import com.openbankproject.commons.util.Functions.Implicits._
 import org.apache.commons.lang3.StringUtils
 
@@ -1093,6 +1093,7 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
       case _: BooleanBody => "boolean"
       case _: IntBody | _: LongBody | _: BigIntBody => "integer"
       case _: FloatBody | _: DoubleBody | _: BigDecimalBody => "number"
+      case _: JArrayBody => "array"
       case EmptyBody => throw new IllegalArgumentException(s"$EmptyBody have no type name.")
     }
 
@@ -1107,6 +1108,7 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
           case FloatBody(v) => JDouble(v)
           case DoubleBody(v) => JDouble(v)
           case BigDecimalBody(v) => JDouble(v.doubleValue())
+          case JArrayBody(v) => v
           case _ => throw new RuntimeException(s"$value is not supported, please add a case for it.")
         }
     }
@@ -1129,6 +1131,12 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
   case class FloatBody(value: Float) extends PrimaryDataBody[Float]
   case class BigDecimalBody(value: BigDecimal) extends PrimaryDataBody[BigDecimal]
   case class BigIntBody(value: BigInt) extends PrimaryDataBody[BigInt]
+  case class JArrayBody(value: JArray) extends PrimaryDataBody[JArray]
+
+  /**
+   * Any dynamic endpoint'ResourceDoc, it's partialFunction should set this stub endpoint.
+   */
+  val genericEndpointStub: OBPEndpoint = Functions.doNothing
 
   // Used to document the API calls
   case class ResourceDoc(

--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -819,7 +819,7 @@ trait APIMethods400 {
       "/management/dynamic-entities",
       "Get Dynamic Entities",
       s"""Get the all Dynamic Entities.""",
-      emptyObjectJson,
+      EmptyBody,
       ListResult(
         "dynamic_entities",
         List(dynamicEntityResponseBodyExample)
@@ -967,8 +967,8 @@ trait APIMethods400 {
       s"""Delete a DynamicEntity specified by DYNAMIC_ENTITY_ID.
          |
          |""",
-      emptyObjectJson,
-      emptyObjectJson,
+      EmptyBody,
+      EmptyBody,
       List(
         $UserNotLoggedIn,
         UserHasMissingRoles,
@@ -2834,7 +2834,7 @@ trait APIMethods400 {
          |Get one DynamicEndpoint,
          |
          |""",
-      emptyObjectJson,
+      EmptyBody,
       dynamicEndpointResponseBodyExample,
       List(
         $UserNotLoggedIn,
@@ -2872,7 +2872,7 @@ trait APIMethods400 {
          |Get Dynamic Endpoints.
          |
          |""",
-      emptyObjectJson,
+      EmptyBody,
       ListResult(
         "dynamic_endpoints",
         List(dynamicEndpointResponseBodyExample)
@@ -2912,8 +2912,8 @@ trait APIMethods400 {
       s"""Delete a DynamicEndpoint specified by DYNAMIC_ENDPOINT_ID.
          |
          |""",
-      emptyObjectJson,
-      emptyObjectJson,
+      EmptyBody,
+      EmptyBody,
       List(
         $UserNotLoggedIn,
         UserHasMissingRoles,

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
@@ -9,7 +9,7 @@ import java.util.{Date, Optional, UUID}
 
 import akka.http.scaladsl.model.{HttpMethods, HttpMethod => AkkaHttpMethod}
 import code.DynamicEndpoint.{DynamicEndpointProvider, DynamicEndpointT}
-import code.api.util.APIUtil.{BigDecimalBody, BigIntBody, BooleanBody, Catalogs, DoubleBody, EmptyBody, FloatBody, IntBody, LongBody, OBPEndpoint, ResourceDoc, StringBody, notCore, notOBWG, notPSD2}
+import code.api.util.APIUtil.{BigDecimalBody, BigIntBody, BooleanBody, Catalogs, DoubleBody, EmptyBody, FloatBody, IntBody, JArrayBody, LongBody, OBPEndpoint, ResourceDoc, StringBody, notCore, notOBWG, notPSD2}
 import code.api.util.ApiTag.{ResourceDocTag, apiTagApi, apiTagNewStyle}
 import code.api.util.ErrorMessages.{UnknownError, UserHasMissingRoles, UserNotLoggedIn}
 import code.api.util.{APIUtil, ApiRole, ApiTag, CustomJsonFormats}
@@ -160,7 +160,7 @@ object DynamicEndpointHelper extends RestHelper {
       (method: HttpMethod, op: Operation) <- pathItem.readOperationsMap.asScala
     } yield {
       val implementedInApiVersion = ApiVersion.v4_0_0
-      val partialFunction: OBPEndpoint = APIMethods400.Implementations4_0_0.genericEndpoint // this function is just placeholder, not need a real value.
+
       val partialFunctionName: String = s"$method-$path".replaceAll("\\W", "_")
       val requestVerb: String = method.name()
       val requestUrl: String = buildRequestUrl(path)
@@ -241,7 +241,7 @@ object DynamicEndpointHelper extends RestHelper {
         ))
       }
       val doc = ResourceDoc(
-        partialFunction,
+        APIUtil.genericEndpointStub,
         implementedInApiVersion,
         partialFunctionName,
         requestVerb,
@@ -438,7 +438,7 @@ object DynamicEndpointHelper extends RestHelper {
       case v: Float => FloatBody(v)
       case v: Double => DoubleBody(v)
       case v: BigDecimal => BigDecimalBody(v)
-      case JArray(arr) => List(arr)
+      case v: JArray => JArrayBody(v)
       case v: JObject => v
       case v :scala.Product => v
       case v => json.Extraction.decompose(v) match {
@@ -492,7 +492,10 @@ object DynamicEndpointHelper extends RestHelper {
         getDefaultValue(v, {
           val itemsSchema: Schema[_] = v.getItems
           val singleItemExample = getExampleBySchema(openAPI, itemsSchema)
-          Array(singleItemExample)
+          singleItemExample match {
+            case v: JValue => JArray(v::Nil)
+            case v => json.Extraction.decompose(Array(v))
+          }
         })
       case v: MapSchema => getDefaultValue(v, Map("name"-> "John", "age" -> 12))
 

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEntityHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEntityHelper.scala
@@ -1,6 +1,6 @@
 package code.api.v4_0_0
 
-import code.api.util.APIUtil.{Catalogs, ResourceDoc, authenticationRequiredMessage, emptyObjectJson, generateUUID, notCore, notOBWG, notPSD2}
+import code.api.util.APIUtil.{Catalogs, EmptyBody, ResourceDoc, authenticationRequiredMessage, generateUUID, notCore, notOBWG, notPSD2}
 import code.api.util.ApiTag.{ResourceDocTag, apiTagApi, apiTagNewStyle}
 import code.api.util.ErrorMessages.{InvalidJsonFormat, UnknownError, UserHasMissingRoles, UserNotLoggedIn}
 import code.api.util.{APIUtil, ApiRole, ApiTag, NewStyle}
@@ -87,7 +87,7 @@ object MockerConnector {
     val idNameInUrl = StringHelpers.snakify(dynamicEntityInfo.idName).toUpperCase()
     val listName = dynamicEntityInfo.listName
 
-    val endPoint = APIMethods400.Implementations4_0_0.genericEndpoint
+    val endPoint = APIUtil.genericEndpointStub
     val implementedInApiVersion = ApiVersion.v4_0_0
     val resourceDocs = ArrayBuffer[ResourceDoc]()
     val apiTag: ResourceDocTag = fun(singularName, entityName)
@@ -112,7 +112,7 @@ object MockerConnector {
          |e.g: /${entityName}?name=James%20Brown&number=123.456&number=11.11
          |Will do filter by this rule: name == "James Brown" && (number==123.456 || number=11.11)
          |""".stripMargin,
-      emptyObjectJson,
+      EmptyBody,
       dynamicEntityInfo.getExampleList,
       List(
         UserNotLoggedIn,
@@ -139,7 +139,7 @@ object MockerConnector {
          |
          |${authenticationRequiredMessage(true)}
          |""".stripMargin,
-      emptyObjectJson,
+      EmptyBody,
       dynamicEntityInfo.getSingleExample,
       List(
         UserNotLoggedIn,

--- a/obp-api/src/main/scala/code/api/v4_0_0/OBPAPI4_0_0.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/OBPAPI4_0_0.scala
@@ -76,7 +76,6 @@ object OBPAPI4_0_0 extends OBPRestHelper with APIMethods130 with APIMethods140 w
 
   // Filter the possible endpoints by the disabled / enabled Props settings and add them together
   val routes : List[OBPEndpoint] =
-      Implementations4_0_0.genericEndpoint::
       Implementations4_0_0.root :: // For now we make this mandatory
       getAllowedEndpoints(endpoints, allResourceDocs)
 

--- a/obp-api/src/test/scala/code/api/ResourceDocs1_4_0/ResourceDocsTest.scala
+++ b/obp-api/src/test/scala/code/api/ResourceDocs1_4_0/ResourceDocsTest.scala
@@ -5,7 +5,7 @@ import java.util
 import code.api.ResourceDocs1_4_0.ResourceDocsV140ServerSetup
 import code.api.util.{ApiRole, CustomJsonFormats}
 import code.api.v1_4_0.JSONFactory1_4_0.ResourceDocsJson
-import com.openbankproject.commons.util.ApiVersion
+import com.openbankproject.commons.util.{ApiVersion, Functions}
 import io.swagger.parser.OpenAPIParser
 import net.liftweb.json
 import net.liftweb.json.JsonAST._
@@ -24,33 +24,11 @@ class ResourceDocsTest extends ResourceDocsV140ServerSetup {
     private val CLAZZ = classOf[Product]
 
     override def deserialize(implicit format: Formats): PartialFunction[(TypeInfo, json.JValue), Product] = {
-      case (TypeInfo(CLAZZ, _), json) if json == JNull => null
-      case (TypeInfo(CLAZZ, _), json: JObject) => {
-        val keyValues = json.obj.map(pair => {
-          val JField(name, jvalue) = pair
-          val value = jvalue match {
-            case JBool(v) => v
-            case JString(v) => v
-            case JInt(v) => v
-            case JDouble(v) => v
-            case JArray(arr) => arr
-            case JObject(v) => v.map(it => (it.name, it.value))
-            case _ => jvalue
-          }
-          (name, value)
-        })
-
-        new Product {
-          override def productElement(n: Int): Any = keyValues.lift(n)
-          override def productArity: Int = keyValues.size
-          override def canEqual(that: Any): Boolean = false
-        }
-      }
+      case (TypeInfo(CLAZZ, _), json) if json == JNull || json == JNothing => null
+      case (TypeInfo(CLAZZ, _), json: JObject) => json
     }
 
-    override def serialize(implicit format: Formats): PartialFunction[Any, json.JValue] = {
-      case null => JNull // not need do serialize
-    }
+    override def serialize(implicit format: Formats): PartialFunction[Any, json.JValue] = Functions.doNothing
   }
   // here must supply a Serializer of json, to support Product type, because the follow type are ApiRole:
   //ResourceDocsJson#ResourceDocJson.roles


### PR DESCRIPTION
### Changes:
1. DynamicEntity corresponding endpoints add to generated swagger.
2. DynamicEndpoint corresponding endpoints add to generated swagger.
3. Modify README.md: Add a description of endpoints request body response body type.

![README.md changes](https://user-images.githubusercontent.com/2577334/80053846-6fee7d80-8550-11ea-87b6-571b9714b1e8.jpg)


Jenkins job are pass:
[https://jenkins.tesobe.com/job/Build-OBP-API-shuang/258](https://jenkins.tesobe.com/job/Build-OBP-API-shuang/258)
[https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk11/11](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk11/11)
[https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/113](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/113)