### PR TITLE
feature/make_dynamicEntity_dynamicEndpoint_show_reasonable_result

### DIFF
--- a/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
+++ b/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
@@ -81,6 +81,7 @@ object ErrorMessages {
   val InvalidInBoundMapping = "OBP-10032: Incorrect inBoundMapping Format, it should be a json structure."
   val InvalidUri = "OBP-10404: Request Not Found. The server has not found anything matching the Request-URI.Check your URL and the headers. " +
     "NOTE: when it is POST or PUT api, the Content-Type must be `application/json`. OBP only support the json format body."
+  val ResourceNotExists = "OBP-10405: Resource not exists."
 
   // General Sort and Paging
   val FilterSortDirectionError = "OBP-10023: obp_sort_direction parameter can only take two values: DESC or ASC!" // was OBP-20023

--- a/obp-api/src/main/scala/code/remotedata/RemotedataActors.scala
+++ b/obp-api/src/main/scala/code/remotedata/RemotedataActors.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import akka.actor.{ActorSystem, Props => ActorProps}
 import bootstrap.liftweb.ToSchemify
-import code.actorsystem.ObpActorConfig
+import code.actorsystem.{ObpActorConfig, ObpLookupSystem}
 import code.api.util.APIUtil
 import code.util.Helper
 import code.util.Helper.MdcLoggable
@@ -14,8 +14,8 @@ import net.liftweb.db.StandardDBVendor
 import net.liftweb.http.LiftRules
 import net.liftweb.mapper.{DB, Schemifier}
 import net.liftweb.util.Props
-
 import com.openbankproject.commons.ExecutionContext.Implicits.global
+
 import scala.concurrent.duration._
 
 
@@ -116,7 +116,7 @@ object RemotedataActors extends MdcLoggable {
   }
 
   def showLogoAfterDelay() = {
-    val actorSystem = ActorSystem()
+    val actorSystem = ObpLookupSystem.obpLookupSystem
     val scheduler = actorSystem.scheduler
     scheduler.scheduleOnce(
       Duration(4, TimeUnit.SECONDS),

--- a/obp-api/src/main/scala/code/transactionstatus/TransactionStatusScheduler.scala
+++ b/obp-api/src/main/scala/code/transactionstatus/TransactionStatusScheduler.scala
@@ -2,19 +2,18 @@ package code.transactionStatusScheduler
 
 import java.util.concurrent.TimeUnit
 
-import akka.actor.ActorSystem
+import code.actorsystem.ObpLookupSystem
 import code.transactionrequests.TransactionRequests
 import code.util.Helper.MdcLoggable
-
 
 import scala.concurrent.duration._
 
 
 object TransactionStatusScheduler extends MdcLoggable {
 
-  val actorSystem = ActorSystem()
-  implicit val executor = actorSystem.dispatcher
-  val scheduler = actorSystem.scheduler
+  private lazy val actorSystem = ObpLookupSystem.obpLookupSystem
+  implicit lazy val executor = actorSystem.dispatcher
+  private lazy val scheduler = actorSystem.scheduler
 
   def start(interval: Long): Unit = {
     scheduler.schedule(

--- a/obp-api/src/main/scala/code/util/AkkaHttpClient.scala
+++ b/obp-api/src/main/scala/code/util/AkkaHttpClient.scala
@@ -1,15 +1,16 @@
 package code.util
 
 
-import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.ActorMaterializer
+import code.actorsystem.ObpLookupSystem
 import code.api.util.{APIUtil, CustomJsonFormats}
 import code.util.Helper.MdcLoggable
 import com.openbankproject.commons.ExecutionContext
 
+import scala.concurrent.duration.DurationInt
 import scala.concurrent.Future
 
 
@@ -41,66 +42,64 @@ object AkkaHttpClient extends MdcLoggable with CustomJsonFormats {
     val entity: RequestEntity = HttpEntity(ContentTypes.`application/json`, entityJsonString)
     HttpRequest(uri = uri, method = method, entity = entity, protocol = httpProtocol)
   }
-  
-  
 
-  implicit val system = ActorSystem()
+
+  implicit lazy val system = ObpLookupSystem.obpLookupSystem
   implicit val materializer = ActorMaterializer()
   // needed for the future flatMap/onComplete in the end
-  implicit val executionContext =ExecutionContext.wrapExecutionContext(system.dispatcher)
+  implicit val executionContext = ExecutionContext.wrapExecutionContext(system.dispatcher)
 
-  def makeHttpRequest(httpRequest: HttpRequest): Future[HttpResponse] = {
-    import scala.concurrent.duration.DurationInt
-    val poolSettingsWithHttpsProxy  =
-      ConnectionPoolSettings(system.settings.config).copy(
-       /*
-        # The minimum duration to backoff new connection attempts after the previous connection attempt failed.
-        #
-        # The pool uses an exponential randomized backoff scheme. After the first failure, the next attempt will only be
-        # tried after a random duration between the base connection backoff and twice the base connection backoff. If that
-        # attempt fails as well, the next attempt will be delayed by twice that amount. The total delay is capped using the
-        # `max-connection-backoff` setting.
-        #
-        # The backoff applies for the complete pool. I.e. after one failed connection attempt, further connection attempts
-        # to that host will backoff for all connections of the pool. After the service recovered, connections will come out
-        # of backoff one by one due to the random extra backoff time. This is to avoid overloading just recently recovered
-        # services with new connections ("thundering herd").
-        #
-        # Example: base-connection-backoff = 100ms, max-connection-backoff = 10 seconds
-        #   - After 1st failure, backoff somewhere between 100ms and 200ms
-        #   - After 2nd, between  200ms and  400ms
-        #   - After 3rd, between  200ms and  400ms
-        #   - After 4th, between  400ms and  800ms
-        #   - After 5th, between  800ms and 1600ms
-        #   - After 6th, between 1600ms and 3200ms
-        #   - After 7th, between 3200ms and 6400ms
-        #   - After 8th, between 5000ms and 10 seconds (max capped by max-connection-backoff, min by half of that)
-        #   - After 9th, etc., stays between 5000ms and 10 seconds
-        #
-        # This setting only applies to the new pool implementation and is ignored for the legacy one.
-       */
-        baseConnectionBackoff = 1.second,
-       /*
-        # Maximum backoff duration between failed connection attempts. For more information see the above comment for the
-        # `base-connection-backoff` setting.
-        #
-        # This setting only applies to the new pool implementation and is ignored for the legacy one.
-       */
-        maxConnectionBackoff = 1.minute,
-       /*
-        # The maximum number of times failed requests are attempted again,
-        # (if the request can be safely retried) before giving up and returning an error.
-        # Set to zero to completely disable request retries.
-       */
-        maxRetries=5)
-
+  private lazy val connectionPoolSettings: ConnectionPoolSettings = {
+    val systemConfig = ConnectionPoolSettings(system.settings.config)
     //Note: get the timeout setting from here:  https://github.com/akka/akka-http/issues/742
-    val clientSettings = poolSettingsWithHttpsProxy.connectionSettings.withIdleTimeout(httpRequestTimeout seconds) 
-    
-    val settings = poolSettingsWithHttpsProxy.copy(connectionSettings = clientSettings)
-
-    Http().singleRequest(request = httpRequest, settings = settings)
+    val clientSettings = systemConfig.connectionSettings.withIdleTimeout(httpRequestTimeout seconds)
+    // reset some settings value
+    systemConfig.copy(
+      /*
+       # The minimum duration to backoff new connection attempts after the previous connection attempt failed.
+       #
+       # The pool uses an exponential randomized backoff scheme. After the first failure, the next attempt will only be
+       # tried after a random duration between the base connection backoff and twice the base connection backoff. If that
+       # attempt fails as well, the next attempt will be delayed by twice that amount. The total delay is capped using the
+       # `max-connection-backoff` setting.
+       #
+       # The backoff applies for the complete pool. I.e. after one failed connection attempt, further connection attempts
+       # to that host will backoff for all connections of the pool. After the service recovered, connections will come out
+       # of backoff one by one due to the random extra backoff time. This is to avoid overloading just recently recovered
+       # services with new connections ("thundering herd").
+       #
+       # Example: base-connection-backoff = 100ms, max-connection-backoff = 10 seconds
+       #   - After 1st failure, backoff somewhere between 100ms and 200ms
+       #   - After 2nd, between  200ms and  400ms
+       #   - After 3rd, between  200ms and  400ms
+       #   - After 4th, between  400ms and  800ms
+       #   - After 5th, between  800ms and 1600ms
+       #   - After 6th, between 1600ms and 3200ms
+       #   - After 7th, between 3200ms and 6400ms
+       #   - After 8th, between 5000ms and 10 seconds (max capped by max-connection-backoff, min by half of that)
+       #   - After 9th, etc., stays between 5000ms and 10 seconds
+       #
+       # This setting only applies to the new pool implementation and is ignored for the legacy one.
+      */
+      baseConnectionBackoff = 1.second,
+      /*
+       # Maximum backoff duration between failed connection attempts. For more information see the above comment for the
+       # `base-connection-backoff` setting.
+       #
+       # This setting only applies to the new pool implementation and is ignored for the legacy one.
+      */
+      maxConnectionBackoff = 16.second,
+      /*
+       # The maximum number of times failed requests are attempted again,
+       # (if the request can be safely retried) before giving up and returning an error.
+       # Set to zero to completely disable request retries.
+      */
+      maxRetries = 5,
+      connectionSettings = clientSettings
+    )
   }
 
-  
+  def makeHttpRequest(httpRequest: HttpRequest): Future[HttpResponse] =
+    Http().singleRequest(request = httpRequest, settings = connectionPoolSettings)
+
 }

--- a/obp-api/src/main/scala/code/webhook/WebhookHttpClient.scala
+++ b/obp-api/src/main/scala/code/webhook/WebhookHttpClient.scala
@@ -1,15 +1,14 @@
 package code.webhook
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.ActorMaterializer
 import akka.util.ByteString
 import code.actorsystem.ObpLookupSystem
-import code.api.util.{ApiTrigger, CustomJsonFormats}
 import code.api.util.ApiTrigger.{OnBalanceChange, OnCreditTransaction, OnDebitTransaction}
+import code.api.util.{ApiTrigger, CustomJsonFormats}
 import code.util.Helper.MdcLoggable
 import code.webhook.WebhookActor.{WebhookFailure, WebhookRequest, WebhookResponse}
 import net.liftweb
@@ -17,6 +16,7 @@ import net.liftweb.json.Extraction
 import net.liftweb.mapper.By
 
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success}
 
 
@@ -130,14 +130,14 @@ object WebhookHttpClient extends MdcLoggable {
   }
     
 
-  implicit val system = ActorSystem()
-  implicit val materializer = ActorMaterializer()
+  lazy implicit val system = ObpLookupSystem.obpLookupSystem
+  implicit lazy val materializer = ActorMaterializer()
   // needed for the future flatMap/onComplete in the end
-  implicit val executionContext = system.dispatcher
+  implicit lazy val executionContext = system.dispatcher
 
   // The Actor which has sent the request. 
   // We need to respond to it after we finish an event.
-  val requestActor = ObpLookupSystem.getWebhookActor()
+  lazy val requestActor = ObpLookupSystem.getWebhookActor()
   
   private def makeRequest(httpRequest: HttpRequest, request: WebhookRequest): Unit = {
     makeHttpRequest(httpRequest).onComplete {
@@ -149,53 +149,51 @@ object WebhookHttpClient extends MdcLoggable {
       }
   }
 
-  private def makeHttpRequest(httpRequest: HttpRequest): Future[HttpResponse] = {
-    import scala.concurrent.duration.DurationInt
-    val poolSettingsWithHttpsProxy  = 
-      ConnectionPoolSettings.apply(system)
-       /*
-        # The minimum duration to backoff new connection attempts after the previous connection attempt failed.
-        #
-        # The pool uses an exponential randomized backoff scheme. After the first failure, the next attempt will only be
-        # tried after a random duration between the base connection backoff and twice the base connection backoff. If that
-        # attempt fails as well, the next attempt will be delayed by twice that amount. The total delay is capped using the
-        # `max-connection-backoff` setting.
-        #
-        # The backoff applies for the complete pool. I.e. after one failed connection attempt, further connection attempts
-        # to that host will backoff for all connections of the pool. After the service recovered, connections will come out
-        # of backoff one by one due to the random extra backoff time. This is to avoid overloading just recently recovered
-        # services with new connections ("thundering herd").
-        #
-        # Example: base-connection-backoff = 100ms, max-connection-backoff = 10 seconds
-        #   - After 1st failure, backoff somewhere between 100ms and 200ms
-        #   - After 2nd, between  200ms and  400ms
-        #   - After 3rd, between  200ms and  400ms
-        #   - After 4th, between  400ms and  800ms
-        #   - After 5th, between  800ms and 1600ms
-        #   - After 6th, between 1600ms and 3200ms
-        #   - After 7th, between 3200ms and 6400ms
-        #   - After 8th, between 5000ms and 10 seconds (max capped by max-connection-backoff, min by half of that)
-        #   - After 9th, etc., stays between 5000ms and 10 seconds
-        #
-        # This setting only applies to the new pool implementation and is ignored for the legacy one.
-       */
+  private lazy val poolSettingsWithHttpsProxy  =
+    ConnectionPoolSettings.apply(system)
+      /*
+       # The minimum duration to backoff new connection attempts after the previous connection attempt failed.
+       #
+       # The pool uses an exponential randomized backoff scheme. After the first failure, the next attempt will only be
+       # tried after a random duration between the base connection backoff and twice the base connection backoff. If that
+       # attempt fails as well, the next attempt will be delayed by twice that amount. The total delay is capped using the
+       # `max-connection-backoff` setting.
+       #
+       # The backoff applies for the complete pool. I.e. after one failed connection attempt, further connection attempts
+       # to that host will backoff for all connections of the pool. After the service recovered, connections will come out
+       # of backoff one by one due to the random extra backoff time. This is to avoid overloading just recently recovered
+       # services with new connections ("thundering herd").
+       #
+       # Example: base-connection-backoff = 100ms, max-connection-backoff = 10 seconds
+       #   - After 1st failure, backoff somewhere between 100ms and 200ms
+       #   - After 2nd, between  200ms and  400ms
+       #   - After 3rd, between  200ms and  400ms
+       #   - After 4th, between  400ms and  800ms
+       #   - After 5th, between  800ms and 1600ms
+       #   - After 6th, between 1600ms and 3200ms
+       #   - After 7th, between 3200ms and 6400ms
+       #   - After 8th, between 5000ms and 10 seconds (max capped by max-connection-backoff, min by half of that)
+       #   - After 9th, etc., stays between 5000ms and 10 seconds
+       #
+       # This setting only applies to the new pool implementation and is ignored for the legacy one.
+      */
       .withBaseConnectionBackoff(1.second)
-       /*
-        # Maximum backoff duration between failed connection attempts. For more information see the above comment for the
-        # `base-connection-backoff` setting.
-        #
-        # This setting only applies to the new pool implementation and is ignored for the legacy one.
-       */
+      /*
+       # Maximum backoff duration between failed connection attempts. For more information see the above comment for the
+       # `base-connection-backoff` setting.
+       #
+       # This setting only applies to the new pool implementation and is ignored for the legacy one.
+      */
       .withMaxConnectionBackoff(1.minute)
-       /*
-        # The maximum number of times failed requests are attempted again,
-        # (if the request can be safely retried) before giving up and returning an error.
-        # Set to zero to completely disable request retries.
-       */
+      /*
+       # The maximum number of times failed requests are attempted again,
+       # (if the request can be safely retried) before giving up and returning an error.
+       # Set to zero to completely disable request retries.
+      */
       .withMaxRetries(5)
-    
+
+  private def makeHttpRequest(httpRequest: HttpRequest): Future[HttpResponse] =
     Http().singleRequest(request = httpRequest, settings = poolSettingsWithHttpsProxy)
-  }
 
   def main(args: Array[String]): Unit = {
     val uri = "https://www.openbankproject.com"


### PR DESCRIPTION
1. refactor dynamicEntity and dynamicEndpoint response error message.
2. ActorSystem() changed to ObpLookupSystem. caused create new ActorSystem.obpLookupSystem to avoid create new ActorSystem instance.

### Jenkins job is passed, it is ready to be merged.

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/318)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/74/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/182/)