### PR TITLE
bugfix dynamic entity data process 404 logic

### DIFF
--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.tesobe</groupId>
     <artifactId>obp-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.4.3</version>
+    <version>1.4.4</version>
   </parent>
   <artifactId>obp-api</artifactId>
   <packaging>war</packaging>

--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -1188,7 +1188,7 @@ object NewStyle {
     }
     def getProduct(bankId : BankId, productCode : ProductCode, callContext: Option[CallContext]) : OBPReturnType[Product] =
       Future {Connector.connector.vend.getProduct(bankId : BankId, productCode : ProductCode)} map {
-        i => (unboxFullOrFail(i, callContext, ProductNotFoundByProductCode + " {" + productCode.value + "}", 400), callContext)
+        i => (unboxFullOrFail(i, callContext, ProductNotFoundByProductCode + " {" + productCode.value + "}", 404), callContext)
       }
     
     def getProductCollection(collectionCode: String, 

--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -101,6 +101,9 @@ object NewStyle {
     def `204`(callContext: CallContext): Option[CallContext] = {
       Some(callContext.copy(httpCode = Some(204)))
     }
+    def `404`(callContext: CallContext): Option[CallContext] = {
+      Some(callContext.copy(httpCode = Some(404)))
+    }
   }
 
 
@@ -1185,7 +1188,7 @@ object NewStyle {
     }
     def getProduct(bankId : BankId, productCode : ProductCode, callContext: Option[CallContext]) : OBPReturnType[Product] =
       Future {Connector.connector.vend.getProduct(bankId : BankId, productCode : ProductCode)} map {
-        i => (unboxFullOrFail(i, callContext, ProductNotFoundByProductCode + " {" + productCode.value + "}", 404), callContext)
+        i => (unboxFullOrFail(i, callContext, ProductNotFoundByProductCode + " {" + productCode.value + "}", 400), callContext)
       }
     
     def getProductCollection(collectionCode: String, 
@@ -1899,12 +1902,6 @@ object NewStyle {
       if(operation == GET_ONE || operation == UPDATE || operation == DELETE) {
         if (entityId.isEmpty) {
           return Helper.booleanToFuture(s"$InvalidJsonFormat entityId is required for $operation operation.")(entityId.isEmpty || StringUtils.isBlank(entityId.get))
-            .map(it => (it.map(_.asInstanceOf[JValue]), callContext))
-        }
-        val id = entityId.get
-        val value = DynamicDataProvider.connectorMethodProvider.vend.get(entityName, id)
-        if (value.isEmpty) {
-          return Helper.booleanToFuture(s"$EntityNotFoundByEntityId please check: entityId = $id", 404)(false)
             .map(it => (it.map(_.asInstanceOf[JValue]), callContext))
         }
       }

--- a/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -3150,10 +3150,6 @@ object LocalMappedConnector extends Connector with MdcLoggable {
           val deleteResult: Boolean = DynamicDataProvider.connectorMethodProvider.vend.delete(entityName, id)
           Full(JBool(deleteResult))
         }
-        case IS_EXISTS_DATA => {
-          val isExistsData: Boolean = DynamicDataProvider.connectorMethodProvider.vend.existsData(entityName)
-          Full(JBool(isExistsData))
-        }
       }
       (processResult, callContext)
     }

--- a/obp-api/src/main/scala/code/bankconnectors/rest/RestConnector_vMar2019.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/rest/RestConnector_vMar2019.scala
@@ -9535,6 +9535,7 @@ trait RestConnector_vMar2019 extends Connector with KafkaHelper with MdcLoggable
       case response@HttpResponse(status, _, entity@_, _) => (status, entity)
     }.flatMap {
       case (status, entity) if status.isSuccess() => extractEntity[T](entity, inBoundMapping)
+      case (status, entity) if status.intValue == 404 => Future.successful(Empty)
       case (status, entity) => {
           val future: Future[Box[Box[T]]] = extractBody(entity) map { msg =>
             tryo {

--- a/obp-commons/pom.xml
+++ b/obp-commons/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.tesobe</groupId>
         <artifactId>obp-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.4.3</version>
+        <version>1.4.4</version>
     </parent>
     <artifactId>obp-commons</artifactId>
     <packaging>jar</packaging>

--- a/obp-commons/src/main/scala/com/openbankproject/commons/model/enums/Enumerations.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/model/enums/Enumerations.scala
@@ -106,7 +106,6 @@ object DynamicEntityOperation extends OBPEnumeration[DynamicEntityOperation] {
   object CREATE extends Value
   object UPDATE extends Value
   object DELETE extends Value
-  object IS_EXISTS_DATA extends Value
 }
 
 sealed trait LanguageParam extends EnumValue

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesobe</groupId>
   <artifactId>obp-parent</artifactId>
-  <version>1.4.3</version>
+  <version>1.4.4</version>
   <packaging>pom</packaging>
   <name>Open Bank Project API Parent</name>
   <inceptionYear>2011</inceptionYear>


### PR DESCRIPTION
When dynamic entity data do GET_ONE, UPDATE, DELETE, if no entity exists, 404 is not correct process, this pull request just fix this bug.

Jenkins job:
[jdk 1.8 job](https://jenkins.tesobe.com/job/Build-obp-api-shuang/270/)
[jdk 11 job](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/26/)
[jdk 13 job](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/124/)