### PR TITLE
Payment return the transactionId associated to the bank account

### DIFF
--- a/obp-api/src/main/scala/code/model/BankingData.scala
+++ b/obp-api/src/main/scala/code/model/BankingData.scala
@@ -563,9 +563,12 @@ object BankAccountX {
         if (counterparty.otherAccountSecondaryRoutingScheme.isEmpty) Nil
         else List(AccountRouting(counterparty.otherAccountSecondaryRoutingScheme, counterparty.otherAccountSecondaryRoutingAddress))
 
+      // Due to the new field in the database, old counterparty have void currency, so by default, we set it to EUR
+      val counterpartyCurrency = if (counterparty.currency.nonEmpty) counterparty.currency else "EUR"
+
       Full(BankAccountCommons(
         AccountId(""), "", 0,
-        currency = counterparty.currency
+        currency = counterpartyCurrency
         , "", "", "", BankId(""), new Date(), "",
         accountRoutings = accountRouting1 ++ accountRouting2,
         List.empty, accountHolder = counterparty.name,


### PR DESCRIPTION
Modifications asked by Tobias

The mapped connector now return the transactionId linked to the bankAccount after a payment. This behavious is guaranteed only for external payments (Settlement account --> OBP Account or OBP Account --> Settlement Account). In case of a OBP Account --> OBP Account transaction, we always return the debit transaction.

Here is an example for a credit on an OBP account
![Capture 1](https://user-images.githubusercontent.com/17991359/93342741-fbceb200-f82f-11ea-81e3-9a64021cebd0.PNG)
![Capture 3](https://user-images.githubusercontent.com/17991359/93342752-00936600-f830-11ea-9d98-63ff25d958fe.PNG)


Here is an example for a debit on an OBP account
![Capture 2](https://user-images.githubusercontent.com/17991359/93342772-05581a00-f830-11ea-86b4-44aa49cda561.PNG)
![Capture 4](https://user-images.githubusercontent.com/17991359/93342785-08530a80-f830-11ea-91d6-5dc784446211.PNG)

As you can see, we always return the transactionId related to the account

Other features in this commit :
- add a default currency (EUR) to counterparty if no counterparty currency is found
- compute the new amount (according to the currency rate) if the default settlement account is selected