### PR TITLE
Add the account routings deletion in DeleteAccountCascade

### DIFF
--- a/obp-api/src/main/scala/deletion/DeleteAccountCascade.scala
+++ b/obp-api/src/main/scala/deletion/DeleteAccountCascade.scala
@@ -6,7 +6,7 @@ import code.api.util.APIUtil.fullBoxOrException
 import code.api.util.ErrorMessages.CouldNotDeleteCascade
 import code.bankconnectors.Connector
 import code.cards.MappedPhysicalCard
-import code.model.dataAccess.{MappedBankAccount, MappedBankAccountData}
+import code.model.dataAccess.{BankAccountRouting, MappedBankAccount, MappedBankAccountData}
 import code.views.system.{AccountAccess, ViewDefinition}
 import code.webhook.MappedAccountWebhook
 import com.openbankproject.commons.model.{AccountId, BankId}
@@ -29,6 +29,7 @@ object DeleteAccountCascade {
         deleteAccountWebhooks(bankId, accountId) ::
         deleteBankAccountData(bankId, accountId) ::
         deleteCards(accountId) ::
+        deleteAccountRoutings(bankId, accountId) ::
         deleteAccount(bankId, accountId) ::
         Nil
     doneTasks.forall(_ == true)
@@ -90,6 +91,12 @@ object DeleteAccountCascade {
     AccountAccess.bulkDelete_!!(
       By(AccountAccess.bank_id, bankId.value),
       By(AccountAccess.account_id, accountId.value)
+    )
+  }
+  private def deleteAccountRoutings(bankId: BankId, accountId: AccountId): Boolean = {
+    BankAccountRouting.bulkDelete_!!(
+      By(BankAccountRouting.BankId, bankId.value),
+      By(BankAccountRouting.AccountId, accountId.value)
     )
   }
 


### PR DESCRIPTION
Partial solution to a problem encountered by Marko. He tried to create a new account with an already existing routing scheme.

The routing scheme was existing, but not the account linked to this routoing scheme, so the connector method `getBankAccountByRouting` didn't returned the account although the account routing was existing. This generated an SQL error.
```
Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: Cannot insert duplicate key row in object 'dbo.bankaccountrouting' with unique index 'bankaccountrouting_bankid_accountroutingscheme_accountroutingaddress'. The duplicate key value is (1, AccountNumber, 4930396).
```

An accountRouting shouldn't exist without an associated existing account.

The real solution will be to add foreign keys constrainst to avoid this data integrity problems.