### PR TITLE
feature/endpoint_map_connector_methods

### DIFF
--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.tesobe</groupId>
     <artifactId>obp-parent</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>1.5.6</version>
+    <version>1.5.7</version>
   </parent>
   <artifactId>obp-api</artifactId>
   <packaging>war</packaging>

--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
@@ -176,9 +176,12 @@ trait ResourceDocsAPIMethods extends MdcLoggable with APIMethods220 with APIMeth
           isFeatured = getIsFeaturedApi(x.partialFunctionName),
           specialInstructions = getSpecialInstructions(x.partialFunctionName),
           requestUrl =  s"/${x.implementedInApiVersion.urlPrefix}/${x.implementedInApiVersion.vDottedApiVersion}${x.requestUrl}", // This is the "implemented" in url
-          specifiedUrl = Some(s"/${x.implementedInApiVersion.urlPrefix}/${requestedApiVersion.vDottedApiVersion}${x.requestUrl}") // This is the "specified" in url when we call the resourceDoc api
+          specifiedUrl = Some(s"/${x.implementedInApiVersion.urlPrefix}/${requestedApiVersion.vDottedApiVersion}${x.requestUrl}"), // This is the "specified" in url when we call the resourceDoc api
         )
-      } yield y
+      } yield {
+        y.connectorMethods = x.connectorMethods // scala language bug, var field can't be kept when do copy, it must reset itself manually.
+        y
+      }
 
 
       logger.debug(s"There are ${theResourceDocs.length} resource docs (including local) available to $requestedApiVersion")

--- a/obp-api/src/main/scala/code/api/util/APIUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/APIUtil.scala
@@ -1179,7 +1179,7 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
                           isFeatured: Boolean = false,
                           specialInstructions: Option[String] = None,
                           specifiedUrl: Option[String] = None, // A derived value: Contains the called version (added at run time). See the resource doc for resource doc!
-                          var connectorMethods: Option[List[String]] = None //TOD move to body as one field. because the value passed to constructor will be ignore,
+                          var connectorMethods: Option[List[String]] = None //TOD move to body as one field. because the value passed to constructor will be ignored.
                         ) {
     // this code block will be merged to constructor.
     {

--- a/obp-api/src/main/scala/code/api/util/APIUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/APIUtil.scala
@@ -57,10 +57,12 @@ import code.ratelimiting.{RateLimiting, RateLimitingDI}
 import code.sanitycheck.SanityCheck
 import code.scope.Scope
 import code.usercustomerlinks.UserCustomerLink
+import code.util.ClassScanUtils.findTypes
 import code.util.Helper
 import code.util.Helper.{MdcLoggable, SILENCE_IS_GOLDEN}
 import code.views.Views
 import code.webuiprops.MappedWebUiPropsProvider.getWebUiPropsValue
+import com.alibaba.ttl.internal.javassist.CannotCompileException
 import com.github.dwickern.macros.NameOf.{nameOf, nameOfType}
 import com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SCA
 import com.openbankproject.commons.model.enums.{PemCertificateRole, StrongCustomerAuthentication}
@@ -81,14 +83,19 @@ import net.liftweb.util.{Helpers, LiftFlowOfControlException, Props, StringHelpe
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.{List, Nil}
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import com.openbankproject.commons.ExecutionContext.Implicits.global
 import com.openbankproject.commons.util.{ApiVersion, Functions, JsonAble, ReflectUtils, ScannedApiVersion}
 import com.openbankproject.commons.util.Functions.Implicits._
+import com.openbankproject.commons.util.Functions.Memo
+import javassist.ClassPool
+import javassist.expr.{ExprEditor, MethodCall}
 import org.apache.commons.lang3.StringUtils
 
+import scala.collection.mutable
 import scala.concurrent.Future
 import scala.io.BufferedSource
+import scala.runtime.AbstractPartialFunction
 import scala.xml.{Elem, XML}
 
 object APIUtil extends MdcLoggable with CustomJsonFormats{
@@ -1172,10 +1179,13 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
                           isFeatured: Boolean = false,
                           specialInstructions: Option[String] = None,
                           specifiedUrl: Option[String] = None, // A derived value: Contains the called version (added at run time). See the resource doc for resource doc!
-                          connectorMethods: Option[List[String]] = None
+                          var connectorMethods: Option[List[String]] = None //TOD move to body as one field. because the value passed to constructor will be ignore,
                         ) {
     // this code block will be merged to constructor.
     {
+      // reset dependent connector methods
+      connectorMethods = endpointToConnectorMethod.get(partialFunction.getClass.getName).map(_.map("obp."+))
+
       val authenticationIsRequired = authenticationRequiredMessage(true)
       val authenticationIsOptional = authenticationRequiredMessage(false)
 
@@ -1265,6 +1275,20 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
       this
     }
 
+    private val requestUrlPartPath: Array[String] = StringUtils.split(requestUrl, '/')
+
+    private val requestUrlBankId = requestUrlPartPath.indexOf("BANK_ID")
+    private val requestUrlAccountId = requestUrlPartPath.indexOf("ACCOUNT_ID")
+    private val requestUrlViewId = requestUrlPartPath.indexOf("VIEW_ID")
+
+    private val isNeedCheckAuth = errorResponseBodies.contains($UserNotLoggedIn)
+    private val isNeedCheckRoles = _autoValidateRoles && rolesForCheck.nonEmpty
+    private val isNeedCheckBank = errorResponseBodies.contains($BankNotFound) && requestUrlBankId != -1
+    private val isNeedCheckAccount = errorResponseBodies.contains($BankAccountNotFound) &&
+      requestUrlBankId != -1 && requestUrlAccountId != -1
+    private val isNeedCheckView = errorResponseBodies.contains($UserNoPermissionAccessView) &&
+      requestUrlBankId != -1 && requestUrlAccountId != -1 && requestUrlViewId != -1
+
     /**
      * According errorResponseBodies whether contains UserNotLoggedIn and UserHasMissingRoles do validation.
      * So can avoid duplicate code in endpoint body for expression do check.
@@ -1279,12 +1303,6 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
      * @return wrapped endpoint
      */
     def wrappedWithAuthCheck(obpEndpoint: OBPEndpoint): OBPEndpoint = {
-
-      val requestUrlPartPath: Array[String] = StringUtils.split(requestUrl, '/')
-
-      val requestUrlBankId = requestUrlPartPath.indexOf("BANK_ID")
-      val requestUrlAccountId = requestUrlPartPath.indexOf("ACCOUNT_ID")
-      val requestUrlViewId = requestUrlPartPath.indexOf("VIEW_ID")
 
       def getIds(url: List[String]): (Option[BankId], Option[AccountId], Option[ViewId]) = {
         val apiPrefixLength = url.size - requestUrlPartPath.size
@@ -1309,31 +1327,33 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
         (bankId, accountId, viewId)
       }
 
-      def checkAuth(cc: CallContext): Future[(Box[User], Option[CallContext])] =
-        if (errorResponseBodies.contains($UserNotLoggedIn)) authenticatedAccess(cc) else anonymousAccess(cc)
+      def checkAuth(cc: CallContext): Future[(Box[User], Option[CallContext])] = {
+        if (isNeedCheckAuth) authenticatedAccessFun(cc) else anonymousAccessFun(cc)
+      }
 
-      def checkRoles(bankId: Option[BankId], user: Box[User]):Future[Box[Unit]] =
-        if(_autoValidateRoles && rolesForCheck.nonEmpty) {
-            val bankIdStr = bankId.map(_.value).getOrElse("")
-            val userIdStr = user.map(_.userId).openOr("")
-            NewStyle.function.hasAtLeastOneEntitlement(bankIdStr, userIdStr, rolesForCheck)
-          } else {
-              Future.successful(Full(Unit))
-            }
+      def checkRoles(bankId: Option[BankId], user: Box[User]):Future[Box[Unit]] = {
+        if (isNeedCheckRoles) {
+          val bankIdStr = bankId.map(_.value).getOrElse("")
+          val userIdStr = user.map(_.userId).openOr("")
+          checkRolesFun(bankIdStr)(userIdStr, rolesForCheck)
+        } else {
+          Future.successful(Full(Unit))
+        }
+      }
 
       def checkBank(bankId: Option[BankId], callContext: Option[CallContext]): Future[(Bank, Option[CallContext])] = {
-        val needCheckBank = errorResponseBodies.contains($BankNotFound)
-        (needCheckBank, bankId) match {
-          case (true, Some(bId)) => NewStyle.function.getBank(bId, callContext)
-          case _ => Future.successful(null.asInstanceOf[Bank] -> callContext)
+        if (isNeedCheckBank && bankId.isDefined) {
+          checkBankFun(bankId.get)(callContext)
+        } else {
+          Future.successful(null.asInstanceOf[Bank] -> callContext)
         }
       }
 
       def checkAccount(bankId: Option[BankId], accountId: Option[AccountId], callContext: Option[CallContext]): Future[(BankAccount, Option[CallContext])] = {
-        val needCheckAccount = errorResponseBodies.contains($BankAccountNotFound)
-        (needCheckAccount,bankId, accountId) match {
-          case (true, Some(bId), Some(aId)) => NewStyle.function.getBankAccount(bId, aId, callContext)
-          case _ => Future.successful(null.asInstanceOf[BankAccount] -> callContext)
+        if(isNeedCheckAccount && bankId.isDefined && accountId.isDefined) {
+          checkAccountFun(bankId.get)(accountId.get, callContext)
+        } else {
+          Future.successful(null.asInstanceOf[BankAccount] -> callContext)
         }
       }
 
@@ -1342,15 +1362,46 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
                     accountId: Option[AccountId],
                     boxUser: Box[User],
                     callContext: Option[CallContext]): Future[View] = {
-        val needCheckView = errorResponseBodies.contains($UserNoPermissionAccessView)
-
-        (needCheckView, bankId, accountId, viewId) match {
-          case (true, Some(bId), Some(aId), Some(vId)) =>
-            val bankIdAccountId = BankIdAccountId(bId, aId)
-            NewStyle.function.checkViewAccessAndReturnView(vId, bankIdAccountId, boxUser, callContext)
-          case _ => Future.successful(null.asInstanceOf[View])
+        if(isNeedCheckView && bankId.isDefined && accountId.isDefined && viewId.isDefined) {
+          val bankIdAccountId = BankIdAccountId(bankId.get, accountId.get)
+          checkViewFun(viewId.get)(bankIdAccountId, boxUser, callContext)
+        } else {
+          Future.successful(null.asInstanceOf[View])
         }
       }
+      // reset connectorMethods
+      {
+          val checkerClassNames = mutable.ListBuffer[String]()
+          if (isNeedCheckAuth) {
+            checkerClassNames += authenticatedAccessFun.getClass.getName
+          } else {
+            checkerClassNames += anonymousAccessFun.getClass.getName
+          }
+          if (isNeedCheckRoles) {
+            checkerClassNames += checkRolesFun.getClass.getName
+          }
+          if (isNeedCheckBank) {
+            checkerClassNames += checkBankFun.getClass.getName
+          }
+          if (isNeedCheckAccount) {
+            checkerClassNames += checkAccountFun.getClass.getName
+          }
+          if (isNeedCheckView) {
+            checkerClassNames += checkViewFun.getClass.getName
+          }
+          val addedMethods: List[String] = checkerClassNames.toList.map(endpointToConnectorMethod.get(_)) flatMap {
+            case Some(x) if x.nonEmpty => x.map("obp."+)
+            case _ => Nil
+          }
+
+          this.connectorMethods = this.connectorMethods match {
+            case Some(x) if addedMethods.nonEmpty =>
+              val allMethods = (addedMethods ::: x).distinct
+              Some(allMethods)
+            case None if addedMethods.nonEmpty => Some(addedMethods.distinct)
+            case x => x
+          }
+        }
 
       new OBPEndpoint {
         override def isDefinedAt(x: Req): Boolean = obpEndpoint.isDefinedAt(x)
@@ -3203,5 +3254,73 @@ Returns a string showed to the developer
   }
 
   lazy val loginButtonText = getWebUiPropsValue("webui_login_button_text", S.?("log.in"))
+
+  // the follow PartialFunction just delegate one method, in this way will be compiled to a class, in order to trace call whitch connector methods
+  private val authenticatedAccessFun: PartialFunction[CallContext, OBPReturnType[Box[User]]] = {
+    case x => authenticatedAccess(x)
+  }
+  private val anonymousAccessFun: PartialFunction[CallContext, OBPReturnType[Box[User]]] = {
+    case x => anonymousAccess(x)
+  }
+  private val checkRolesFun: PartialFunction[String, (String, List[ApiRole]) => Future[Box[Unit]]] = {
+    case x => NewStyle.function.hasAtLeastOneEntitlement(x, _, _)
+  }
+  private val checkBankFun: PartialFunction[BankId, Option[CallContext] => OBPReturnType[Bank]] = {
+    case x => NewStyle.function.getBank(x, _)
+  }
+  private val checkAccountFun: PartialFunction[BankId, (AccountId, Option[CallContext]) => OBPReturnType[BankAccount]] = {
+    case x => NewStyle.function.getBankAccount(x, _, _)
+  }
+  private val checkViewFun: PartialFunction[ViewId, (BankIdAccountId, Option[User], Option[CallContext]) => Future[View]] = {
+    case x => NewStyle.function.checkViewAccessAndReturnView(x, _, _, _)
+  }
+
+  /**
+   * endpoint class name to dependent connector method name List
+   */
+  lazy val endpointToConnectorMethod: Map[String, List[String]] = {
+    val endpointType = scala.reflect.runtime.universe.typeOf[OBPEndpoint]
+    // scanned OBPEndpoint are sub type of scala.runtime.AbstractPartialFunction
+    val supperClassName = classOf[AbstractPartialFunction[_,_]].getName
+    val endpoints = findTypes(it => it.superClassName == supperClassName && ReflectUtils.forType(it.name) <:< endpointType)
+    val checkerClassNames = List(authenticatedAccessFun, anonymousAccessFun, checkRolesFun, checkBankFun, checkAccountFun, checkViewFun).map(_.getClass.getName)
+    val connectorTypeName = classOf[Connector].getName
+
+    // cache for method -> called obp methods:
+    // (className, methodName, signature) -> List[(className, methodName, signature)]
+    val memo = new Memo[(String, String, String), List[(String, String, String)]]
+    val cp = ClassPool.getDefault
+
+    def getObpTrace(className: String, methodName: String, signature: String, exclude: List[(String, String, String)] = Nil): List[(String, String, String)] =
+      memo.memoize((className, methodName, signature)) {
+        val methods = ListBuffer[(String, String, String)]()
+        val method = cp.get(className).getMethod(methodName, signature)
+        method.instrument(new ExprEditor() {
+          @throws[CannotCompileException]
+          override def edit(m: MethodCall): Unit = {
+            val tuple = (m.getClassName, m.getMethodName, m.getSignature)
+            if (ReflectUtils.isObpClass(m.getClassName)) {
+              methods += tuple
+            }
+          }
+        })
+
+        val list = methods.distinct.toList.filterNot(exclude.contains)
+        list.collect {
+          case x@(clazzName, _, _) if clazzName == connectorTypeName => x :: Nil
+          case (clazzName, mName, mSignature) =>
+            getObpTrace(clazzName, mName, mSignature, list ::: exclude)
+        }.flatten.distinct
+      }
+    // pair list, pair is: class name -> connector method name list
+    val pairList: List[(String, String)] = for {
+      endpointClassName <- endpoints ::: checkerClassNames
+      method <- cp.get(endpointClassName).getDeclaredMethods
+      (clazzName, methodName, _) <- getObpTrace(endpointClassName, method.getName, method.getSignature)
+      if clazzName == connectorTypeName && !methodName.contains("$default$")
+    } yield (endpointClassName, methodName)
+
+    pairList.groupBy(_._1).mapValues(_.map(_._2).distinct)
+  }
 
 }

--- a/obp-commons/pom.xml
+++ b/obp-commons/pom.xml
@@ -7,7 +7,7 @@
         <groupId>com.tesobe</groupId>
         <artifactId>obp-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.5.6</version>
+        <version>1.5.7</version>
     </parent>
     <artifactId>obp-commons</artifactId>
     <packaging>jar</packaging>

--- a/obp-commons/src/main/scala/com/openbankproject/commons/util/ReflectUtils.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/util/ReflectUtils.scala
@@ -26,6 +26,8 @@ object ReflectUtils {
 
   def isObpClass(clazz: Class[_]): Boolean = clazz != null && OBP_TYPE_REGEX.findFirstIn(clazz.getName).isDefined
 
+  def isObpClass(clazzName: String): Boolean = clazzName != null && OBP_TYPE_REGEX.findFirstIn(clazzName).isDefined
+
   /**
    * get given instance FieldMirror, and operate it. this function is just for helper of getField and setField function
    * @param obj
@@ -480,6 +482,8 @@ object ReflectUtils {
 
 
   def getType(obj: Any): ru.Type = mirror.reflect(obj).symbol.toType
+
+  def forType(className: String): ru.Type = mirror.staticClass(className).toType
 
   def getPrimaryConstructor(tp: ru.Type): MethodSymbol = tp.decl(ru.termNames.CONSTRUCTOR).alternatives.head.asMethod
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.tesobe</groupId>
   <artifactId>obp-parent</artifactId>
-  <version>1.5.6</version>
+  <version>1.5.7</version>
   <packaging>pom</packaging>
   <name>Open Bank Project API Parent</name>
   <inceptionYear>2011</inceptionYear>


### PR DESCRIPTION
In the API-Explorer, we can see all dependent connector methods.
For MessageDoc show dependent endpoint: not be included in this pull request. this pull requst have finished the most important part.

### Jenkins job passed, it is ready be merged.

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/296/)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/52/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/157/)

Here is one example:
![Snipaste_2020-07-09_21-58-22](https://user-images.githubusercontent.com/2577334/87049265-572c6480-c22f-11ea-8bc7-8c44fc87061a.jpg)

