### PR TITLE
bugfix/StoredProcedureConnectorBuilder_type_not_support_error

### DIFF
--- a/obp-api/src/main/scala/code/api/util/CodeGenerateUtils.scala
+++ b/obp-api/src/main/scala/code/api/util/CodeGenerateUtils.scala
@@ -144,6 +144,8 @@ object CodeGenerateUtils {
       val TypeRef(_, _, args: List[Type]) = tp
       val optionValue = createDocExample(args.head, fieldName, parentFieldName, parentType)
       s"""Some($optionValue)"""
+    } else if(tp <:< typeOf[Map[String, List[String]]]) {
+      s"""Map("some_name" -> List("name1", "name2"))"""
     } else if(typeName.matches("""Array|List|Seq""")) {
       val TypeRef(_, _, args: List[Type]) = tp
       (example, typeName) match {

--- a/obp-api/src/main/scala/code/bankconnectors/storedprocedure/StoredProcedureConnectorBuilder.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/storedprocedure/StoredProcedureConnectorBuilder.scala
@@ -243,7 +243,7 @@ object StoredProcedureConnectorBuilder extends App {
   nameSignature.map(_.toString).foreach(println(_))
   println("===================")
 
-  val path = new File(getClass.getResource("").toURI.toString.replaceFirst("target/.*", "").replace("file:", ""), "src/main/scala/code/bankconnectors/storedprocedure/MsStoredProcedureConnector_vDec2019.scala")
+  val path = new File(getClass.getResource("").toURI.toString.replaceFirst("target/.*", "").replace("file:", ""), "src/main/scala/code/bankconnectors/storedprocedure/StoredProcedureConnector_vDec2019.scala")
   val source = FileUtils.readFileToString(path, "utf-8")
   val start = "//---------------- dynamic start -------------------please don't modify this line"
   val end   = "//---------------- dynamic end ---------------------please don't modify this line"


### PR DESCRIPTION
When execute `StoredProcedureConnectorBuilder` to generate stored procedure connector methods, throw Exception with the message: `type Map[String, List[String]] is not supported, please add this type to here.`

It is fixed.