### PR TITLE
feature/Clean up the JSON body for POST and GET bank(s). v4.0.0

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -16,7 +16,7 @@ import code.api.v3_0_0.JSONFactory300.createBranchJsonV300
 import code.api.v3_0_0.custom.JSONFactoryCustom300
 import code.api.v3_0_0.{LobbyJsonV330, _}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, CustomerWithAttributesJsonV310, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
-import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, ChallengeJsonV400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
+import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankJson400, BanksJson400, ChallengeJsonV400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
 import code.branches.Branches.{Branch, DriveUpString, LobbyString}
 import code.consent.ConsentStatus
@@ -812,6 +812,19 @@ object SwaggerDefinitionsJSON {
 
   val banksJSON = BanksJSON(
     banks = List(bankJSON)
+  )
+
+  val bankJson400 = BankJson400(
+    id = "gh.29.uk",
+    short_name = "short_name ",
+    full_name = "full_name",
+    logo = "logo",
+    website = "www.openbankproject.com",
+    bank_routings = List(bankRoutingJsonV121)
+  )
+
+  val banksJSON400 = BanksJson400(
+    banks = List(bankJson400)
   )
 
   val accountHolderJSON = AccountHolderJSON(

--- a/obp-api/src/main/scala/code/api/v3_0_0/APIMethods300.scala
+++ b/obp-api/src/main/scala/code/api/v3_0_0/APIMethods300.scala
@@ -43,6 +43,7 @@ import com.openbankproject.commons.ExecutionContext.Implicits.global
 
 import scala.concurrent.Future
 import code.api.v2_0_0.AccountsHelper._
+import code.api.v4_0_0.JSONFactory400
 import com.openbankproject.commons.dto.CustomerAndAttribute
 import com.openbankproject.commons.util.ApiVersion
 import net.liftweb.json.JsonAST.JField
@@ -2419,13 +2420,12 @@ trait APIMethods300 {
         |* Logo URL
         |* Website""",
       emptyObjectJson,
-      bankJSON,
+      bankJson400,
       List(UserNotLoggedIn, UnknownError, BankNotFound),
       Catalogs(Core, PSD2, OBWG),
       apiTagBank :: apiTagPSD2AIS :: apiTagNewStyle :: Nil
     )
 
-    //The Json Body is totally the same as V121, just use new style endpoint.
     lazy val bankById : OBPEndpoint = {
       //get bank by id
       case "banks" :: BankId(bankId) :: Nil JsonGet _ => {
@@ -2433,7 +2433,7 @@ trait APIMethods300 {
           for {
             (bank, callContext) <- NewStyle.function.getBank(bankId, Option(cc))
           } yield
-            (JSONFactory.createBankJSON(bank), HttpCode.`200`(callContext))
+            (JSONFactory400.createBankJSON400(bank), HttpCode.`200`(callContext))
       }
     }
 

--- a/obp-api/src/test/scala/code/api/v4_0_0/BankTests.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/BankTests.scala
@@ -1,7 +1,7 @@
 package code.api.v4_0_0
 
 import com.openbankproject.commons.model.ErrorMessage
-import code.api.ResourceDocs1_4_0.SwaggerDefinitionsJSON.bankJSONV220
+import code.api.ResourceDocs1_4_0.SwaggerDefinitionsJSON.bankJson400
 import code.api.util.APIUtil.OAuth._
 import code.api.util.ApiRole.CanCreateBank
 import code.api.util.ErrorMessages.UserHasMissingRoles
@@ -39,7 +39,7 @@ class BankTests extends V400ServerSetupAsync with DefaultUsers {
     scenario("We try to consume endpoint createBank - Anonymous access", ApiEndpoint1, VersionOfApi) {
       When("We make the request")
       val requestGet = (v4_0_0_Request / "banks").POST
-      val responseGet = makePostRequestAsync(requestGet, write(bankJSONV220))
+      val responseGet = makePostRequestAsync(requestGet, write(bankJson400))
       Then("We should get a 401")
       And("We should get a message: " + ErrorMessages.UserNotLoggedIn)
       responseGet map { r =>
@@ -51,7 +51,7 @@ class BankTests extends V400ServerSetupAsync with DefaultUsers {
     scenario("We try to consume endpoint createBank without proper role - Authorized access", ApiEndpoint1, VersionOfApi) {
       When("We make the request")
       val requestGet = (v4_0_0_Request / "banks").POST <@ (user1)
-      val responseGet = makePostRequestAsync(requestGet, write(bankJSONV220))
+      val responseGet = makePostRequestAsync(requestGet, write(bankJson400))
       Then("We should get a 403")
       And("We should get a message: " + s"$CanCreateBank entitlement required")
       responseGet map { r =>
@@ -67,11 +67,11 @@ class BankTests extends V400ServerSetupAsync with DefaultUsers {
       val requestGet = (v4_0_0_Request / "banks").POST <@ (user1)
       val response = for {
         before <- NewStyle.function.getEntitlementsByUserId(resourceUser1.userId, None) map {
-          _.exists( e => e.roleName == ApiRole.CanCreateEntitlementAtOneBank.toString && e.bankId == bankJSONV220.id)
+          _.exists( e => e.roleName == ApiRole.CanCreateEntitlementAtOneBank.toString && e.bankId == bankJson400.id)
         }
-        response: APIResponse <- makePostRequestAsync(requestGet, write(bankJSONV220))
+        response: APIResponse <- makePostRequestAsync(requestGet, write(bankJson400))
         after <- NewStyle.function.getEntitlementsByUserId(resourceUser1.userId, None) map {
-          _.exists( e => e.roleName == ApiRole.CanCreateEntitlementAtOneBank.toString && e.bankId == bankJSONV220.id)
+          _.exists( e => e.roleName == ApiRole.CanCreateEntitlementAtOneBank.toString && e.bankId == bankJson400.id)
         }
       } yield (before, after, response)
       Then("We should get a 201")


### PR DESCRIPTION
This commit put the BIC/SWIFT in the bank routings which is now a list.

**WARNING**: when we create a bank, only the first bankRouting different from `BIC` is saved, indeed we can currently only store one routing scheme different from `BIC` in the database. So the next step is to create an additional table in the database to store the account routings for each bank (like account routings).

[Jenkins tests result](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/39/)