### PR TITLE
feature make json convert schema support root json type is Array

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 install:
   - echo "Running a custom install command"
-  - mvn.sh clean install -pl .,obp-commons && mvn.sh install -DskipTests -pl obp-api
+  - mvn clean install -pl .,obp-commons && mvn install -DskipTests -pl obp-api

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,3 @@
 install:
   - echo "Running a custom install command"
-  - ./mvn.sh clean install -pl .,obp-commons && ./mvn.sh install -DskipTests -pl obp-api
+  - mvn.sh clean install -pl .,obp-commons && mvn.sh install -DskipTests -pl obp-api

--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -2001,6 +2001,12 @@ object NewStyle {
        }
     }
 
+    def getSupportedConnectorNames(): List[String] = {
+      Connector.nameToConnector.keys
+        .filter(it => supportedConnectorNames.exists(it.startsWith(_)))
+        .toList
+    }
+
     def getConnectorByName(connectorName: String): Option[Connector] = {
       if(supportedConnectorNames.exists(connectorName.startsWith _)) {
         Connector.nameToConnector.get(connectorName).map(_())

--- a/obp-api/src/main/scala/code/api/v3_1_0/APIMethods310.scala
+++ b/obp-api/src/main/scala/code/api/v3_1_0/APIMethods310.scala
@@ -4221,6 +4221,7 @@ trait APIMethods310 {
         .toList
     }
 
+    private val supportedConnectorNames = NewStyle.function.getSupportedConnectorNames().mkString("[", " | ", "]")
     resourceDocs += ResourceDoc(
       createMethodRouting,
       implementedInApiVersion,
@@ -4235,7 +4236,7 @@ trait APIMethods310 {
         |
         |Explaination of Fields:
         |
-        |* method_name is required String value
+        |* method_name is required String value, current supported value: $supportedConnectorNames
         |* connector_name is required String value
         |* is_bank_id_exact_match is required boolean value, if bank_id_pattern is exact bank_id value, this value is true; if bank_id_pattern is null or a regex, this value is false
         |* bank_id_pattern is optional String value, it can be null, a exact bank_id or a regex
@@ -4337,7 +4338,7 @@ trait APIMethods310 {
         |
         |Explaination of Fields:
         |
-        |* method_name is required String value
+        |* method_name is required String value, current supported value: $supportedConnectorNames
         |* connector_name is required String value
         |* is_bank_id_exact_match is required boolean value, if bank_id_pattern is exact bank_id value, this value is true; if bank_id_pattern is null or a regex, this value is false
         |* bank_id_pattern is optional String value, it can be null, a exact bank_id or a regex

--- a/obp-api/src/test/scala/code/util/JsonUtilsTest.scala
+++ b/obp-api/src/test/scala/code/util/JsonUtilsTest.scala
@@ -171,4 +171,131 @@ class JsonUtilsTest extends FlatSpec with Matchers {
     str1 shouldEqual str2
   }
 
+  val zsonList = json.parse(
+    """
+      |[
+      |  {
+      |    "id": "xrest-bank-x--uk",
+      |    "shortName": "bank shortName string",
+      |    "fullName": "bank fullName x from rest connector",
+      |    "logo": "bank logoUrl string",
+      |    "websiteUrl": "bank websiteUrl string",
+      |    "bankRouting": [{
+      |      "Scheme": "BIC",
+      |      "Address": "GENODEM1GLS"
+      |    }],
+      |    "swiftBic": "bank swiftBic string",
+      |    "nationalIdentifier": "bank nationalIdentifier string"
+      |  },
+      |  {
+      |    "id": "xrest-bank-y--uk",
+      |    "shortName": "bank shortName y",
+      |    "fullName": "bank fullName y  from rest connector",
+      |    "logo": "bank logoUrl y",
+      |    "websiteUrl": "bank websiteUrl y",
+      |    "bankRouting": [{
+      |      "Scheme": "BIC2",
+      |      "Address": "GENODEM1GLS2"
+      |    }],
+      |    "swiftBic": "bank swiftBic string",
+      |    "nationalIdentifier": "bank nationalIdentifier string"
+      |  }
+      |]
+      |""".stripMargin)
+  val zsonListSchema = json.parse(
+    """
+      |{
+      |  "inboundAdapterCallContext$default":{
+      |    "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+      |    "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+      |    "generalContext":[{
+      |      "key":"5987953",
+      |      "value":"FYIUYF6SUYFSD"
+      |    }]
+      |  },
+      |  "status$default":{
+      |    "errorCode":"status error code string",
+      |    "backendMessages":[{
+      |      "source":"",
+      |      "status":"Status string",
+      |      "errorCode":"",
+      |      "text":"text string"
+      |    }]
+      |  },
+      |  "data[]":{
+      |    "bankId[]":{
+      |      "value":"id"
+      |    },
+      |    "shortName[]":"shortName",
+      |    "fullName[]":"fullName",
+      |    "logoUrl[]":"logo",
+      |    "websiteUrl[]":"websiteUrl",
+      |    "bankRoutingScheme[]":"bankRouting.Scheme",
+      |    "bankRoutingAddress[]":"bankRouting.Address",
+      |    "swiftBic[]":"swiftBic",
+      |    "nationalIdentifier[]":"swiftBic"
+      |  }
+      |}
+      |""".stripMargin)
+  val expectListResult = json.parse(
+    """
+      |{
+      |  "inboundAdapterCallContext":{
+      |    "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+      |    "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+      |    "generalContext":[
+      |      {
+      |        "key":"5987953",
+      |        "value":"FYIUYF6SUYFSD"
+      |      }
+      |    ]
+      |  },
+      |  "status":{
+      |    "errorCode":"status error code string",
+      |    "backendMessages":[
+      |      {
+      |        "source":"",
+      |        "status":"Status string",
+      |        "errorCode":"",
+      |        "text":"text string"
+      |      }
+      |    ]
+      |  },
+      |  "data":[
+      |    {
+      |      "bankId":{
+      |        "value":"xrest-bank-x--uk"
+      |      },
+      |      "shortName":"bank shortName string",
+      |      "fullName":"bank fullName x from rest connector",
+      |      "logoUrl":"bank logoUrl string",
+      |      "websiteUrl":"bank websiteUrl string",
+      |      "bankRoutingScheme":"BIC",
+      |      "bankRoutingAddress":"GENODEM1GLS",
+      |      "swiftBic":"bank swiftBic string",
+      |      "nationalIdentifier":"bank swiftBic string"
+      |    },
+      |    {
+      |      "bankId":{
+      |        "value":"xrest-bank-y--uk"
+      |      },
+      |      "shortName":"bank shortName y",
+      |      "fullName":"bank fullName y  from rest connector",
+      |      "logoUrl":"bank logoUrl y",
+      |      "websiteUrl":"bank websiteUrl y",
+      |      "bankRoutingScheme":"BIC2",
+      |      "bankRoutingAddress":"GENODEM1GLS2",
+      |      "swiftBic":"bank swiftBic string",
+      |      "nationalIdentifier":"bank swiftBic string"
+      |    }
+      |  ]
+      |}
+      |""".stripMargin)
+  "list type fields" should "properly be convert" taggedAs JsonUtilsTag in {
+    val resultJson = buildJson(zsonList, zsonListSchema)
+
+    val str1 = json.prettyRender(resultJson)
+    val str2 = json.prettyRender(expectListResult)
+    str1 shouldEqual str2
+  }
 }

--- a/obp-api/src/test/scala/code/util/JsonUtilsTest.scala
+++ b/obp-api/src/test/scala/code/util/JsonUtilsTest.scala
@@ -130,4 +130,45 @@ class JsonUtilsTest extends FlatSpec with Matchers {
     val str2 = json.prettyRender(expectedJson)
     str1 shouldEqual str2
   }
+
+  val arrayRoot = json.parse(
+    """
+      |[
+      | {"name": "Shuang", "age": 10},
+      | {"name": "Sean", "age": 11},
+      | ["running", "coding"]
+      |]
+      |""".stripMargin)
+
+  val arrayRootSchema = json.parse(
+    """
+      |{
+      | "firstPerson": "[0]"
+      | "secondName": "[1].name",
+      | "secondHobby": "[2][1]",
+      | "noPerson": "[3]",
+      |}
+      |""".stripMargin)
+
+  val expectedZson = json.parse(
+    """
+      |{
+      |  "firstPerson":{
+      |    "name":"Shuang",
+      |    "age":10
+      |  },
+      |  "secondName":"Sean",
+      |  "secondHobby":"coding"
+      |}
+      |""".stripMargin)
+
+  "get Array type json given index, when exists" should "get given item" taggedAs JsonUtilsTag in {
+    val resultJson = buildJson(arrayRoot, arrayRootSchema)
+
+    val str1 = json.prettyRender(resultJson)
+    println(str1)
+    val str2 = json.prettyRender(expectedZson)
+    str1 shouldEqual str2
+  }
+
 }


### PR DESCRIPTION
Now schema can be this structure if root json is array:
source json:
```
[
    {"name": "Shuang", "age": 10},
    {"name": "Sean", "age": 11},
    ["running", "coding"]
]
```

schema:
```
{
       "firstPerson": "[0]"
       "secondName": "[1].name",
       "secondHobby": "[2][1]",
       "noPerson": "[3]",
}
```
----
Jenkins job:
[jdk 1.8 job](https://jenkins.tesobe.com/job/Build-obp-api-shuang/277/)
[jdk 11 job](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/32/)
[jdk 13 job](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/129/)