### PR TITLE
bugfix/endpoint_show_wrong_dependent_connector_methods: createTransac…

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -51,9 +51,7 @@ getAllowedEndpoints(endpointsOf3_0_0, Implementations3_0_0.resourceDocs)
 
 4) Once we have a final list of routes we serve them:
 
-  routes.foreach(route => {
-    oauthServe(apiPrefix{route}, findResourceDoc(route))
-  })
+  `registerRoutes(routes, allResourceDocs, apiPrefix, autoValidateAll = true)`
 
 
 

--- a/obp-api/src/main/scala/code/api/util/APIUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/APIUtil.scala
@@ -1373,25 +1373,25 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
       }
       // reset connectorMethods
       {
-        val checkerClassNames = mutable.ListBuffer[String]()
+        val checkerFunctions = mutable.ListBuffer[PartialFunction[_, _]]()
         if (isNeedCheckAuth) {
-          checkerClassNames += authenticatedAccessFun.getClass.getName
+          checkerFunctions += authenticatedAccessFun
         } else {
-          checkerClassNames += anonymousAccessFun.getClass.getName
+          checkerFunctions += anonymousAccessFun
         }
         if (isNeedCheckRoles) {
-          checkerClassNames += checkRolesFun.getClass.getName
+          checkerFunctions += checkRolesFun
         }
         if (isNeedCheckBank) {
-          checkerClassNames += checkBankFun.getClass.getName
+          checkerFunctions += checkBankFun
         }
         if (isNeedCheckAccount) {
-          checkerClassNames += checkAccountFun.getClass.getName
+          checkerFunctions += checkAccountFun
         }
         if (isNeedCheckView) {
-          checkerClassNames += checkViewFun.getClass.getName
+          checkerFunctions += checkViewFun
         }
-        val addedMethods: List[String] = checkerClassNames.toList.flatMap(getDependentConnectorMethods(_)).map("obp." +)
+        val addedMethods: List[String] = checkerFunctions.toList.flatMap(getDependentConnectorMethods(_)).map("obp." +)
 
         // add connector method to endpoint info
         addEndpointInfos(addedMethods, partialFunctionName, implementedInApiVersion)


### PR DESCRIPTION
# Fix this bug:
endpoint `createTransactionRequest` have multiple ResourceDocs, they have no auto validate code called connector methods.
### current fix:
--------
![image](https://user-images.githubusercontent.com/2577334/87502326-e43e4600-c693-11ea-80f8-e140a49b5ff1.png)

### Jenkins job is passed, it is ready to be merged.

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/305/)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/60/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/165/)