### PR TITLE
bugfix/Delete a constraint in DoubleEntryBookTransaction.scala

### DIFF
--- a/obp-api/src/main/scala/code/model/dataAccess/DoubleEntryBookTransaction.scala
+++ b/obp-api/src/main/scala/code/model/dataAccess/DoubleEntryBookTransaction.scala
@@ -48,7 +48,6 @@ object DoubleEntryBookTransaction extends DoubleEntryBookTransaction with LongKe
   override def dbIndexes: List[BaseIndex[DoubleEntryBookTransaction]] =
     UniqueIndex(DebitTransactionBankId, DebitTransactionAccountId, DebitTransactionId) ::
     UniqueIndex(CreditTransactionBankId, CreditTransactionAccountId, CreditTransactionId) ::
-    UniqueIndex(DebitTransactionBankId, DebitTransactionAccountId, DebitTransactionId, CreditTransactionBankId, CreditTransactionAccountId, CreditTransactionId) ::
     super.dbIndexes
 
 }


### PR DESCRIPTION
Remove a constraint in  DoubleEntryBookTransaction creating an error with postgreSQL

`org.postgresql.util.PSQLException: ERROR: relation "doubleentrybooktransaction_debittransactionbankid_debittransact" already exists`

This error was due to two unique constraint beginning with the same values. As the PostgreSQL's max identifier length is 63 characters, this was creating two relations with the same name.