### PR TITLE
bugfix/database_messages_scheduler_interval_props_cause_port_conflict 

### DIFF
--- a/obp-api/src/main/scala/code/scheduler/DatabaseDriverScheduler.scala
+++ b/obp-api/src/main/scala/code/scheduler/DatabaseDriverScheduler.scala
@@ -3,7 +3,7 @@ package code.scheduler
 import java.sql.SQLException
 import java.util.concurrent.TimeUnit
 
-import akka.actor.ActorSystem
+import code.actorsystem.ObpLookupSystem
 import code.util.Helper.MdcLoggable
 import net.liftweb.db.DB
 
@@ -12,9 +12,9 @@ import scala.concurrent.duration._
 
 object DatabaseDriverScheduler extends MdcLoggable {
 
-  private val actorSystem = ActorSystem()
-  implicit val executor = actorSystem.dispatcher
-  private val scheduler = actorSystem.scheduler
+  private lazy val actorSystem = ObpLookupSystem.obpLookupSystem
+  implicit lazy val executor = actorSystem.dispatcher
+  private lazy val scheduler = actorSystem.scheduler
 
   def start(interval: Long): Unit = {
     scheduler.schedule(


### PR DESCRIPTION
When set props `database_messages_scheduler_interval=3600`, will cause port 2662 binding error.

### Jenkins job is passed, it is ready to be merged.

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/317/)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/73/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/181/)