### PR TITLE
feature/Add the NotifyTransactionRequest connector method [SEPA Adapter]

### DIFF
--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -787,6 +787,12 @@ object NewStyle {
         (unboxFullOrFail(i._1, callContext, s"$InvalidConnectorResponseForGetTransactionRequests210", 400), i._2)
       }
     }
+
+    def notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]): OBPReturnType[TransactionRequestStatus.Value] = {
+      Connector.connector.vend.notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]) map { i =>
+        (unboxFullOrFail(i._1, callContext, s"$TransactionRequestStatusNotInitiated Can't notify TransactionRequestId(${transactionRequest.id}) ", 400), i._2)
+      }
+    }
     
     def getCounterpartyByCounterpartyId(counterpartyId: CounterpartyId, callContext: Option[CallContext]): OBPReturnType[CounterpartyTrait] = 
     {

--- a/obp-api/src/main/scala/code/bankconnectors/Connector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/Connector.scala
@@ -1040,6 +1040,9 @@ trait Connector extends MdcLoggable {
                                                 charge: TransactionRequestCharge,
                                                 chargePolicy: String): Box[TransactionRequest] = Failure(setUnimplementedError)
 
+  def notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestStatus.Value]] =
+    Future{(Failure(setUnimplementedError), callContext)}
+
   def saveTransactionRequestTransaction(transactionRequestId: TransactionRequestId, transactionId: TransactionId): Box[Boolean] = {
     //put connector agnostic logic here if necessary
     saveTransactionRequestTransactionImpl(transactionRequestId, transactionId)

--- a/obp-commons/src/main/scala/com/openbankproject/commons/dto/JsonsTransfer.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/dto/JsonsTransfer.scala
@@ -156,6 +156,13 @@ case class OutBoundMakePaymentv210(outboundAdapterCallContext: OutboundAdapterCa
 
 case class InBoundMakePaymentv210(inboundAdapterCallContext: InboundAdapterCallContext, status: Status, data: TransactionId) extends InBoundTrait[TransactionId]
 
+case class OutBoundNotifyTransactionRequest(outboundAdapterCallContext: OutboundAdapterCallContext,
+                                            fromAccount: BankAccount, toAccount: BankAccount,
+                                            transactionRequest: TransactionRequest) extends TopicTrait
+
+case class InBoundNotifyTransactionRequest(inboundAdapterCallContext: InboundAdapterCallContext,
+                                           status: Status, data: TransactionRequestStatus.Value) extends InBoundTrait[TransactionRequestStatus.Value]
+
 case class OutBoundMakePaymentV400(outboundAdapterCallContext: OutboundAdapterCallContext,
                                    transactionRequest: TransactionRequest,
                                    reasons: Option[List[TransactionRequestReason]]) extends TopicTrait


### PR DESCRIPTION
This new method can be used to notify an adapter (e.g. SEPA Adapter) of a transaction request status change

[Jenkins tests passed](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/55/)