### PR TITLE
bugfix/dynamic_entity_name_contains_number_cause_exception 

### DIFF
--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -1896,7 +1896,7 @@ object NewStyle {
         }
       }
       val dynamicInstance: Option[JObject] = requestBody.map { it =>
-        val entityIdName = s"${entityName}Id".replaceAll("(?<=[a-z])(?=[A-Z])|-", "_").toLowerCase
+        val entityIdName = s"${entityName}_Id".replaceAll("(?<=[a-z0-9])(?=[A-Z])|-", "_").toLowerCase
         val entityIdValue = it \ entityIdName
 
         entityIdValue match {

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
@@ -262,7 +262,7 @@ object DynamicEndpointHelper extends RestHelper {
   }
 
   private val PathParamRegx = """\{(.+?)\}""".r
-  private val WordBoundPattern = Pattern.compile("(?<=[a-z])(?=[A-Z])|-")
+  private val WordBoundPattern = Pattern.compile("(?<=[a-z0-9])(?=[A-Z])|-")
 
   private def buildRequestUrl(path: String): String = {
     val url = StringUtils.split(s"$urlPrefix/$path", "/")

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEntityHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEntityHelper.scala
@@ -80,7 +80,7 @@ object MockerConnector {
                 (dynamicEntityInfo: DynamicEntityInfo): ArrayBuffer[ResourceDoc] = {
     val entityName = dynamicEntityInfo.entityName
     // e.g: "someMultiple-part_Name" -> ["Some", "Multiple", "Part", "Name"]
-    val capitalizedNameParts = entityName.split("(?<=[a-z])(?=[A-Z])|-|_").map(_.capitalize).filterNot(_.trim.isEmpty)
+    val capitalizedNameParts = entityName.split("(?<=[a-z0-9])(?=[A-Z])|-|_").map(_.capitalize).filterNot(_.trim.isEmpty)
     val singularName = capitalizedNameParts.mkString(" ")
     val pluralName = English.plural(singularName)
 

--- a/obp-api/src/main/scala/code/dynamicEntity/MapppedDynamicDataProvider.scala
+++ b/obp-api/src/main/scala/code/dynamicEntity/MapppedDynamicDataProvider.scala
@@ -46,7 +46,7 @@ object MappedDynamicDataProvider extends DynamicDataProvider with CustomJsonForm
   }
 
   private def getIdName(entityName: String) = {
-    s"${entityName}_id".replaceAll("(?<=[a-z])(?=[A-Z])|-", "_").toLowerCase
+    s"${entityName}_id".replaceAll("(?<=[a-z0-9])(?=[A-Z])|-", "_").toLowerCase
   }
 }
 


### PR DESCRIPTION
Fix the bug of when DynamicEntity name contains a number, Create a new data cause exception.
Jenkins job passed:
[https://jenkins.tesobe.com/job/Build-obp-api-shuang/262/](https://jenkins.tesobe.com/job/Build-obp-api-shuang/262/)
[https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/15/](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/15/)
[https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/116/](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/116/)