### PR TITLE
bugfix: convert dynamic entity name to tag name role is changed.

### DIFF
--- a/obp-api/src/main/scala/code/dynamicEntity/MapppedDynamicDataProvider.scala
+++ b/obp-api/src/main/scala/code/dynamicEntity/MapppedDynamicDataProvider.scala
@@ -46,7 +46,7 @@ object MappedDynamicDataProvider extends DynamicDataProvider with CustomJsonForm
   }
 
   private def getIdName(entityName: String) = {
-    s"${entityName}_id".replaceAll("(?<=[a-z0-9])(?=[A-Z])|-", "_").toLowerCase
+    s"${entityName}_Id".replaceAll("(?<=[a-z0-9])(?=[A-Z])|-", "_").toLowerCase
   }
 }
 

--- a/obp-api/src/main/scala/code/dynamicEntity/MapppedDynamicEntityProvider.scala
+++ b/obp-api/src/main/scala/code/dynamicEntity/MapppedDynamicEntityProvider.scala
@@ -1,13 +1,14 @@
 package code.dynamicEntity
 
 import code.api.util.CustomJsonFormats
+import code.util.Helper.MdcLoggable
 import code.util.MappedUUID
 import net.liftweb.common.{Box, Empty, EmptyBox, Full}
 import net.liftweb.mapper._
 import net.liftweb.util.Helpers.tryo
 import org.apache.commons.lang3.StringUtils
 
-object MappedDynamicEntityProvider extends DynamicEntityProvider with CustomJsonFormats{
+object MappedDynamicEntityProvider extends DynamicEntityProvider with CustomJsonFormats with MdcLoggable {
 
   override def getById(dynamicEntityId: String): Box[DynamicEntityT] =  DynamicEntity.find(
     By(DynamicEntity.DynamicEntityId, dynamicEntityId)
@@ -34,10 +35,16 @@ object MappedDynamicEntityProvider extends DynamicEntityProvider with CustomJson
     }
 
     tryo{
-      entityToPersist
-        .EntityName(dynamicEntity.entityName)
-        .MetadataJson(dynamicEntity.metadataJson)
-        .saveMe()
+      try {
+        entityToPersist
+          .EntityName(dynamicEntity.entityName)
+          .MetadataJson(dynamicEntity.metadataJson)
+          .saveMe()
+      } catch {
+        case e =>
+          logger.error("Create or Update DynamicEntity fail.", e)
+          throw e
+      }
     }
   }
 
@@ -68,6 +75,6 @@ class DynamicEntity extends DynamicEntityT with LongKeyedMapper[DynamicEntity] w
 }
 
 object DynamicEntity extends DynamicEntity with LongKeyedMetaMapper[DynamicEntity] {
-  override def dbIndexes = UniqueIndex(DynamicEntityId) :: UniqueIndex(MetadataJson) :: super.dbIndexes
+  override def dbIndexes = UniqueIndex(DynamicEntityId) :: super.dbIndexes
 }
 

--- a/obp-api/src/main/scripts/migrate/migrate_00000019.sql
+++ b/obp-api/src/main/scripts/migrate/migrate_00000019.sql
@@ -1,0 +1,3 @@
+-- the index DDL is: CREATE UNIQUE INDEX dynamicentity_metadatajson ON public.dynamicentity USING btree (metadatajson);
+-- it is not be used now, and btree type index have length limit of 2704, So just delete this index.
+DROP INDEX public.dynamicentity_metadatajson;


### PR DESCRIPTION
1. fix the error of creating DynamicEntity with 50 fields
2. change DynamicEntity name to tag rolw:
New role as follow:
```
Csem-case -> Csem Case
_Csem-case -> _Csem Case
Csem_case -> Csem Case
_Csem_case -> _Csem Case
csem-case -> Csem Case
```

![Snipaste_2020-05-05_23-32-30](https://user-images.githubusercontent.com/2577334/81084643-b963a300-8f28-11ea-8560-77142e7f6768.jpg)
