### PR TITLE
bugfix/endpoint_map_connector_method_duplicated: fixed.

### DIFF
--- a/obp-api/src/main/scala/code/api/util/APIUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/APIUtil.scala
@@ -3323,7 +3323,7 @@ Returns a string showed to the developer
       if clazzName == connectorTypeName && !methodName.contains("$default$")
     } yield methodName
 
-    connectorMethods.toList
+    connectorMethods.toList.distinct
   }
 
   case class EndpointInfo(name: String, version: String)


### PR DESCRIPTION
An endpoint has duplicated connector method names:
![Clipboard - July 13, 2020 11_57 AM](https://user-images.githubusercontent.com/2577334/87299118-00c86a00-c53e-11ea-82de-72aa4c275700.png)

### Jenkins job is passed, it is ready to be merged.

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/301/)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/56/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/161/)