### PR TITLE
feature/login_with_hydra: login and consent with hydra

### DIFF
--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -456,6 +456,12 @@
       <version>1.2.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>sh.ory.hydra</groupId>
+      <artifactId>hydra-client</artifactId>
+      <version>1.7.0</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/obp-api/src/main/resources/props/sample.props.template
+++ b/obp-api/src/main/resources/props/sample.props.template
@@ -860,3 +860,12 @@ outboundAdapterCallContext.generalContext
 ## example:
 #connector.name.export.as.endpoint=stored_procedure_vDec2019
 # ------------------------------------------------------------------------------------------
+
+# ------------------------------ Hydra oauth2 props ------------------------------
+## if login_with_hydra set to true, all other props must not be empty
+#login_with_hydra=true
+#hydra_public_url=http://127.0.0.1:4444
+#hydra_admin_url=http://127.0.0.1:4445
+#hydra_client_id=auth-code-client
+#hydra_client_scope=openid,offline
+# ------------------------------ Hydra oauth2 props end ------------------------------

--- a/obp-api/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/obp-api/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -489,6 +489,7 @@ class Boot extends MdcLoggable {
           Menu("Validate OTP", "Validate OTP") / "otp" >> AuthUser.loginFirst,
           // Menu.i("Metrics") / "metrics", //TODO: allow this page once we can make the account number anonymous in the URL
           Menu.i("OAuth") / "oauth" / "authorize", //OAuth authorization page
+          Menu.i("Consent") / "consent" >> AuthUser.loginFirst,//OAuth consent page
           OAuthWorkedThanks.menu, //OAuth thanks page that will do the redirect
           Menu.i("INTRODUCTION") / "introduction"
     ) ++ accountCreation ++ Admin.menus

--- a/obp-api/src/main/scala/code/snippet/ConsentConfirmation.scala
+++ b/obp-api/src/main/scala/code/snippet/ConsentConfirmation.scala
@@ -1,0 +1,121 @@
+/**
+ * Open Bank Project - API
+ * Copyright (C) 2011-2019, TESOBE GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Email: contact@tesobe.com
+ * TESOBE GmbH.
+ * Osloer Strasse 16/17
+ * Berlin 13359, Germany
+ *
+ * This product includes software developed at
+ * TESOBE (http://www.tesobe.com/)
+ *
+ */
+package code.snippet
+
+import code.model.dataAccess.AuthUser
+import code.util.Helper.MdcLoggable
+import code.webuiprops.MappedWebUiPropsProvider.getWebUiPropsValue
+import net.liftweb.http.{RequestVar, S, SHtml}
+import net.liftweb.util.CssSel
+import net.liftweb.util.Helpers._
+import sh.ory.hydra.model.{AcceptConsentRequest, ConsentRequestSession, RejectRequest}
+
+import scala.jdk.CollectionConverters.{asScalaBufferConverter, seqAsJavaListConverter}
+
+
+class ConsentConfirmation extends MdcLoggable {
+
+  private object submitButtonDefenseFlag extends RequestVar("")
+
+  private object cancelButtonDefenseFlag extends RequestVar("")
+
+
+  val confirmConsentButtonValue = getWebUiPropsValue("webui_post_confirm_consent_submit_button_value", "Yes, I confirm")
+  val rejectConsentButtonValue = getWebUiPropsValue("webui_post_reject_consent_submit_button_value", "Cancel")
+
+  def registerForm: CssSel = {
+
+    def submitButtonDefense: Unit = {
+      submitButtonDefenseFlag("true")
+    }
+
+    def cancelButtonDefense: Unit = {
+      cancelButtonDefenseFlag("true")
+    }
+
+
+    def formElement(ele: => CssSel): CssSel =
+      "form" #> {
+        "type=submit" #> SHtml.submit(s"$confirmConsentButtonValue", () => submitButtonDefense) &
+          "type=button" #> SHtml.submit(s"$rejectConsentButtonValue", () => cancelButtonDefense) &
+          ele
+      }
+
+
+    val consentChallengeBox = S.param("consent_challenge")
+    if (consentChallengeBox.isEmpty) {
+      return formElement {
+        "#confirm-errors" #> "Please login first."
+      }
+    }
+    val consentChallenge = consentChallengeBox.orNull
+    if (cancelButtonDefenseFlag.get == "true") {
+      val rejectRequest = new RejectRequest()
+      rejectRequest.setError("access_denied")
+      rejectRequest.setErrorDescription("The resource owner denied the request")
+      val rejectResponse = AuthUser.hydraAdmin.rejectConsentRequest(consentChallenge, rejectRequest)
+      AuthUser.logUserOut()
+      return S.redirectTo(rejectResponse.getRedirectTo)
+    }
+
+    val consentResponse = AuthUser.hydraAdmin.getConsentRequest(consentChallenge)
+
+    if (S.post_?) {
+      val scopes = S.params("consent_scope")
+      val consentRequest = new AcceptConsentRequest()
+      consentRequest.setGrantScope(scopes.asJava)
+      consentRequest.setGrantAccessTokenAudience(consentResponse.getRequestedAccessTokenAudience)
+      consentRequest.setRemember(false)
+      consentRequest.setRememberFor(3600) // TODO set in props
+      consentRequest.setSession(new ConsentRequestSession())
+
+      val acceptConsentResponse = AuthUser.hydraAdmin.acceptConsentRequest(consentChallenge, consentRequest)
+      S.redirectTo(acceptConsentResponse.getRedirectTo)
+    } else {
+      if (consentResponse.getSkip) {
+        val requestBody = new AcceptConsentRequest()
+        requestBody.setGrantScope(consentResponse.getRequestedScope)
+        requestBody.setGrantAccessTokenAudience(consentResponse.getRequestedAccessTokenAudience)
+        val requestSession = new ConsentRequestSession()
+        requestBody.setSession(requestSession)
+        val skipResponse = AuthUser.hydraAdmin.acceptConsentRequest(consentChallenge, requestBody)
+        S.redirectTo(skipResponse.getRedirectTo)
+      } else {
+        formElement {
+          "#confirm-errors" #> "" &
+            "#consent_challenge [value]" #> consentChallenge &
+            "#scope_group" #> consentResponse.getRequestedScope.asScala.map { scope =>
+              "@consent_scope [value]" #> scope &
+                "@consent_scope_label [for]" #> scope &
+                "@consent_scope_label *" #> scope
+            }
+        }
+
+      }
+    }
+  }
+}

--- a/obp-api/src/main/webapp/consent.html
+++ b/obp-api/src/main/webapp/consent.html
@@ -1,0 +1,61 @@
+<!--
+Open Bank Project - API
+Copyright (C) 2011-2017, TESOBE GmbH
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Email: contact@tesobe.com
+TESOBE GmbH
+Osloerstrasse 16/17
+Berlin 13359, Germany
+
+  This product includes software developed at
+  TESOBE (http://www.tesobe.com/)
+  by
+  Simon Redfern : simon AT tesobe DOT com
+  Sebastian Henschel : sebastian AT tesobe DOT com
+-->
+<div id="register-consumer" data-lift="surround?with=default;at=content">
+	<div data-lift="ConsentConfirmation.registerForm">
+		<h1>Consent Confirmation</h1>
+
+		<div id="register-consumer-input">
+			<div id="register-consumer-explanation">The Application (Name) has requested the following permissions on your account:</div>
+
+			<form method="post">
+				<div class="row">
+					<div class="col-xs-12 col-sm-12" id="scope_group">
+						<div class="form-group">
+							<input type="checkbox" name="consent_scope" id="consent_scope_openid" value="openid">
+							<label for="consent_scope_openid" name="consent_scope_label">openid</label>
+						</div>
+					</div>
+				</div>
+				<!--						<div class="form-group">
+                                            <input type="checkbox" name="consent_scope" id="consent_scope_offline" value="offline">
+                                            <label for="consent_scope_offline" name="consent_scope_label">offline</label>
+                                        </div>-->
+				<input type="hidden" name="consent_challenge" id="consent_challenge">
+
+				<input type="button" name="confirm" value="Cancel" class="btn btn-default" />
+
+				<input type="submit" name="confirm" value="Yes, I confirm" class="btn btn-default" />
+				<div id = "confirm-errors-div" class="hide alert alert-danger">
+					<span data-lift="Msg?id=confirm-errors"/>
+				</div>
+			</form>
+		</div>
+
+	</div>
+</div>

--- a/obp-api/src/main/webapp/templates-hidden/_login.html
+++ b/obp-api/src/main/webapp/templates-hidden/_login.html
@@ -16,6 +16,7 @@
 			<!-- Note we could show a drop down here of banks so user could switch bank at this point -->
 			<div class="form-group">
 				<input class="form-control" id="brand" type="hidden" placeholder="brand" name="brand" tabindex="1" autofocus autocomplete="off"/>
+				<input class="form-control" id="login_challenge" type="hidden" name="login_challenge" autofocus autocomplete="off"/>
 			</div>
 
 			<div class="row">


### PR DESCRIPTION
Portal login can support hydra way.
Add follow props:
```
login_with_hydra=true
hydra_public_url=https://test-oauth2.openbankproject.com/hydra-public
hydra_admin_url=https://test-oauth2.openbankproject.com/hydra-private
hydra_client_id=auth-code-clienta
hydra_client_scope=openid,offline,hello_world
``` 

### Jenkins job is running, please wait this pull request. 

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/331)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/87/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/201/)