### PR TITLE
bugfix/Add space character check for bank creation

### DIFF
--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -1839,6 +1839,11 @@ trait APIMethods400 {
             _ <- Helper.booleanToFuture(failMsg = s"$InvalidJsonFormat Min length of BANK_ID should be 5 characters.") {
               bank.id.length > 5
             }
+
+            _ <- Helper.booleanToFuture(failMsg = s"$InvalidJsonFormat BANK_ID can not contain space characters") {
+              !bank.id.contains(" ")
+            }
+
             (success, callContext) <- NewStyle.function.createOrUpdateBank(
               bank.id,
               bank.full_name,


### PR DESCRIPTION
We now check if the bankId contains space, if it's the case, we return an error:
![image](https://user-images.githubusercontent.com/17991359/92215513-2cf4cd00-ee95-11ea-8cfb-b0d8b83286db.png)