### PR TITLE
features: move dynamic endpoints to group, query by AccountAttribute

### DIFF
--- a/obp-api/src/main/scala/code/api/util/ApiTag.scala
+++ b/obp-api/src/main/scala/code/api/util/ApiTag.scala
@@ -67,8 +67,8 @@ object ApiTag {
   val apiTagConsent = ResourceDocTag("Consent")
   val apiTagMethodRouting = ResourceDocTag("Method-Routing")
   val apiTagWebUiProps = ResourceDocTag("WebUi-Props")
-  val apiTagDynamicEntity= ResourceDocTag("Dynamic-Entity")
-  val apiTagDynamicEndpoint= ResourceDocTag("Dynamic-Endpoint")
+  val apiTagDynamicEntity = ResourceDocTag("Dynamic-Entity")
+  val apiTagDynamicEndpoint = ResourceDocTag("Dynamic-Endpoints-(Manage)")
 
   // To mark the Berlin Group APIs suggested order of implementation
   val apiTagBerlinGroupM = ResourceDocTag("Berlin-Group-M")

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
@@ -168,7 +168,7 @@ object DynamicEndpointHelper extends RestHelper {
     }
 
   private def buildDynamicEndpointInfo(openAPI: OpenAPI, id: String): DynamicEndpointInfo = {
-    val tags: List[ResourceDocTag] = List(ApiTag.apiTagDynamicEndpoint, apiTagApi, apiTagNewStyle)
+    val tags: List[ResourceDocTag] = List(ApiTag(s"Dynamic-Endpoints-Grp-(${openAPI.getInfo.getTitle})"), apiTagApi, apiTagNewStyle)
 
     val serverUrl = {
       val servers = openAPI.getServers


### PR DESCRIPTION
1. move dynamic endpoints to the separated group.
2. endpoint `Get Firehose Accounts at Bank` support query parameter to filter with AccountAttribute name and value.

### Jenkins job is passed, it is ready to be merged.

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/324)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/80/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/192/)