### PR TITLE
feature/dynamic_endpoint_host_is_obp_mock

### DIFF
--- a/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
+++ b/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
@@ -81,7 +81,7 @@ object ErrorMessages {
   val InvalidInBoundMapping = "OBP-10032: Incorrect inBoundMapping Format, it should be a json structure."
   val InvalidUri = "OBP-10404: Request Not Found. The server has not found anything matching the Request-URI.Check your URL and the headers. " +
     "NOTE: when it is POST or PUT api, the Content-Type must be `application/json`. OBP only support the json format body."
-  val ResourceNotExists = "OBP-10405: Resource not exists."
+  val ResourceDoesNotExist = "OBP-10405: Resource does not exist."
 
   // General Sort and Paging
   val FilterSortDirectionError = "OBP-10023: obp_sort_direction parameter can only take two values: DESC or ASC!" // was OBP-20023

--- a/obp-api/src/main/scala/code/api/v3_1_0/APIMethods310.scala
+++ b/obp-api/src/main/scala/code/api/v3_1_0/APIMethods310.scala
@@ -4184,7 +4184,7 @@ trait APIMethods310 {
           for {
             (Full(u), callContext) <- authenticatedAccess(cc)
             _ <- NewStyle.function.hasEntitlement("", u.userId, ApiRole.canGetMethodRoutings, callContext)
-            methodRoutings <- NewStyle.function.getMethodRoutingsByMethdName(req.param("method_name"))
+            methodRoutings <- NewStyle.function.getMethodRoutingsByMethodName(req.param("method_name"))
           } yield {
             val listCommons: List[MethodRoutingCommons] = req.param("active") match {
               case Full("true") =>  methodRoutings ++ getDefaultMethodRountings(methodRoutings )
@@ -4316,7 +4316,7 @@ trait APIMethods310 {
                 Pattern.compile(postedData.bankIdPattern.get)
               }
             }
-            _ <- NewStyle.function.checkMethodRoutingAlreadyExists(methodName, callContext)
+            _ <- NewStyle.function.checkMethodRoutingAlreadyExists(postedData, callContext)
             Full(methodRouting) <- NewStyle.function.createOrUpdateMethodRouting(postedData)
           } yield {
             val commonsData: MethodRoutingCommons = methodRouting

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
@@ -551,7 +551,7 @@ object DynamicEndpointHelper extends RestHelper {
  * one endpoint information defined in swagger file.
  * @param path path defined in swagger file
  * @param successCode success response code
- * @param resourceDoc ResourseDoc built with one endpoint information defined in swagger file
+ * @param resourceDoc ResourceDoc built with one endpoint information defined in swagger file
  */
 case class DynamicEndpointItem(path: String, successCode: Int, resourceDoc: ResourceDoc)
 

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
@@ -8,7 +8,7 @@ import java.util.{Date, UUID}
 
 import akka.http.scaladsl.model.{HttpMethods, HttpMethod => AkkaHttpMethod}
 import code.DynamicEndpoint.{DynamicEndpointProvider, DynamicEndpointT}
-import code.api.util.APIUtil.{BigDecimalBody, BigIntBody, BooleanBody, Catalogs, DoubleBody, EmptyBody, FloatBody, IntBody, JArrayBody, LongBody, OBPEndpoint, ResourceDoc, StringBody, notCore, notOBWG, notPSD2}
+import code.api.util.APIUtil.{BigDecimalBody, BigIntBody, BooleanBody, Catalogs, DoubleBody, EmptyBody, FloatBody, IntBody, JArrayBody, LongBody, OBPEndpoint, PrimaryDataBody, ResourceDoc, StringBody, notCore, notOBWG, notPSD2}
 import code.api.util.ApiTag.{ResourceDocTag, apiTagApi, apiTagNewStyle}
 import code.api.util.ErrorMessages.{UnknownError, UserHasMissingRoles, UserNotLoggedIn}
 import code.api.util.{APIUtil, ApiRole, ApiTag, CustomJsonFormats}
@@ -24,9 +24,9 @@ import net.liftweb.common.{Box, Full}
 import net.liftweb.http.Req
 import net.liftweb.http.rest.RestHelper
 import net.liftweb.json
-import net.liftweb.json.JValue
+import net.liftweb.json.{Formats, JValue}
 import net.liftweb.json.JsonAST.{JArray, JField, JNothing, JObject}
-import net.liftweb.util.StringHelpers
+import net.liftweb.util.{StringHelpers, ThreadGlobal}
 import org.apache.commons.collections4.MapUtils
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.StringUtils
@@ -35,10 +35,10 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.List
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.compat.java8.OptionConverters._
 
 
 object DynamicEndpointHelper extends RestHelper {
+  protected override implicit def formats: Formats = CustomJsonFormats.formats
 
   /**
    * dynamic endpoints url prefix
@@ -47,21 +47,21 @@ object DynamicEndpointHelper extends RestHelper {
 
   private def dynamicEndpointInfos: List[DynamicEndpointInfo] = {
     val dynamicEndpoints: List[DynamicEndpointT] = DynamicEndpointProvider.connectorMethodProvider.vend.getAll()
-    val infos = dynamicEndpoints.map(it => swaggerToResourceDocs(it.swaggerString, it.dynamicEndpointId.get))
+    val infos = dynamicEndpoints.map(it => buildDynamicEndpointInfo(it.swaggerString, it.dynamicEndpointId.get))
     infos
   }
 
   def allDynamicEndpointRoles: List[ApiRole] = {
     for {
       dynamicEndpoint <- DynamicEndpointProvider.connectorMethodProvider.vend.getAll()
-      info = swaggerToResourceDocs(dynamicEndpoint.swaggerString, dynamicEndpoint.dynamicEndpointId.get)
+      info = buildDynamicEndpointInfo(dynamicEndpoint.swaggerString, dynamicEndpoint.dynamicEndpointId.get)
       role <- getRoles(info)
     } yield role
   }
 
   def getRoles(dynamicEndpointId: String): List[ApiRole] = {
     val foundInfos: Box[DynamicEndpointInfo] = DynamicEndpointProvider.connectorMethodProvider.vend.get(dynamicEndpointId)
-      .map(dynamicEndpoint => swaggerToResourceDocs(dynamicEndpoint.swaggerString, dynamicEndpoint.dynamicEndpointId.get))
+      .map(dynamicEndpoint => buildDynamicEndpointInfo(dynamicEndpoint.swaggerString, dynamicEndpoint.dynamicEndpointId.get))
 
 
     val roles: List[ApiRole] = foundInfos match {
@@ -86,6 +86,7 @@ object DynamicEndpointHelper extends RestHelper {
   object DynamicReq extends JsonTest with JsonBody {
 
     private val ExpressionRegx = """\{(.+?)\}""".r
+    private val IsMockUrl = """https?://obp_mock(?::\d+)?/.*""".r
     /**
      * unapply Request to (request url, json, http method, request parameters, path parameters, role)
      * request url is  current request target url to remote server
@@ -95,9 +96,9 @@ object DynamicEndpointHelper extends RestHelper {
      * path parameters: /banks/{bankId}/users/{userId} bankId and userId corresponding key to value
      * role is current endpoint required entitlement
      * @param r HttpRequest
-     * @return
+     * @return (adapterUrl, requestBodyJson, httpMethod, requestParams, pathParams, role, mockResponseCode->mockResponseBody)
      */
-    def unapply(r: Req): Option[(String, JValue, AkkaHttpMethod, Map[String, List[String]], Map[String, String], ApiRole)] = {
+    def unapply(r: Req): Option[(String, JValue, AkkaHttpMethod, Map[String, List[String]], Map[String, String], ApiRole, Option[(Int, JValue)])] = {
       val partPath = r.path.partPath
       if (!testResponse_?(r) || partPath.headOption != Option(urlPrefix))
         None
@@ -106,29 +107,42 @@ object DynamicEndpointHelper extends RestHelper {
         val httpMethod = HttpMethod.valueOf(r.requestType.method)
         // url that match original swagger endpoint.
         val url = partPath.tail.mkString("/", "/", "")
-        val foundDynamicEndpoint: Option[(DynamicEndpointInfo, ResourceDoc, String)] = dynamicEndpointInfos
+        val foundDynamicEndpoint: Option[(String, String, Int, ResourceDoc)] = dynamicEndpointInfos
           .map(_.findDynamicEndpoint(httpMethod, url))
           .collectFirst {
             case Some(x) => x
           }
 
         foundDynamicEndpoint
-          .flatMap[(String, JValue, AkkaHttpMethod, Map[String, List[String]], Map[String, String], ApiRole)] { it =>
-            val (dynamicEndpointInfo, doc, originalUrl) = it
+          .flatMap { it =>
+            val (serverUrl, endpointUrl, code, doc) = it
 
-            val pathParams: Map[String, String] = if(originalUrl == url) {
+            val pathParams: Map[String, String] = if(endpointUrl == url) {
               Map.empty[String, String]
             } else {
-              val tuples: Array[(String, String)] = StringUtils.split(originalUrl, "/").zip(partPath.tail)
+              val tuples: Array[(String, String)] = StringUtils.split(endpointUrl, "/").zip(partPath.tail)
               tuples.collect {
                 case (ExpressionRegx(name), value) => name->value
               }.toMap
             }
 
+            val mockResponse: Option[(Int, JValue)] = (serverUrl, doc.successResponseBody) match {
+              case (IsMockUrl(), v: PrimaryDataBody[_]) =>
+                Some(code -> v.toJValue)
+
+              case (IsMockUrl(), v: JValue) =>
+                Some(code -> v)
+
+              case (IsMockUrl(), v) =>
+                Some(code -> json.Extraction.decompose(v))
+
+              case _ => None
+            }
+
             val Some(role::_) = doc.roles
             body(r).toOption
               .orElse(Some(JNothing))
-              .map(t => (dynamicEndpointInfo.targetUrl(url), t, akkaHttpMethod, r.params, pathParams, role))
+              .map(zson => (s"""$serverUrl$url""", zson, akkaHttpMethod, r.params, pathParams, role, mockResponse))
           }
 
       }
@@ -147,13 +161,13 @@ object DynamicEndpointHelper extends RestHelper {
 
   private val dynamicEndpointInfoMemo = new Memo[String, DynamicEndpointInfo]
 
-  private def swaggerToResourceDocs(content: String, id: String): DynamicEndpointInfo =
+  private def buildDynamicEndpointInfo(content: String, id: String): DynamicEndpointInfo =
     dynamicEndpointInfoMemo.memoize(content) {
       val openAPI: OpenAPI = parseSwaggerContent(content)
-      swaggerToResourceDocs(openAPI, id)
+      buildDynamicEndpointInfo(openAPI, id)
     }
 
-  private def swaggerToResourceDocs(openAPI: OpenAPI, id: String): DynamicEndpointInfo = {
+  private def buildDynamicEndpointInfo(openAPI: OpenAPI, id: String): DynamicEndpointInfo = {
     val tags: List[ResourceDocTag] = List(ApiTag.apiTagDynamicEndpoint, apiTagApi, apiTagNewStyle)
 
     val serverUrl = {
@@ -164,7 +178,7 @@ object DynamicEndpointHelper extends RestHelper {
 
     val paths: mutable.Map[String, PathItem] = openAPI.getPaths.asScala
     def entitlementSuffix(path: String) = Math.abs(path.hashCode).toString.substring(0, 3) // to avoid different swagger have same entitlement
-    val docs: mutable.Iterable[(ResourceDoc, String)] = for {
+    val dynamicEndpointItems: mutable.Iterable[DynamicEndpointItem] = for {
       (path, pathItem) <- paths
       (method: HttpMethod, op: Operation) <- pathItem.readOperationsMap.asScala
     } yield {
@@ -210,7 +224,7 @@ object DynamicEndpointHelper extends RestHelper {
           |
           |""".stripMargin
       val exampleRequestBody: Product = getRequestExample(openAPI, op.getRequestBody)
-      val successResponseBody: Product = getResponseExample(openAPI, op.getResponses)
+      val (successCode, successResponseBody: Product) = getResponseExample(openAPI, op.getResponses)
       val errorResponseBodies: List[String] = List(
         UserNotLoggedIn,
         UserHasMissingRoles,
@@ -264,10 +278,10 @@ object DynamicEndpointHelper extends RestHelper {
         tags,
         roles
       )
-      (doc, path)
+      DynamicEndpointItem(path, successCode, doc)
     }
 
-    DynamicEndpointInfo(id, docs, serverUrl)
+    DynamicEndpointInfo(id, dynamicEndpointItems, serverUrl)
   }
 
   private val PathParamRegx = """\{(.+?)\}""".r
@@ -382,29 +396,34 @@ object DynamicEndpointHelper extends RestHelper {
     case _ => None
   }
 
-  private def getResponseExample(openAPI: OpenAPI, apiResponses: ApiResponses): Product = {
+  // get response example: success code -> success response body
+  private def getResponseExample(openAPI: OpenAPI, apiResponses: ApiResponses): (Int, Product) = {
+    val emptySuccess = 200 -> EmptyBody
+
     if(apiResponses == null || apiResponses.isEmpty) {
-      return EmptyBody
+      return emptySuccess
     }
 
-    val successResponse: Option[ApiResponse] = apiResponses.asScala
-      .find(_._1.startsWith("20"))
-      .orElse(apiResponses.asScala.find(_._1 == "default"))
-      .map(_._2)
+    val successResponse: Option[(Int, ApiResponse)] =
+      apiResponses.asScala.toList.sortBy(_._1) collectFirst {
+      case (code, apiResponse) if code.startsWith("20") => code.toInt -> apiResponse
+      case (code, apiResponse) if code == "default" => 200 -> apiResponse
+    }
 
-    val result: Option[Product] = for {
-     response <- successResponse
+    val result: Option[(Int, Product)] = for {
+     (code, response) <- successResponse
      schema <- getResponseSchema(openAPI, response)
      example = getExample(openAPI, schema)
-    } yield example
+    } yield code -> example
 
     result
       .orElse(
           successResponse.collect { //if only exists default ApiResponse, use description as example
-            case v if StringUtils.isNoneBlank(v.getDescription) => StringBody(v.getDescription)
+            case (code, apiResponse) if StringUtils.isNotBlank(apiResponse.getDescription) =>
+              code -> StringBody(apiResponse.getDescription)
           }
        )
-      .getOrElse(EmptyBody)
+      .getOrElse(emptySuccess)
   }
 
   private def getResponseSchema(openAPI: OpenAPI, apiResponse: ApiResponse): Option[Schema[_]] = {
@@ -529,25 +548,35 @@ object DynamicEndpointHelper extends RestHelper {
 }
 
 /**
+ * one endpoint information defined in swagger file.
+ * @param path path defined in swagger file
+ * @param successCode success response code
+ * @param resourceDoc ResourseDoc built with one endpoint information defined in swagger file
+ */
+case class DynamicEndpointItem(path: String, successCode: Int, resourceDoc: ResourceDoc)
+
+/**
  *
  * @param id DynamicEntity id value
- * @param docsToUrl ResourceDoc to url that defined in swagger content
+ * @param dynamicEndpointItems ResourceDoc to url that defined in swagger content
  * @param serverUrl base url that defined in swagger content
  */
-case class DynamicEndpointInfo(id: String, docsToUrl: mutable.Iterable[(ResourceDoc, String)], serverUrl: String) {
-  val resourceDocs: mutable.Iterable[ResourceDoc] = docsToUrl.map(_._1)
+case class DynamicEndpointInfo(id: String, dynamicEndpointItems: mutable.Iterable[DynamicEndpointItem], serverUrl: String) {
+  val resourceDocs: mutable.Iterable[ResourceDoc] = dynamicEndpointItems.map(_.resourceDoc)
 
-  private val existsUrlToMethod: mutable.Iterable[(HttpMethod, String, ResourceDoc)] =
-    docsToUrl
+  private val existsUrlToMethod: mutable.Iterable[(HttpMethod, String, Int, ResourceDoc)] =
+    dynamicEndpointItems
     .map(it => {
-      val (doc, path) = it
-      (HttpMethod.valueOf(doc.requestVerb), path, doc)
+      val DynamicEndpointItem(path, code, doc) = it
+      (HttpMethod.valueOf(doc.requestVerb), path, code, doc)
     })
 
-  def findDynamicEndpoint(newMethod: HttpMethod, newUrl: String): Option[(DynamicEndpointInfo, ResourceDoc, String)] = existsUrlToMethod.find(it => {
-    val (method, url, _) = it
-    isSameUrl(newUrl, url) && newMethod == method
-  }).map(it => (this, it._3, it._2))
+  // return (serverUrl, endpointUrl, successCode, resourceDoc)
+  def findDynamicEndpoint(newMethod: HttpMethod, newUrl: String): Option[(String, String, Int, ResourceDoc)] =
+    existsUrlToMethod collectFirst {
+    case (method, url, code, doc) if isSameUrl(newUrl, url) && newMethod == method =>
+      (this.serverUrl, url, code, doc)
+  }
 
   def existsEndpoint(newMethod: HttpMethod, newUrl: String): Boolean = findDynamicEndpoint(newMethod, newUrl).isDefined
 
@@ -579,4 +608,19 @@ case class DynamicEndpointInfo(id: String, docsToUrl: mutable.Iterable[(Resource
     }
   }
 
+}
+
+/**
+ * if the endpoint domain is obp_mock, then pass success code and example response to connector
+ */
+object MockResponseHolder {
+  private val _codeAndBody = new ThreadGlobal[(Int, JValue)]
+
+  def init[B](codeAndBody: Option[(Int, JValue)])(f: => B): B = {
+    _codeAndBody.doWith(codeAndBody.orNull) {
+      f
+    }
+  }
+
+  def mockResponse: Box[(Int, JValue)] = _codeAndBody.box
 }

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEntityHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEntityHelper.scala
@@ -293,8 +293,7 @@ case class DynamicEntityInfo(definition: String, entityName: String) {
   val description = entity \ "description" match {
     case JString(s) if StringUtils.isNotBlank(s) =>
       s"""
-        |**Entity Description:**
-        |$s
+        |${s.capitalize}
         |""".stripMargin
     case _ => ""
   }
@@ -312,7 +311,7 @@ case class DynamicEntityInfo(definition: String, entityName: String) {
       if(descriptions.nonEmpty) {
         descriptions
           .map(field => s"""* ${field.name}: ${(field.value \ "description").asInstanceOf[JString].s}""")
-          .mkString("**Properties Description:** \n", "\n", "")
+          .mkString("**Property List:** \n", "\n", "")
       } else {
         ""
       }

--- a/obp-api/src/main/scala/code/bankconnectors/ConnectorBuilderUtil.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/ConnectorBuilderUtil.scala
@@ -170,7 +170,7 @@ object ConnectorBuilderUtil {
       }
 
       var body =
-      s"""|    import com.openbankproject.commons.dto.{$outBoundName => OutBound, $inBoundName => InBound}  $callContext
+      s"""|    import com.openbankproject.commons.dto.{$inBoundName => InBound, $outBoundName => OutBound}  $callContext
           |        val req = OutBound($parametersNamesString)
           |        val response: Future[Box[InBound]] = ${responseExpression(methodName)}
           |        response.map(convertToTuple[$inboundDataFieldType](callContext))        """.stripMargin

--- a/obp-api/src/main/scala/code/bankconnectors/rest/RestConnector_vMar2019.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/rest/RestConnector_vMar2019.scala
@@ -9233,7 +9233,7 @@ trait RestConnector_vMar2019 extends Connector with KafkaHelper with MdcLoggable
     val mockResponse: Box[(Int, JValue)] = MockResponseHolder.mockResponse
 
     // when there is no methodRouting, but there is mock response, just return mock response content
-    if(urlInMethodRouting.isEmpty &&  mockResponse.isDefined) {
+    if(urlInMethodRouting.isEmpty && mockResponse.isDefined) {
       val Full((code, body)) = mockResponse
       val response: JObject = ("code" -> code) ~ ("value" -> body)
       return Future.successful((Full(response), callContext))

--- a/obp-api/src/main/scala/code/bankconnectors/rest/RestConnector_vMar2019.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/rest/RestConnector_vMar2019.scala
@@ -9437,7 +9437,7 @@ trait RestConnector_vMar2019 extends Connector with KafkaHelper with MdcLoggable
       case (status, entity) if status.isSuccess() => extractEntity[T](entity, inBoundMapping)
       case (status, _) if status.intValue == 404 =>
         Future {
-          val errorMsg = s"$ResourceNotExists the resource url is: $url"
+          val errorMsg = s"$ResourceDoesNotExist the resource url is: $url"
           ParamFailure(errorMsg, APIFailureNewStyle(errorMsg, status.intValue()))
         }
       case (status, entity) => {

--- a/obp-api/src/main/scala/code/bankconnectors/rest/RestConnector_vMar2019.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/rest/RestConnector_vMar2019.scala
@@ -23,57 +23,55 @@ Osloerstrasse 16/17
 Berlin 13359, Germany
 */
 
-import java.net.{ConnectException, URLEncoder}
-import java.util.UUID.randomUUID
+import java.net.{ConnectException, URLEncoder, UnknownHostException}
 import java.util.Date
+import java.util.UUID.randomUUID
 
-import akka.http.scaladsl.model.{HttpProtocol, _}
-import akka.http.scaladsl.model.headers.RawHeader
-import akka.util.ByteString
 import _root_.akka.stream.StreamTcpException
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{HttpProtocol, _}
+import akka.util.ByteString
+import code.api.APIFailureNewStyle
 import code.api.ResourceDocs1_4_0.MessageDocsSwaggerDefinitions
-import code.api.{APIFailure, APIFailureNewStyle}
-import com.openbankproject.commons.model.ErrorMessage
 import code.api.cache.Caching
-import code.api.util.APIUtil.{AdapterImplementation, MessageDoc, OBPReturnType, saveConnectorMetric}
+import code.api.util.APIUtil.{AdapterImplementation, MessageDoc, OBPReturnType, saveConnectorMetric, _}
 import code.api.util.ErrorMessages._
-import code.api.util.{APIUtil, CallContext, CustomJsonFormats, NewStyle, OBPQueryParam}
+import code.api.util.ExampleValue._
+import code.api.util.{APIUtil, CallContext, OBPQueryParam}
+import code.api.v4_0_0.MockResponseHolder
 import code.bankconnectors._
 import code.bankconnectors.vJune2017.AuthInfo
+import code.customer.internalMapping.MappedCustomerIdMappingProvider
 import code.kafka.KafkaHelper
+import code.model.dataAccess.internalMapping.MappedAccountIdMappingProvider
 import code.util.AkkaHttpClient._
 import code.util.Helper.MdcLoggable
 import com.openbankproject.commons.dto.{InBoundTrait, _}
-import com.openbankproject.commons.model.{TopicTrait, _}
+import com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SCA
+import com.openbankproject.commons.model.enums.{AccountAttributeType, CardAttributeType, DynamicEntityOperation, ProductAttributeType}
+import com.openbankproject.commons.model.{ErrorMessage, TopicTrait, _}
+import com.openbankproject.commons.util.{JsonUtils, ReflectUtils}
 import com.tesobe.{CacheKeyFromArguments, CacheKeyOmit}
 import net.liftweb.common.{Box, Empty, _}
+import net.liftweb.json
+import net.liftweb.json.Extraction.decompose
+import net.liftweb.json.JsonDSL._
+import net.liftweb.json.JsonParser.ParseException
+import net.liftweb.json.{JValue, _}
 import net.liftweb.util.Helpers.tryo
+import org.apache.commons.lang3.StringUtils
 
 import scala.collection.immutable.List
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 import scala.reflect.runtime.universe._
-import code.api.util.ExampleValue._
-import code.api.util.APIUtil._
-import com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SCA
-import code.customer.internalMapping.MappedCustomerIdMappingProvider
-import code.model.dataAccess.internalMapping.MappedAccountIdMappingProvider
-import com.openbankproject.commons.util.JsonUtils
-import com.openbankproject.commons.model.enums.{AccountAttributeType, CardAttributeType, DynamicEntityOperation, ProductAttributeType}
-import com.openbankproject.commons.util.ReflectUtils
-import net.liftweb.json
-import net.liftweb.json.{JValue, _}
-import net.liftweb.json.JsonDSL._
-import net.liftweb.json.Extraction.decompose
-import net.liftweb.json.JsonParser.ParseException
-import org.apache.commons.lang3.StringUtils
 
 
 trait RestConnector_vMar2019 extends Connector with KafkaHelper with MdcLoggable {
   //this one import is for implicit convert, don't delete
-  import com.openbankproject.commons.model.{CustomerFaceImage, CreditLimit, CreditRating, AmountOfMoney}
+  import com.openbankproject.commons.model.{AmountOfMoney, CreditLimit, CreditRating, CustomerFaceImage}
 
   implicit override val nameOfConnector = RestConnector_vMar2019.toString
 
@@ -9232,6 +9230,15 @@ trait RestConnector_vMar2019 extends Connector with KafkaHelper with MdcLoggable
       case _: EmptyBox => None
       case Full(routing) => routing.parameters.find(_.key == "url").map(_.value)
     }
+    val mockResponse: Box[(Int, JValue)] = MockResponseHolder.mockResponse
+
+    // when there is no methodRouting, but there is mock response, just return mock response content
+    if(urlInMethodRouting.isEmpty &&  mockResponse.isDefined) {
+      val Full((code, body)) = mockResponse
+      val response: JObject = ("code" -> code) ~ ("value" -> body)
+      return Future.successful((Full(response), callContext))
+    }
+
     val pathVariableRex = """\{:(.+?)\}""".r
     val targetUrl = urlInMethodRouting.map { urlInRouting =>
       val tuples: Iterator[(String, String)] = pathVariableRex.findAllMatchIn(urlInRouting).map{ regex =>
@@ -9249,7 +9256,7 @@ trait RestConnector_vMar2019 extends Connector with KafkaHelper with MdcLoggable
         expression -> paramValue
       }
 
-      (urlInRouting /: tuples) {(pre, kv)=>
+      tuples.foldLeft(urlInRouting) { (pre, kv)=>
         pre.replace(kv._1, kv._2)
       }
     }.getOrElse(url)
@@ -9307,9 +9314,9 @@ trait RestConnector_vMar2019 extends Connector with KafkaHelper with MdcLoggable
         Future.failed(
           new Exception(s"$AdapterTimeOurError Please Check Adapter Side, the response should be returned to OBP-Side in $httpRequestTimeout seconds. Details: ${e.getMessage}", e)
         )
-      case e: StreamTcpException if classOf[ConnectException].isInstance(e.getCause) =>
+      case e: StreamTcpException if classOf[ConnectException].isInstance(e.getCause) || classOf[UnknownHostException].isInstance(e.getCause)=>
         logger.error(s"dynamic endpoint corresponding adapter function not available, the http method is: $method, url is ${method.value}", e)
-        Future.failed(new Exception(s"$AdapterFunctionNotImplemented Please Check Rest Adapter Side! Details: the http method is: ${method.value}, url is $paramUrl", e))
+        Future.failed(new Exception(s"$AdapterFunctionNotImplemented Please Check Rest Adapter Side! http method: ${method.value}, url: $paramUrl", e))
       case e: Exception =>
         Future.failed(new Exception(s"$AdapterUnknownError Please Check Adapter Side! Details: ${e.getMessage}", e))
     }
@@ -9430,9 +9437,8 @@ trait RestConnector_vMar2019 extends Connector with KafkaHelper with MdcLoggable
     val request = prepareHttpRequest(url, method, HttpProtocol("HTTP/1.1"), outBoundJson).withHeaders(callContext)
     logger.debug(s"RestConnector_vMar2019 request is : $request")
     val responseFuture = makeHttpRequest(request)
-    val jsonType = typeOf[T]
     responseFuture.map {
-      case response@HttpResponse(status, _, entity@_, _) => (status, entity)
+      case HttpResponse(status, _, entity@_, _) => (status, entity)
     }.flatMap {
       case (status, entity) if status.isSuccess() => extractEntity[T](entity, inBoundMapping)
       case (status, _) if status.intValue == 404 =>

--- a/obp-api/src/main/scala/code/dynamicEntity/DynamicEntityProvider.scala
+++ b/obp-api/src/main/scala/code/dynamicEntity/DynamicEntityProvider.scala
@@ -433,10 +433,13 @@ object DynamicEntityCommons extends Converter[DynamicEntityT, DynamicEntityCommo
       // 'type' exists and value should be one of allowed type
       val fieldType = value \ "type"
       val fieldTypeName = fieldType.asInstanceOf[JString].s
+
       checkFormat(fieldType.isInstanceOf[JString] && fieldTypeName.nonEmpty, s"$DynamicEntityInstanceValidateFail The property of $fieldName's 'type' field should be exists and type is json string")
       checkFormat(allowedFieldType.contains(fieldTypeName), s"$DynamicEntityInstanceValidateFail The property of $fieldName's 'type' field should be one of these string value: ${allowedFieldType.mkString(", ")}")
 
-      if(DynamicEntityFieldType.withName(fieldTypeName) == DynamicEntityFieldType.string) {
+      val fieldTypeOp: Option[DynamicEntityFieldType] = DynamicEntityFieldType.withNameOption(fieldTypeName)
+
+      if(fieldTypeOp.exists(_ == DynamicEntityFieldType.string)) {
         val minLength = value \ "minLength"
         val maxLength = value \ "maxLength"
         def toInt(jValue: JValue) = jValue.asInstanceOf[JInt].num.intValue()
@@ -458,8 +461,8 @@ object DynamicEntityCommons extends Converter[DynamicEntityT, DynamicEntityCommo
       val fieldExample = value \ "example"
       checkFormat(fieldExample != JNothing, s"$DynamicEntityInstanceValidateFail The property of $fieldName's 'example' field should be exists")
       // example type is correct
-      if(DynamicEntityFieldType.withNameOption(fieldTypeName).isDefined) {
-        val dEntityFieldType: DynamicEntityFieldType = DynamicEntityFieldType.withName(fieldTypeName)
+      if(fieldTypeOp.isDefined) {
+        val Some(dEntityFieldType: DynamicEntityFieldType) = fieldTypeOp
         checkFormat(dEntityFieldType.isJValueValid(fieldExample),
           s"$DynamicEntityInstanceValidateFail The value of $fieldName's 'example' is wrong, ${dEntityFieldType.wrongTypeMsg}")
       } else if(ReferenceType.referenceTypeNames.contains(fieldTypeName)) {


### PR DESCRIPTION
1. When swagger's host field is `obp_mock`, dynamic endpoint will return example response.
2. change doc description of `Create dynamic entity data`.
3. fix a bug caused by create dynamic entity with reference type field.

### Jenkins job is passed, it is ready to be merged.

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/323)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/79/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/191/)