### PR TITLE
feature/change_dynamic_endpoints_group_name

### DIFF
--- a/obp-api/src/main/scala/code/api/util/Pegdown.scala
+++ b/obp-api/src/main/scala/code/api/util/Pegdown.scala
@@ -28,6 +28,8 @@ object PegdownOptions {
       .replaceAll("&amp;;", "&")
       .replaceAll("&lsquo;", "'")
       .replaceAll("&hellip;", "...")
+        //not support make text bold that not at beginning of a line, so here manual convert to it to <strong> tag
+      .replaceAll("""\*\*(.+?)\*\*""", "<strong>$1</strong>")
   }
   // convertPegdownToHtmlTweaked not support insert image, so here manual convert to html img tag
   private def convertImgTag(markdown: String) = markdown.stripMargin.replaceAll("""!\[(.*)\]\((.*) =(.*?)x(.*?)\)""", """<img alt="$1" src="$2" width="$3" height="$4" />""")

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEndpointHelper.scala
@@ -168,7 +168,7 @@ object DynamicEndpointHelper extends RestHelper {
     }
 
   private def buildDynamicEndpointInfo(openAPI: OpenAPI, id: String): DynamicEndpointInfo = {
-    val tags: List[ResourceDocTag] = List(ApiTag(s"Dynamic-Endpoints-Grp-(${openAPI.getInfo.getTitle})"), apiTagApi, apiTagNewStyle)
+    val tags: List[ResourceDocTag] = List(ApiTag(openAPI.getInfo.getTitle), apiTagApi, apiTagNewStyle)
 
     val serverUrl = {
       val servers = openAPI.getServers

--- a/obp-api/src/main/scala/code/api/v4_0_0/DynamicEntityHelper.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/DynamicEntityHelper.scala
@@ -310,8 +310,8 @@ case class DynamicEntityInfo(definition: String, entityName: String) {
       )
       if(descriptions.nonEmpty) {
         descriptions
-          .map(field => s"""* ${field.name}: ${(field.value \ "description").asInstanceOf[JString].s}""")
-          .mkString("**Property List:** \n", "\n", "")
+          .map(field => s"""<li> ${field.name}: ${(field.value \ "description").asInstanceOf[JString].s}</li>""")
+          .mkString("**Property List:** \n<ul>", "\n", "</ul>")
       } else {
         ""
       }


### PR DESCRIPTION

1. change dynamic endpoints group name: change from  Dynamic-Endpoints-Grp-(${openAPI.getInfo.getTitle}) to openAPI.getInfo.getTitle
2. change dynamic entity fields description: change from asterisk to bullet point, that it is * to **·**


![new group name](https://user-images.githubusercontent.com/2577334/90406758-2fef6f80-e0d8-11ea-8dad-8b59cf46ae97.jpg)
![bullets](https://user-images.githubusercontent.com/2577334/90406751-2d8d1580-e0d8-11ea-88bd-bdf0a0ccf1b6.jpg)

### Jenkins job is pass, please merge this pull request. 

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/328)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/84/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/196/)
