### PR TITLE
bugfix/javassist.NotFoundException_when_start_with_JDK1.8: fixed.

### DIFF
--- a/obp-api/src/main/scala/code/api/util/APIUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/APIUtil.scala
@@ -88,7 +88,7 @@ import com.openbankproject.commons.ExecutionContext.Implicits.global
 import com.openbankproject.commons.util.{ApiVersion, Functions, JsonAble, ReflectUtils, ScannedApiVersion}
 import com.openbankproject.commons.util.Functions.Implicits._
 import com.openbankproject.commons.util.Functions.Memo
-import javassist.ClassPool
+import javassist.{ClassPool, LoaderClassPath}
 import javassist.expr.{ExprEditor, MethodCall}
 import org.apache.commons.lang3.StringUtils
 
@@ -3277,7 +3277,14 @@ Returns a string showed to the developer
   // cache for method -> called obp methods:
   // (className, methodName, signature) -> List[(className, methodName, signature)]
   private val memo = new Memo[(String, String, String), List[(String, String, String)]]
-  private val cp = ClassPool.getDefault
+
+  private val cp = {
+    val pool = ClassPool.getDefault
+    // avoid error when call with JDK 1.8:
+    // javassist.NotFoundException: code.api.UKOpenBanking.v3_1_0.APIMethods_AccountAccessApi$$anonfun$createAccountAccessConsents$lzycompute$1
+    pool.appendClassPath(new LoaderClassPath(Thread.currentThread.getContextClassLoader))
+    pool
+  }
 
   /**
    * get all dependent connector method names for an object


### PR DESCRIPTION
when start server, have this type error:

```
[WARNING] Nested in java.lang.ExceptionInInitializerError:
javassist.NotFoundException: code.api.UKOpenBanking.v3_1_0.APIMethods_AccountAccessApi$$anonfun$createAccountAccessConsents$lzycompute$1
    at javassist.ClassPool.get (ClassPool.java:422)
    at code.api.util.APIUtil$.getDependentConnectorMethods (APIUtil.scala:3314)
    at code.api.util.APIUtil$ResourceDoc.<init> (APIUtil.scala:1215)
    at code.api.UKOpenBanking.v3_1_0.APIMethods_AccountAccessApi$.<init> (AccountAccessApi.scala:31)
    at code.api.UKOpenBanking.v3_1_0.APIMethods_AccountAccessApi$.<clinit> (AccountAccessApi.scala)
    at code.api.UKOpenBanking.v3_1_0.OBP_UKOpenBanking_310$.<init> (OBP_UKOpenBanking_310.scala:54)
    at code.api.UKOpenBanking.v3_1_0.OBP_UKOpenBanking_310$.<clinit> (OBP_UKOpenBanking_310.scala)
    at java.lang.Class.forName0 (Native Method)
    at java.lang.Class.forName (Class.java:264)
    at code.util.ClassScanUtils$.companion (ClassScanUtils.scala:28)
    at code.util.ClassScanUtils$.$anonfun$getSubTypeObjects$3 (ClassScanUtils.scala:38)
    at scala.collection.immutable.Stream.map (Stream.scala:418)
    at code.util.ClassScanUtils$.getSubTypeObjects (ClassScanUtils.scala:38)
    at code.api.util.ScannedApis$.versionMapScannedApis$lzycompute (ScannedApis.scala:26)
    at code.api.util.ScannedApis$.versionMapScannedApis (ScannedApis.scala:25)
    at bootstrap.liftweb.Boot.boot (Boot.scala:357)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at net.liftweb.util.ClassHelpers.$anonfun$createInvoker$2 (ClassHelpers.scala:357)
    at net.liftweb.http.DefaultBootstrap$.$anonfun$boot$1 (LiftRules.scala:2250)

```

### Jenkins job is running, it is not ready to be merged.

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/299/)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/55/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/160/)