### PR TITLE
Add transaction_attributes in getTransaction(s) endpoints

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -2853,7 +2853,13 @@ object SwaggerDefinitionsJSON {
     this_account = thisAccountJsonV300,
     other_account = otherAccountJsonV300,
     details = transactionDetailsJSON,
-    metadata = transactionMetadataJSON
+    metadata = transactionMetadataJSON,
+    transaction_attributes = List(TransactionAttributeResponseJson(
+      transaction_attribute_id = transactionAttributeIdExample.value,
+      name = transactionAttributeNameExample.value,
+      `type` = transactionAttributeTypeExample.value,
+      value = transactionAttributeValueExample.value
+    ))
   )
   
   val transactionsJsonV300 = TransactionsJsonV300(
@@ -2871,7 +2877,13 @@ object SwaggerDefinitionsJSON {
     id = "5995d6a2-01b3-423c-a173-5481df49bdaf",
     this_account = thisAccountJsonV300,
     other_account = coreCounterpartyJsonV300,
-    details = coreTransactionDetailsJSON
+    details = coreTransactionDetailsJSON,
+    transaction_attributes = List(TransactionAttributeResponseJson(
+      transaction_attribute_id = transactionAttributeIdExample.value,
+      name = transactionAttributeNameExample.value,
+      `type` = transactionAttributeTypeExample.value,
+      value = transactionAttributeValueExample.value
+    ))
   )
   
   val coreCounterpartiesJsonV300 =  CoreCounterpartiesJsonV300(

--- a/obp-api/src/main/scala/code/api/v3_0_0/APIMethods300.scala
+++ b/obp-api/src/main/scala/code/api/v3_0_0/APIMethods300.scala
@@ -595,38 +595,40 @@ trait APIMethods300 {
       //get private accounts for all banks
       case "banks" :: BankId(bankId):: "firehose" :: "accounts" ::  AccountId(accountId) :: "views" :: ViewId(viewId) :: "transactions" :: Nil JsonGet req => {
         cc =>
-          val res =
-            for {
-              (Full(u), callContext) <-  authenticatedAccess(cc)
-              _ <- Helper.booleanToFuture(failMsg = AccountFirehoseNotAllowedOnThisInstance +" or " + UserHasMissingRoles + CanUseAccountFirehoseAtAnyBank  ) {
-               canUseAccountFirehose(u)
-              }
-              (bank, callContext) <- NewStyle.function.getBank(bankId, callContext)
-              (bankAccount, callContext) <- NewStyle.function.getBankAccount(bankId, accountId, callContext)
-              view <- NewStyle.function.checkViewAccessAndReturnView(viewId, BankIdAccountId(bankAccount.bankId, bankAccount.accountId),Some(u), callContext)
-              allowedParams = List("sort_direction", "limit", "offset", "from_date", "to_date")
-              httpParams <- NewStyle.function.extractHttpParamsFromUrl(cc.url)
-              obpQueryParams <- NewStyle.function.createObpParams(httpParams, allowedParams, callContext)
-              reqParams = req.params.filterNot(param => allowedParams.contains(param._1))
-              (transactionIds, callContext) <- if(reqParams.nonEmpty) {
-                 NewStyle.function.getTransactionIdsByAttributeNameValues(bankId, reqParams, callContext)
-              } else{
-                Future((List.empty[TransactionId], callContext))
-              }
-            } yield {
-              for {
-              //Note: error handling and messages for getTransactionParams are in the sub method
-                (transactions, callContext) <- bankAccount.getModeratedTransactions(bank, Full(u), view, BankIdAccountId(bankId, accountId), callContext, obpQueryParams)
-                transactionsFiltered= if(reqParams.isEmpty) {
-                  transactions
-                } else {
-                  transactions.filter(transaction => transactionIds.contains(transaction.id))
-                }
-              } yield {
-                (createTransactionsJson(transactionsFiltered), HttpCode.`200`(callContext))
-              }
+          for {
+            (Full(u), callContext) <-  authenticatedAccess(cc)
+            _ <- Helper.booleanToFuture(failMsg = AccountFirehoseNotAllowedOnThisInstance +" or " + UserHasMissingRoles + CanUseAccountFirehoseAtAnyBank  ) {
+             canUseAccountFirehose(u)
             }
-          res map { fullBoxOrException(_) } map { unboxFull(_) }
+            (bank, callContext) <- NewStyle.function.getBank(bankId, callContext)
+            (bankAccount, callContext) <- NewStyle.function.getBankAccount(bankId, accountId, callContext)
+            view <- NewStyle.function.checkViewAccessAndReturnView(viewId, BankIdAccountId(bankAccount.bankId, bankAccount.accountId),Some(u), callContext)
+            allowedParams = List("sort_direction", "limit", "offset", "from_date", "to_date")
+            httpParams <- NewStyle.function.extractHttpParamsFromUrl(cc.url)
+            obpQueryParams <- NewStyle.function.createObpParams(httpParams, allowedParams, callContext)
+            reqParams = req.params.filterNot(param => allowedParams.contains(param._1))
+            (transactionIds, callContext) <- if(reqParams.nonEmpty) {
+               NewStyle.function.getTransactionIdsByAttributeNameValues(bankId, reqParams, callContext)
+            } else{
+              Future((List.empty[TransactionId], callContext))
+            }
+            (transactions, callContext) <- Future(bankAccount.getModeratedTransactions(bank, Full(u), view, BankIdAccountId(bankId, accountId), callContext, obpQueryParams)) map {
+              unboxFullOrFail(_, callContext, UnknownError)
+            }
+            (moderatedTansactionsWithAttributes, callContext) <- Future.sequence(transactions.map(transaction =>
+              NewStyle.function.getTransactionAttributes(
+                bankId,
+                transaction.id,
+                cc.callContext: Option[CallContext]).map(attributes => ModeratedTransactionWithAttributes(transaction, attributes._1))
+            )).map(t => (t, callContext))
+            transactionsFiltered = if(reqParams.isEmpty) {
+              moderatedTansactionsWithAttributes
+            } else {
+              moderatedTansactionsWithAttributes.filter(t => transactionIds.contains(t.transaction.id))
+            }
+          } yield {
+            (createTransactionsJson(transactionsFiltered), HttpCode.`200`(callContext))
+          }
       }
     }
 
@@ -682,8 +684,14 @@ trait APIMethods300 {
             (transactionsCore, callContext) <- bankAccount.getModeratedTransactionsCore(bank, Some(user), view, BankIdAccountId(bankId, accountId), params, callContext) map {
               i => (unboxFullOrFail(i._1, callContext, UnknownError), i._2)
             }
+            moderatedTransactionsCoreWithAttributes <- Future.sequence(transactionsCore.map(transaction =>
+              NewStyle.function.getTransactionAttributes(
+                bankId,
+                transaction.id,
+                cc.callContext: Option[CallContext]).map(attributes => ModeratedTransactionCoreWithAttributes(transaction, attributes._1))
+            ))
           } yield {
-            (createCoreTransactionsJSON(transactionsCore), HttpCode.`200`(callContext))
+            (createCoreTransactionsJSON(moderatedTransactionsCoreWithAttributes), HttpCode.`200`(callContext))
           }
       }
     }
@@ -742,8 +750,14 @@ trait APIMethods300 {
             (transactions, callContext) <- bankAccount.getModeratedTransactionsFuture(bank, user, view, BankIdAccountId(bankId, accountId), callContext, params) map {
               connectorEmptyResponse(_, callContext)
             }
+            moderatedTansactionsWithAttributes <- Future.sequence(transactions.map(transaction =>
+              NewStyle.function.getTransactionAttributes(
+                bankId,
+                transaction.id,
+                cc.callContext: Option[CallContext]).map(attributes => ModeratedTransactionWithAttributes(transaction, attributes._1))
+            ))
           } yield {
-            (createTransactionsJson(transactions), HttpCode.`200`(callContext))
+            (createTransactionsJson(moderatedTansactionsWithAttributes), HttpCode.`200`(callContext))
           }
       }
     }

--- a/obp-api/src/main/scala/code/api/v3_1_0/APIMethods310.scala
+++ b/obp-api/src/main/scala/code/api/v3_1_0/APIMethods310.scala
@@ -1119,7 +1119,7 @@ trait APIMethods310 {
          |
          |""",
       emptyObjectJson,
-      transactionJSON,
+      transactionJsonV300,
       List(UserNotLoggedIn, BankAccountNotFound ,ViewNotFound, UserNoPermissionAccessView, UnknownError),
       Catalogs(Core, notPSD2, OBWG),
       List(apiTagTransaction, apiTagNewStyle))
@@ -1136,8 +1136,12 @@ trait APIMethods310 {
             (moderatedTransaction, callContext) <- account.moderatedTransactionFuture(bankId, accountId, transactionId, view, user, callContext) map {
               unboxFullOrFail(_, callContext, GetTransactionsException)
             }
+            (transactionAttributes, callContext) <- NewStyle.function.getTransactionAttributes(
+              bankId,
+              transactionId,
+              cc.callContext: Option[CallContext])
           } yield {
-            (JSONFactory.createTransactionJSON(moderatedTransaction), HttpCode.`200`(callContext))
+            (JSONFactory300.createTransactionJSON(moderatedTransaction, transactionAttributes), HttpCode.`200`(callContext))
           }
       }
     }

--- a/obp-api/src/main/scala/code/obp/grpc/HelloWorldServer.scala
+++ b/obp-api/src/main/scala/code/obp/grpc/HelloWorldServer.scala
@@ -3,7 +3,7 @@ package code.obp.grpc
 import java.util.logging.Logger
 
 import code.api.util.{APIUtil, CallContext, NewStyle}
-import code.api.v3_0_0.CoreTransactionsJsonV300
+import code.api.v3_0_0.{CoreTransactionsJsonV300, ModeratedTransactionCoreWithAttributes}
 import code.api.v4_0_0.{BankJson400, BanksJson400, JSONFactory400, OBPAPI4_0_0}
 import code.obp.grpc.api.BanksJson400Grpc.{BankJson400Grpc, BankRoutingJsonV121Grpc}
 import code.obp.grpc.api._
@@ -131,7 +131,7 @@ class HelloWorldServer(executionContext: ExecutionContext) { self =>
         (bank, callContext) <- NewStyle.function.getBank(bankId, callContext)
         view <- NewStyle.function.checkOwnerViewAccessAndReturnOwnerView(user, BankIdAccountId(bankAccount.bankId, bankAccount.accountId), callContext)
         (Full(transactionsCore), callContext) <- bankAccount.getModeratedTransactionsCore(bank, Full(user), view, BankIdAccountId(bankId, accountId), Nil, callContext)
-        obpCoreTransactions: CoreTransactionsJsonV300 = code.api.v3_0_0.JSONFactory300.createCoreTransactionsJSON(transactionsCore)
+        obpCoreTransactions: CoreTransactionsJsonV300 = code.api.v3_0_0.JSONFactory300.createCoreTransactionsJSON(transactionsCore.map(ModeratedTransactionCoreWithAttributes(_)))
       } yield {
         val jValue = Extraction.decompose(obpCoreTransactions)
         val coreTransactionsJsonV300Grpc = jValue.extract[CoreTransactionsJsonV300Grpc]

--- a/obp-api/src/test/scala/code/api/v3_1_0/TransactionTest.scala
+++ b/obp-api/src/test/scala/code/api/v3_1_0/TransactionTest.scala
@@ -36,7 +36,7 @@ import code.api.v1_2_1.TransactionJSON
 import code.api.v1_4_0.JSONFactory1_4_0.TransactionRequestAccountJsonV140
 import code.api.v2_1_0.TransactionRequestWithChargeJSONs210
 import code.api.v2_2_0.CounterpartyWithMetadataJson
-import code.api.v3_0_0.NewModeratedCoreAccountJsonV300
+import code.api.v3_0_0.{NewModeratedCoreAccountJsonV300, TransactionJsonV300}
 import code.api.v3_0_0.OBPAPI3_0_0.Implementations3_0_0
 import code.api.v3_1_0.OBPAPI3_1_0.Implementations3_1_0
 import code.api.v3_1_0.OBPAPI3_1_0.Implementations2_2_0
@@ -186,9 +186,9 @@ class TransactionTest extends V310ServerSetup {
       val getTransactionbyIdResponse = makeGetRequest(getTransactionbyIdRequest)
 
       getTransactionbyIdResponse.code should equal(200)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].id should be(transactionNewId)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].details.`type` should be(postJsonAccount.`type`)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].details.description should be(postJsonAccount.description)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].id should be(transactionNewId)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].details.`type` should be(postJsonAccount.`type`)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].details.description should be(postJsonAccount.description)
       
     }
 
@@ -259,9 +259,9 @@ class TransactionTest extends V310ServerSetup {
       val getTransactionbyIdResponse = makeGetRequest(getTransactionbyIdRequest)
 
       getTransactionbyIdResponse.code should equal(200)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].id should be(transactionNewId)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].details.`type` should be(postJsonAccount.`type`)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].details.description should be(postJsonAccount.description)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].id should be(transactionNewId)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].details.`type` should be(postJsonAccount.`type`)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].details.description should be(postJsonAccount.description)
     }
 
     scenario("We will test saveHistoricalTransaction -- counterparty  --> account", ApiEndpoint2, VersionOfApi) {
@@ -331,9 +331,9 @@ class TransactionTest extends V310ServerSetup {
       val getTransactionbyIdResponse = makeGetRequest(getTransactionbyIdRequest)
 
       getTransactionbyIdResponse.code should equal(200)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].id should be(transactionNewId)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].details.`type` should be(postJsonAccount.`type`)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].details.description should be(postJsonAccount.description)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].id should be(transactionNewId)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].details.`type` should be(postJsonAccount.`type`)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].details.description should be(postJsonAccount.description)
     }
 
     scenario("We will test saveHistoricalTransaction -- counterparty  --> counterparty", ApiEndpoint2, VersionOfApi) {
@@ -415,9 +415,9 @@ class TransactionTest extends V310ServerSetup {
       val getTransactionbyIdResponse = makeGetRequest(getTransactionbyIdRequest)
 
       getTransactionbyIdResponse.code should equal(200)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].id should be(transactionNewId)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].details.`type` should be(postJsonAccount.`type`)
-      getTransactionbyIdResponse.body.extract[TransactionJSON].details.description should be(postJsonAccount.description)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].id should be(transactionNewId)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].details.`type` should be(postJsonAccount.`type`)
+      getTransactionbyIdResponse.body.extract[TransactionJsonV300].details.description should be(postJsonAccount.description)
     }
     
     scenario(s"We will test saveHistoricalTransaction --counterparty- test error: $InvalidJsonFormat", ApiEndpoint2, VersionOfApi) {


### PR DESCRIPTION
We now have transaction attributes in getTransaction(s) endpoints 

![image](https://user-images.githubusercontent.com/17991359/91294000-27aec880-e799-11ea-91ed-00985bbaa13c.png)

[Jenkins tests passed](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/25/)