### PR TITLE
feature/Add default settlement accounts creation

### DIFF
--- a/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -2510,9 +2510,9 @@ object LocalMappedConnector extends Connector with MdcLoggable {
                                    national_identifier: String,
                                    bankRoutingScheme: String,
                                    bankRoutingAddress: String
-                                 ): Box[Bank] =
+                                 ): Box[Bank] = {
   //check the bank existence and update or insert data
-    getMappedBank(BankId(bankId)) match {
+    val bank = getMappedBank(BankId(bankId)) match {
       case Full(mappedBank) =>
         tryo {
           mappedBank
@@ -2542,6 +2542,42 @@ object LocalMappedConnector extends Connector with MdcLoggable {
             .saveMe()
         } ?~! ErrorMessages.UpdateBankError
     }
+
+    // Insert the default settlement accounts if they doesn't exist
+    MappedBankAccount.find(By(MappedBankAccount.bank, bankId), By(MappedBankAccount.theAccountId, INCOMING_ACCOUNT_ID)) match {
+      case Full(_) =>
+        logger.debug(s"BankAccount(${bankId}, $INCOMING_ACCOUNT_ID) is found.")
+      case _ =>
+        MappedBankAccount.create
+          .bank(bankId)
+          .theAccountId(INCOMING_ACCOUNT_ID)
+          .accountCurrency("EUR")
+          .kind("SETTLEMENT")
+          .holder(fullBankName)
+          .accountName("Default incoming settlement account")
+          .accountLabel("Settlement account: Do not delete!")
+          .saveMe()
+        logger.debug(s"creating BankAccount(${bankId}, $INCOMING_ACCOUNT_ID).")
+    }
+
+    MappedBankAccount.find(By(MappedBankAccount.bank, bankId), By(MappedBankAccount.theAccountId, OUTGOING_ACCOUNT_ID)) match {
+      case Full(_) =>
+        logger.debug(s"BankAccount(${bankId}, $OUTGOING_ACCOUNT_ID) is found.")
+      case _ =>
+        MappedBankAccount.create
+          .bank(bankId)
+          .theAccountId(OUTGOING_ACCOUNT_ID)
+          .accountCurrency("EUR")
+          .kind("SETTLEMENT")
+          .holder(fullBankName)
+          .accountName("Default outgoing settlement account")
+          .accountLabel("Settlement account: Do not delete!")
+          .saveMe()
+        logger.debug(s"creating BankAccount(${bankId}, $OUTGOING_ACCOUNT_ID).")
+    }
+
+    bank
+  }
 
   override def createCounterparty(
                                    name: String,


### PR DESCRIPTION
We now add the default settlement accounts when we create a new bank. 

Settlement accounts are used to record the double-entry transactions when a transaction have his counterparty outside of OBP (external payment solutions like SEPA / Cards / ...)