### PR TITLE
Add settlement account endpoints

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -16,7 +16,7 @@ import code.api.v3_0_0.JSONFactory300.createBranchJsonV300
 import code.api.v3_0_0.custom.JSONFactoryCustom300
 import code.api.v3_0_0.{LobbyJsonV330, _}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, CustomerWithAttributesJsonV310, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
-import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankJson400, BanksJson400, ChallengeJsonV400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
+import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankJson400, BanksJson400, ChallengeJsonV400, SettlementAccountRequestJson, SettlementAccountResponseJson, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
 import code.branches.Branches.{Branch, DriveUpString, LobbyString}
 import code.consent.ConsentStatus
@@ -3690,7 +3690,27 @@ object SwaggerDefinitionsJSON {
     branch_id  = branchIdExample.value,
     account_routings = List(accountRoutingJsonV121)
   )
-  
+
+  val settlementAccountRequestJson = SettlementAccountRequestJson(
+    user_id = userIdExample.value,
+    payment_system = paymentSystemExample.value,
+    balance = amountOfMoneyJsonV121,
+    label = labelExample.value,
+    branch_id = branchIdExample.value,
+    account_routings = List(accountRoutingJsonV121)
+  )
+
+  val settlementAccountResponseJson = SettlementAccountResponseJson(
+    account_id = accountIdExample.value,
+    user_id = userIdExample.value,
+    payment_system = paymentSystemExample.value,
+    balance = amountOfMoneyJsonV121,
+    label = labelExample.value,
+    branch_id = branchIdExample.value,
+    account_routings = List(accountRoutingJsonV121),
+    account_attributes = List(accountAttributeResponseJson)
+  )
+
   val postAccountAccessJsonV400 = PostAccountAccessJsonV400(userIdExample.value, PostViewJsonV400(ExampleValue.viewIdExample.value, true))
   val revokedJsonV400 = RevokedJsonV400(true)
   

--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -16,7 +16,7 @@ import code.api.v3_0_0.JSONFactory300.createBranchJsonV300
 import code.api.v3_0_0.custom.JSONFactoryCustom300
 import code.api.v3_0_0.{LobbyJsonV330, _}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, CustomerWithAttributesJsonV310, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
-import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankJson400, BanksJson400, ChallengeJsonV400, SettlementAccountRequestJson, SettlementAccountResponseJson, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
+import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankJson400, BanksJson400, ChallengeJsonV400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
 import code.branches.Branches.{Branch, DriveUpString, LobbyString}
 import code.consent.ConsentStatus
@@ -3709,6 +3709,20 @@ object SwaggerDefinitionsJSON {
     branch_id = branchIdExample.value,
     account_routings = List(accountRoutingJsonV121),
     account_attributes = List(accountAttributeResponseJson)
+  )
+
+  val settlementAccountJson = SettlementAccountJson(
+    account_id = accountIdExample.value,
+    payment_system = paymentSystemExample.value,
+    balance = amountOfMoneyJsonV121,
+    label = labelExample.value,
+    branch_id = branchIdExample.value,
+    account_routings = List(accountRoutingJsonV121),
+    account_attributes = List(accountAttributeResponseJson)
+  )
+
+  val settlementAccountsJson = SettlementAccountsJson(
+    settlement_accounts = List(settlementAccountJson)
   )
 
   val postAccountAccessJsonV400 = PostAccountAccessJsonV400(userIdExample.value, PostViewJsonV400(ExampleValue.viewIdExample.value, true))

--- a/obp-api/src/main/scala/code/api/util/ApiRole.scala
+++ b/obp-api/src/main/scala/code/api/util/ApiRole.scala
@@ -257,6 +257,12 @@ object ApiRole {
   case class CanCreateBank (requiresBankId: Boolean = false) extends ApiRole
   lazy val canCreateBank = CanCreateBank()
 
+  case class CanCreateSettlementAccountAtOneBank (requiresBankId: Boolean = true) extends ApiRole
+  lazy val canCreateSettlementAccountAtOneBank = CanCreateSettlementAccountAtOneBank()
+
+  case class CanGetSettlementAccountAtOneBank (requiresBankId: Boolean = true) extends ApiRole
+  lazy val canGetSettlementAccountAtOneBank = CanGetSettlementAccountAtOneBank()
+
   case class CanReadMetrics (requiresBankId: Boolean = false) extends ApiRole
   lazy val canReadMetrics = CanReadMetrics()
 

--- a/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
+++ b/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
@@ -312,6 +312,7 @@ object ErrorMessages {
   val InvalidCustomerBankId = "OBP-30113: Invalid Bank Id. The Customer does not belong to this Bank"
   val InvalidAccountRoutings = "OBP-30114: Invalid Account Routings."
   val AccountRoutingAlreadyExist = "OBP-30115: Account Routing already exist."
+  val InvalidPaymentSystemName = "OBP-30116: Invalid payment system name. The payment system name should only contain 0-9/a-z/A-Z/'-'/'.'/'_', the length should be smaller than 200."
 
 
   val EntitlementIsBankRole = "OBP-30205: This entitlement is a Bank Role. Please set bank_id to a valid bank id."

--- a/obp-api/src/main/scala/code/api/util/ExampleValue.scala
+++ b/obp-api/src/main/scala/code/api/util/ExampleValue.scala
@@ -250,6 +250,8 @@ object ExampleValue {
   
   lazy val currencyExample = balanceCurrencyExample
 
+  lazy val paymentSystemExample = ConnectorField("SEPA", "A payment system can be SEPA, CARD, SWIFT ....")
+
   lazy val owner1Example = ConnectorField("SusanSmith", "A username that is the owner of the account.")
   glossaryItems += makeGlossaryItem("Account.owner", owner1Example)
 

--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -267,6 +267,12 @@ object NewStyle {
         (unboxFullOrFail(i._1, callContext, s"$BankAccountNotFound Current BankId is $bankId and Current AccountId is $accountId", 404), i._2)
       }
 
+    def getBankSettlementAccounts(bankId: BankId, callContext: Option[CallContext]): OBPReturnType[List[BankAccount]] = {
+      Connector.connector.vend.getBankSettlementAccounts(bankId: BankId, callContext: Option[CallContext]) map { i =>
+        (unboxFullOrFail(i._1, callContext,s"$BankNotFound Current BankId is $bankId", 404 ), i._2)
+      }
+    }
+
     def getTransaction(bankId: BankId, accountId : AccountId, transactionId : TransactionId, callContext: Option[CallContext] = None) : OBPReturnType[Transaction] = {
       Connector.connector.vend.getTransaction(bankId, accountId, transactionId, callContext) map {
         x => (unboxFullOrFail(x._1, callContext, TransactionNotFound, 404), x._2)

--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -184,6 +184,115 @@ trait APIMethods400 {
       }
     }
 
+    staticResourceDocs += ResourceDoc(
+      createSettlementAccount,
+      implementedInApiVersion,
+      nameOf(createSettlementAccount),
+      "POST",
+      "/banks/BANK_ID/settlement-accounts",
+      "Create Settlement Account",
+      s"""Create a new settlement account at a bank.
+         |
+         |The created settlement account id will be the concatenation of the payment system and the account currency.
+         |For examples: SEPA_SETTLEMENT_ACCOUNT_EUR, CARD_SETTLEMENT_ACCOUNT_USD
+         |
+         |If the POST body USER_ID *is* specified, the logged in user must have the Role CanCreateAccount. Once created, the Account will be owned by the User specified by USER_ID.
+         |
+         |If the POST body USER_ID is *not* specified, the account will be owned by the logged in User.
+         |
+         |Note: The Amount MUST be zero.
+         |""",
+      settlementAccountRequestJson,
+      settlementAccountResponseJson,
+      List(
+        InvalidJsonFormat,
+        $UserNotLoggedIn,
+        UserHasMissingRoles,
+        BankNotFound,
+        InvalidAccountInitialBalance,
+        InitialBalanceMustBeZero,
+        InvalidISOCurrencyCode,
+        UnknownError
+      ),
+      Catalogs(notCore, notPSD2, OBWG),
+      List(apiTagBank),
+      Some(List(canCreateSettlementAccountAtOneBank))
+    )
+
+    lazy val createSettlementAccount: OBPEndpoint = {
+      case "banks" :: BankId(bankId) :: "settlement-accounts" :: Nil JsonPost json -> _ => {
+        cc =>
+          val failMsg = s"$InvalidJsonFormat The Json body should be the ${prettyRender(Extraction.decompose(settlementAccountRequestJson))}"
+          for {
+            createAccountJson <- NewStyle.function.tryons(failMsg, 400, cc.callContext) {
+              json.extract[SettlementAccountRequestJson]
+            }
+            loggedInUserId = cc.userId
+            userIdAccountOwner = if (createAccountJson.user_id.nonEmpty) createAccountJson.user_id else loggedInUserId
+            (postedOrLoggedInUser,callContext) <- NewStyle.function.findByUserId(userIdAccountOwner, cc.callContext)
+            _ <- Helper.booleanToFuture(s"$UserHasMissingRoles $canCreateSettlementAccountAtOneBank") {
+              hasEntitlement(bankId.value, loggedInUserId, canCreateSettlementAccountAtOneBank) || userIdAccountOwner == loggedInUserId
+            }
+            initialBalanceAsString = createAccountJson.balance.amount
+            accountLabel = createAccountJson.label
+            initialBalanceAsNumber <- NewStyle.function.tryons(InvalidAccountInitialBalance, 400, callContext) {
+              BigDecimal(initialBalanceAsString)
+            }
+            _ <-  Helper.booleanToFuture(InitialBalanceMustBeZero){0 == initialBalanceAsNumber}
+            currency = createAccountJson.balance.currency
+            _ <-  Helper.booleanToFuture(InvalidISOCurrencyCode){isValidCurrencyISOCode(currency)}
+
+            (_, callContext ) <- NewStyle.function.getBank(bankId, callContext)
+            _ <- Helper.booleanToFuture(s"$InvalidAccountRoutings Duplication detected in account routings, please specify only one value per routing scheme") {
+              createAccountJson.account_routings.map(_.scheme).distinct.size == createAccountJson.account_routings.size
+            }
+            alreadyExistAccountRoutings <- Future.sequence(createAccountJson.account_routings.map(accountRouting =>
+              NewStyle.function.getAccountRouting(Some(bankId), accountRouting.scheme, accountRouting.address, callContext).map(_ => Some(accountRouting)).fallbackTo(Future.successful(None))
+            ))
+            alreadyExistingAccountRouting = alreadyExistAccountRoutings.collect {
+              case Some(accountRouting) => s"bankId: $bankId, scheme: ${accountRouting.scheme}, address: ${accountRouting.address}"
+            }
+            _ <- Helper.booleanToFuture(s"$AccountRoutingAlreadyExist (${alreadyExistingAccountRouting.mkString("; ")})") {
+              alreadyExistingAccountRouting.isEmpty
+            }
+            _ <- Helper.booleanToFuture(s"$InvalidAccountRoutings Duplication detected in account routings, please specify only one value per routing scheme") {
+              createAccountJson.account_routings.map(_.scheme).distinct.size == createAccountJson.account_routings.size
+            }
+            _ <- Helper.booleanToFuture(s"$InvalidPaymentSystemName Space characters are not allowed.") {
+              !createAccountJson.payment_system.contains(" ")
+            }
+            accountId = AccountId(createAccountJson.payment_system.toUpperCase + "_SETTLEMENT_ACCOUNT_" + currency.toUpperCase)
+            (bankAccount,callContext) <- NewStyle.function.createBankAccount(
+              bankId,
+              accountId,
+              "SETTLEMENT",
+              accountLabel,
+              currency,
+              initialBalanceAsNumber,
+              postedOrLoggedInUser.name,
+              createAccountJson.branch_id,
+              createAccountJson.account_routings.map(r => AccountRouting(r.scheme, r.address)),
+              callContext
+            )
+            accountId = bankAccount.accountId
+            (productAttributes, callContext) <- NewStyle.function.getProductAttributesByBankAndCode(bankId, ProductCode("SETTLEMENT"), callContext)
+            (accountAttributes, callContext) <- NewStyle.function.createAccountAttributes(
+              bankId,
+              accountId,
+              ProductCode("SETTLEMENT"),
+              productAttributes,
+              callContext: Option[CallContext]
+            )
+          } yield {
+            //1 Create or Update the `Owner` for the new account
+            //2 Add permission to the user
+            //3 Set the user as the account holder
+            BankAccountCreation.setAsOwner(bankId, accountId, postedOrLoggedInUser)
+            (JSONFactory400.createSettlementAccountJson(userIdAccountOwner, bankAccount, accountAttributes), HttpCode.`201`(callContext))
+          }
+      }
+    }
+
     val exchangeRates =
       APIUtil.getPropsValue("webui_api_explorer_url", "") +
         "/more?version=OBPv4.0.0&list-all-banks=false&core=&psd2=&obwg=#OBPv2_2_0-getCurrentFxRate"

--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -324,7 +324,7 @@ trait APIMethods400 {
         cc =>
           for {
             _ <- Helper.booleanToFuture(s"$UserHasMissingRoles $canGetSettlementAccountAtOneBank") {
-              hasEntitlement(bankId.value, cc.userId, canCreateSettlementAccountAtOneBank)
+              hasEntitlement(bankId.value, cc.userId, canGetSettlementAccountAtOneBank)
             }
             (accounts, callContext) <- NewStyle.function.getBankSettlementAccounts(bankId, cc.callContext)
             settlementAccounts <- Future.sequence(accounts.map(account => {

--- a/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
@@ -346,6 +346,20 @@ case class SettlementAccountResponseJson(
                                          account_attributes: List[AccountAttributeResponseJson]
                                         )
 
+case class SettlementAccountJson(
+                                  account_id: String,
+                                  payment_system: String,
+                                  balance: AmountOfMoneyJsonV121,
+                                  label: String,
+                                  branch_id : String,
+                                  account_routings: List[AccountRoutingJsonV121],
+                                  account_attributes: List[AccountAttributeResponseJson]
+                                )
+
+case class SettlementAccountsJson(
+                                  settlement_accounts: List[SettlementAccountJson]
+                                 )
+
 object JSONFactory400 {
   def createBankJSON400(bank: Bank): BankJson400 = {
     val obp = BankRoutingJsonV121("OBP", bank.bankId.value)
@@ -373,6 +387,20 @@ object JSONFactory400 {
     SettlementAccountResponseJson(
       account_id = account.accountId.value,
       user_id = userId,
+      label = account.label,
+      payment_system = account.accountId.value.split("_SETTLEMENT_ACCOUNT").headOption.getOrElse(""),
+      balance = AmountOfMoneyJsonV121(
+        account.currency,
+        account.balance.toString()
+      ),
+      branch_id = account.branchId,
+      account_routings = account.accountRoutings.map(r => AccountRoutingJsonV121(r.scheme, r.address)),
+      account_attributes = accountAttributes.map(createAccountAttributeJson)
+    )
+
+  def getSettlementAccountJson(account: BankAccount, accountAttributes: List[AccountAttribute]): SettlementAccountJson =
+    SettlementAccountJson(
+      account_id = account.accountId.value,
       label = account.label,
       payment_system = account.accountId.value.split("_SETTLEMENT_ACCOUNT").headOption.getOrElse(""),
       balance = AmountOfMoneyJsonV121(

--- a/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
@@ -325,6 +325,27 @@ case class ChallengeJson(
   transaction_request_id: String,
   expected_user_id: String
 )
+
+case class SettlementAccountRequestJson(
+                                         user_id: String,
+                                         payment_system: String,
+                                         balance: AmountOfMoneyJsonV121,
+                                         label: String,
+                                         branch_id : String,
+                                         account_routings: List[AccountRoutingJsonV121]
+                                        )
+
+case class SettlementAccountResponseJson(
+                                         account_id: String,
+                                         user_id: String,
+                                         payment_system: String,
+                                         balance: AmountOfMoneyJsonV121,
+                                         label: String,
+                                         branch_id : String,
+                                         account_routings: List[AccountRoutingJsonV121],
+                                         account_attributes: List[AccountAttributeResponseJson]
+                                        )
+
 object JSONFactory400 {
   def createBankJSON400(bank: Bank): BankJson400 = {
     val obp = BankRoutingJsonV121("OBP", bank.bankId.value)
@@ -347,6 +368,21 @@ object JSONFactory400 {
   def createBanksJson(l: List[Bank]): BanksJson400 = {
     BanksJson400(l.map(createBankJSON400))
   }
+
+  def createSettlementAccountJson(userId: String, account: BankAccount, accountAttributes: List[AccountAttribute]): SettlementAccountResponseJson =
+    SettlementAccountResponseJson(
+      account_id = account.accountId.value,
+      user_id = userId,
+      label = account.label,
+      payment_system = account.accountId.value.split("_SETTLEMENT_ACCOUNT").headOption.getOrElse(""),
+      balance = AmountOfMoneyJsonV121(
+        account.currency,
+        account.balance.toString()
+      ),
+      branch_id = account.branchId,
+      account_routings = account.accountRoutings.map(r => AccountRoutingJsonV121(r.scheme, r.address)),
+      account_attributes = accountAttributes.map(createAccountAttributeJson)
+    )
 
   def createTransactionRequestWithChargeJSON(tr : TransactionRequest, challenges: List[ChallengeJson]) : TransactionRequestWithChargeJSON400 = {
     new TransactionRequestWithChargeJSON400(

--- a/obp-api/src/main/scala/code/bankconnectors/Connector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/Connector.scala
@@ -486,6 +486,8 @@ trait Connector extends MdcLoggable {
   def getCoreBankAccounts(bankIdAccountIds: List[BankIdAccountId], callContext: Option[CallContext]) : Future[Box[(List[CoreAccount], Option[CallContext])]]=
     Future{Failure(setUnimplementedError)}
 
+  def getBankSettlementAccounts(bankId: BankId, callContext: Option[CallContext]): OBPReturnType[Box[List[BankAccount]]] = Future{(Failure(setUnimplementedError), callContext)}
+
   def getBankAccountsHeldLegacy(bankIdAccountIds: List[BankIdAccountId], callContext: Option[CallContext]) : Box[List[AccountHeld]]= Failure(setUnimplementedError)
   def getBankAccountsHeld(bankIdAccountIds: List[BankIdAccountId], callContext: Option[CallContext]) : OBPReturnType[Box[List[AccountHeld]]]= Future {(Failure(setUnimplementedError), callContext)}
 

--- a/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -572,7 +572,7 @@ object LocalMappedConnector extends Connector with MdcLoggable {
       By(MappedBankAccount.theAccountId, accountId.value)
     ).map(bankAccount => (bankAccount, callContext))
   }
-  
+
   override def getBankAccountByIban(iban: String, callContext: Option[CallContext]): OBPReturnType[Box[BankAccount]] = Future {
     getBankAccountByRouting(None, "IBAN", iban, callContext)
   }

--- a/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -698,6 +698,17 @@ object LocalMappedConnector extends Connector with MdcLoggable {
     }
   }
 
+  override def getBankSettlementAccounts(bankId: BankId, callContext: Option[CallContext]): OBPReturnType[Box[List[BankAccount]]] = {
+    Future {
+      Full {
+        MappedBankAccount.findAll(
+          By(MappedBankAccount.bank, bankId.value),
+          By(MappedBankAccount.kind, "SETTLEMENT")
+        )
+      }
+    }.map(account => (account, callContext))
+  }
+
   // localConnector/getBankAccountsHeld/bankIdAccountIds/{bankIdAccountIds}
   override def getBankAccountsHeldLegacy(bankIdAccountIds: List[BankIdAccountId], callContext: Option[CallContext]): Box[List[AccountHeld]] = {
     Full(

--- a/obp-api/src/test/scala/code/api/v4_0_0/BankTests.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/BankTests.scala
@@ -1,6 +1,7 @@
 package code.api.v4_0_0
 
-import com.openbankproject.commons.model.ErrorMessage
+import code.api.Constant.{INCOMING_ACCOUNT_ID, OUTGOING_ACCOUNT_ID}
+import com.openbankproject.commons.model.{AccountId, BankId, ErrorMessage}
 import code.api.ResourceDocs1_4_0.SwaggerDefinitionsJSON.bankJson400
 import code.api.util.APIUtil.OAuth._
 import code.api.util.ApiRole.CanCreateBank
@@ -75,10 +76,15 @@ class BankTests extends V400ServerSetupAsync with DefaultUsers {
         }
       } yield (before, after, response)
       Then("We should get a 201")
-      response map { r =>
+      response flatMap  { r =>
           r._1 should equal(false) // Before we create a bank there is no role CanCreateEntitlementAtOneBank
           r._2 should equal(true) // After we create a bank there is a role CanCreateEntitlementAtOneBank
           r._3.code should equal(201)
+          Then("Default settlement accounts should be created")
+          val defaultOutgoingAccount = NewStyle.function.checkBankAccountExists(BankId(bankJson400.id), AccountId(OUTGOING_ACCOUNT_ID), None)
+          val defaultIncomingAccount = NewStyle.function.checkBankAccountExists(BankId(bankJson400.id), AccountId(INCOMING_ACCOUNT_ID), None)
+          defaultOutgoingAccount.map(account => account._1.accountId.value should equal(OUTGOING_ACCOUNT_ID))
+          defaultIncomingAccount.map(account => account._1.accountId.value should equal(INCOMING_ACCOUNT_ID))
       }
     }
   }

--- a/obp-api/src/test/scala/code/api/v4_0_0/SettlementAccountTest.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/SettlementAccountTest.scala
@@ -1,0 +1,170 @@
+package code.api.v4_0_0
+
+import code.api.ResourceDocs1_4_0.SwaggerDefinitionsJSON
+import code.api.ResourceDocs1_4_0.SwaggerDefinitionsJSON.accountAttributeJson
+import code.api.util.APIUtil.OAuth._
+import code.api.util.ApiRole.CanCreateAccountAttributeAtOneBank
+import code.api.util.ErrorMessages.{UserHasMissingRoles, UserNotLoggedIn}
+import code.api.util.{APIUtil, ApiRole, NewStyle}
+import code.api.v2_0_0.BasicAccountJSON
+import code.api.v3_1_0.{CreateAccountResponseJsonV310, PostPutProductJsonV310, ProductJsonV310}
+import code.api.v4_0_0.OBPAPI4_0_0.Implementations4_0_0
+import code.entitlement.Entitlement
+import com.github.dwickern.macros.NameOf.nameOf
+import com.openbankproject.commons.model.enums.AccountRoutingScheme
+import com.openbankproject.commons.model.{AccountRoutingJsonV121, AmountOfMoneyJsonV121, ErrorMessage}
+import com.openbankproject.commons.util.ApiVersion
+import net.liftweb.common.Box
+import net.liftweb.json.Serialization.write
+import org.scalatest.Tag
+
+import scala.collection.immutable.List
+import scala.util.Random
+
+class SettlementAccountTest extends V400ServerSetup {
+  /**
+    * Test tags
+    * Example: To run tests with tag "getPermissions":
+    * 	mvn test -D tagsToInclude
+    *
+    *  This is made possible by the scalatest maven plugin
+    */
+  object VersionOfApi extends Tag(ApiVersion.v4_0_0.toString)
+  object CreateSettlementAccountEndpoint extends Tag(nameOf(Implementations4_0_0.createSettlementAccount))
+  object GetSettlementAccountsEndpoint extends Tag(nameOf(Implementations4_0_0.getSettlementAccounts))
+
+  lazy val testBankId = testBankId1
+  lazy val createSettlementAccountJson = SwaggerDefinitionsJSON.settlementAccountRequestJson
+    .copy(user_id = resourceUser1.userId, payment_system = "SEPA", balance = AmountOfMoneyJsonV121("EUR","0"))
+  lazy val createSettlementAccountOtherUser = SwaggerDefinitionsJSON.settlementAccountRequestJson
+    .copy(user_id = resourceUser2.userId, payment_system = "CARD", balance = AmountOfMoneyJsonV121("USD","0"),
+      account_routings = List(AccountRoutingJsonV121(Random.nextString(4), Random.nextString(4))))
+  
+
+  feature(s"test $CreateSettlementAccountEndpoint - Unauthorized access") {
+    scenario("We will call the endpoint without user credentials", CreateSettlementAccountEndpoint, VersionOfApi) {
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / testBankId.value / "settlement-accounts").POST
+      val response400 = makePostRequest(request400, write(createSettlementAccountJson))
+      Then("We should get a 401")
+      response400.code should equal(401)
+      And("error should be " + UserNotLoggedIn)
+      response400.body.extract[ErrorMessage].message should equal (UserNotLoggedIn)
+    }
+  }
+  feature(s"test $CreateSettlementAccountEndpoint - Authorized access") {
+    scenario("We will call the endpoint with user credentials", CreateSettlementAccountEndpoint, VersionOfApi) {
+      When("We make a request v4.0.0")
+      val addedEntitlement: Box[Entitlement] = Entitlement.entitlement.vend.addEntitlement(testBankId.value, resourceUser1.userId, ApiRole.CanCreateSettlementAccountAtOneBank.toString)
+      val response400 = try {
+        val request400 = (v4_0_0_Request / "banks" / testBankId.value / "settlement-accounts" ).POST <@(user1)
+        makePostRequest(request400, write(createSettlementAccountJson))
+      } finally {
+        Entitlement.entitlement.vend.deleteEntitlement(addedEntitlement)
+      }
+
+      Then("We should get a 201")
+      response400.code should equal(201)
+      val account = response400.body.extract[SettlementAccountResponseJson]
+      account.account_id should not be empty
+      account.payment_system should be (createSettlementAccountJson.payment_system)
+      account.balance.amount.toDouble should be (createSettlementAccountJson.balance.amount.toDouble)
+      account.balance.currency should be (createSettlementAccountJson.balance.currency)
+      account.branch_id should be (createSettlementAccountJson.branch_id)
+      account.user_id should be (createSettlementAccountJson.user_id)
+      account.label should be (createSettlementAccountJson.label)
+      account.account_routings should be (createSettlementAccountJson.account_routings)
+
+
+      Then("We make a request v4.0.0 but with other user")
+      val requestWithNewAccountId = (v4_0_0_Request / "banks" / testBankId.value / "settlement-accounts" ).POST <@(user1)
+      val responseWithNoRole = makePostRequest(requestWithNewAccountId, write(createSettlementAccountOtherUser))
+      Then("We should get a 403 and some error message")
+      responseWithNoRole.code should equal(403)
+      responseWithNoRole.body.toString contains(s"$UserHasMissingRoles") should be (true)
+
+
+      Then("We grant the roles and test it again")
+      Entitlement.entitlement.vend.addEntitlement(testBankId.value, resourceUser1.userId, ApiRole.CanCreateSettlementAccountAtOneBank.toString)
+      val responseWithOtherUser = makePostRequest(requestWithNewAccountId, write(createSettlementAccountOtherUser))
+
+      val account2 = responseWithOtherUser.body.extract[SettlementAccountResponseJson]
+      account2.account_id should not be empty
+      account2.payment_system should be (createSettlementAccountOtherUser.payment_system)
+      account2.balance.amount.toDouble should be (createSettlementAccountOtherUser.balance.amount.toDouble)
+      account2.balance.currency should be (createSettlementAccountOtherUser.balance.currency)
+      account2.branch_id should be (createSettlementAccountOtherUser.branch_id)
+      account2.user_id should be (createSettlementAccountOtherUser.user_id)
+      account2.label should be (createSettlementAccountOtherUser.label)
+      account2.account_routings should be (createSettlementAccountOtherUser.account_routings)
+    }
+  }
+
+
+  feature(s"test $GetSettlementAccountsEndpoint - Unauthorized access") {
+    scenario("We will call the endpoint without user credentials", VersionOfApi, GetSettlementAccountsEndpoint) {
+      Given("The two previously created settlement accounts")
+
+      When("We send the request")
+      val request = (v4_0_0_Request / "banks" / testBankId.value / "settlement-accounts").GET
+      val response = makeGetRequest(request)
+
+      Then("We should get a 401")
+      response.code should equal(401)
+      And("error should be " + UserNotLoggedIn)
+      response.body.extract[ErrorMessage].message should equal (UserNotLoggedIn)
+    }
+  }
+
+  feature(s"test $GetSettlementAccountsEndpoint - Authorized access") {
+    scenario("We will call the endpoint with user credentials", VersionOfApi, GetSettlementAccountsEndpoint) {
+      Given("We create two settlement accounts at the testBank")
+
+      Entitlement.entitlement.vend.addEntitlement(testBankId.value, resourceUser1.userId, ApiRole.CanCreateSettlementAccountAtOneBank.toString)
+      makePostRequest((v4_0_0_Request / "banks" / testBankId.value / "settlement-accounts" ).POST <@(user1), write(createSettlementAccountJson))
+      makePostRequest((v4_0_0_Request / "banks" / testBankId.value / "settlement-accounts" ).POST <@(user1), write(createSettlementAccountOtherUser))
+
+      When("We send the request")
+      val addedEntitlement: Box[Entitlement] = Entitlement.entitlement.vend.addEntitlement(testBankId.value, resourceUser1.userId, ApiRole.CanGetSettlementAccountAtOneBank.toString)
+
+      val response = try {
+        val request = (v4_0_0_Request / "banks" / testBankId.value / "settlement-accounts").GET <@(user1)
+        makeGetRequest(request)
+      } finally {
+        Entitlement.entitlement.vend.deleteEntitlement(addedEntitlement)
+      }
+
+      Then("We should get a 200 and check the response body")
+      response.code should equal(200)
+      val settlementAccounts = response.body.extract[SettlementAccountsJson]
+      val sepaSettlementAccount = settlementAccounts.settlement_accounts.find(_.account_id == "SEPA_SETTLEMENT_ACCOUNT_EUR")
+      val cardSettlementAccount = settlementAccounts.settlement_accounts.find(_.account_id == "CARD_SETTLEMENT_ACCOUNT_USD")
+      sepaSettlementAccount.map(_.balance.currency) shouldBe Some("EUR")
+      sepaSettlementAccount.map(_.payment_system) shouldBe Some("SEPA")
+      cardSettlementAccount.map(_.balance.currency) shouldBe Some("USD")
+      cardSettlementAccount.map(_.payment_system) shouldBe Some("CARD")
+
+
+      Then("We make a request v4.0.0 but with other user")
+      val requestWithNewAccountId = (v4_0_0_Request / "banks" / testBankId.value / "settlement-accounts" ).GET <@(user1)
+      val responseWithNoRole = makeGetRequest(requestWithNewAccountId)
+      Then("We should get a 403 and some error message")
+      responseWithNoRole.code should equal(403)
+      responseWithNoRole.body.toString contains(s"$UserHasMissingRoles") should be (true)
+
+
+      Then("We grant the roles and test it again")
+      Entitlement.entitlement.vend.addEntitlement(testBankId.value, resourceUser1.userId, ApiRole.CanGetSettlementAccountAtOneBank.toString)
+      val responseWithOtherUser = makeGetRequest(requestWithNewAccountId)
+
+      val settlementAccounts1 = responseWithOtherUser.body.extract[SettlementAccountsJson]
+      val sepaSettlementAccount1 = settlementAccounts1.settlement_accounts.find(_.account_id == "SEPA_SETTLEMENT_ACCOUNT_EUR")
+      val cardSettlementAccount1 = settlementAccounts1.settlement_accounts.find(_.account_id == "CARD_SETTLEMENT_ACCOUNT_USD")
+      sepaSettlementAccount1.map(_.balance.currency) shouldBe Some("EUR")
+      sepaSettlementAccount1.map(_.payment_system) shouldBe Some("SEPA")
+      cardSettlementAccount1.map(_.balance.currency) shouldBe Some("USD")
+      cardSettlementAccount1.map(_.payment_system) shouldBe Some("CARD")
+    }
+  }
+  
+}


### PR DESCRIPTION
Add the two following settlement accounts endpoints :
- /obp/v4.0.0/banks/BANK_ID/settlement-accounts POST (Create settlement account)
- /obp/v4.0.0/banks/BANK_ID/settlement-accounts GET (Get settlements accounts)

I've also wrote some integration tests for those two endpoints and created the associated roles (`CanCreateSettlementAccount`, `CanGetSettlementAccount`)