### PR TITLE
feature/export_any_connector_as_endpoint

### DIFF
--- a/obp-api/src/main/resources/props/sample.props.template
+++ b/obp-api/src/main/resources/props/sample.props.template
@@ -829,3 +829,10 @@ dynamic_endpoints_url_prefix=dynamic
 # You can also explicitly refresh the user using the refresh user endpoint.
 # refresh_user.interval=30
 # --------------------------------------------------------------------
+
+# --- export one Connector as endpoint,the connector name should be fulfil these rule ------
+## (1) if: connector=star, the connector should match props value of 'starConnector_supported_types'
+## (2) else: connector name should be the same as props value of connector, e.g: connector=rest_vMar2019, then the connector should must also be rest_vMar2019
+## example:
+#connector.name.export.as.endpoint=stored_procedure_vDec2019
+# ------------------------------------------------------------------------------------------

--- a/obp-api/src/main/scala/code/api/util/ExampleValue.scala
+++ b/obp-api/src/main/scala/code/api/util/ExampleValue.scala
@@ -1,10 +1,12 @@
 package code.api.util
 
 
+import code.api.util.APIUtil.parseDate
 import net.liftweb.json.JsonDSL._
 import code.api.util.Glossary.{glossaryItems, makeGlossaryItem}
 import code.dynamicEntity.{DynamicEntityDefinition, DynamicEntityFooBar, DynamicEntityFullBarFields, DynamicEntityIntTypeExample, DynamicEntityStringTypeExample}
 import com.openbankproject.commons.model.enums.DynamicEntityFieldType
+import com.openbankproject.commons.util.ReflectUtils
 import net.liftweb.json
 import net.liftweb.json.JObject
 
@@ -660,7 +662,25 @@ object ExampleValue {
   lazy val dynamicEndpointRequestBodyExample = json.parse(dynamicEndpointSwagger).asInstanceOf[JObject]
   lazy val dynamicEndpointResponseBodyExample = ("dynamic_endpoint_id", "dynamic-endpoint-id") ~ ("swagger_string", dynamicEndpointRequestBodyExample)
 
+  /**
+   * parse date example value to Date type
+   * @param exampleValue example value
+   * @return parsed Date type value
+   */
+  def toDate(exampleValue: ConnectorField) = {
+    exampleNameToValue.collectFirst {
+      case (name, example) if example == exampleValue => parseDate(example.value).getOrElse(sys.error(s"$name.value is not a valid date format."))
+    }.getOrElse(sys.error(s"$exampleValue is not an example value of code.api.util.ExampleValue"))
+  }
+
+
+
+  /**
+   * all ConnectorField type example name map value
+   */
+  lazy val exampleNameToValue: Map[String, ConnectorField] = ReflectUtils.getFieldsNameToValue[ConnectorField](this)
 }
+
 
 
 

--- a/obp-api/src/main/scala/code/bankconnectors/ConnectorEndpoints.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/ConnectorEndpoints.scala
@@ -41,7 +41,7 @@ object ConnectorEndpoints extends RestHelper{
   }
 
   lazy val connectorGetMethod: OBPEndpoint = {
-    case "restConnector" :: methodName :: Nil JsonAny json -> req if(hashMethod(methodName, json))  => {
+    case "connector" :: methodName :: Nil JsonAny json -> req if(hashMethod(methodName, json))  => {
       cc => {
         val methodSymbol: ru.MethodSymbol = getMethod(methodName, json).get
         val outBoundType = Class.forName(s"com.openbankproject.commons.dto.OutBound${methodName.capitalize}")


### PR DESCRIPTION
By set `connector.name.export.as.endpoint=stored_procedure_vDec2019` or other connector name, we can export one connector as endpoint.


[Vedio about how to use it](https://youtu.be/6S5sLXYN7dw)

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/289/)
[JDK 11](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/150/)
[JDK 13](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/45/)