### PR TITLE
feature/Add getCounterpartyByIbanAndBankAccountId connector method [SEPA Adapter]

### DIFF
--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -815,6 +815,20 @@ object NewStyle {
         
       }
     }
+
+    def getCounterpartyByIbanAndBankAccountId(iban: String, bankId: BankId, accountId: AccountId, callContext: Option[CallContext]) : OBPReturnType[CounterpartyTrait] =
+    {
+      Connector.connector.vend.getCounterpartyByIbanAndBankAccountId(iban: String, bankId: BankId, accountId: AccountId, callContext: Option[CallContext]) map { i =>
+        (unboxFullOrFail(
+          i._1,
+          callContext,
+          s"$CounterpartyNotFoundByIban. Please check how do you create Counterparty, " +
+            s"set the proper Iban value to `other_account_secondary_routing_address`. Current Iban = $iban. " +
+            s"Check also the bankId and the accountId, Current BankId = ${bankId.value}, Current AccountId = ${accountId.value}",
+          404),
+          i._2)
+      }
+    }
     
     def getTransactionRequestImpl(transactionRequestId: TransactionRequestId, callContext: Option[CallContext]): OBPReturnType[TransactionRequest] = 
     {

--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -842,7 +842,7 @@ trait APIMethods400 {
                     json.extract[TransactionRequestBodySEPAJsonV400]
                   }
                   toIban = transDetailsSEPAJson.to.iban
-                  (toCounterparty, callContext) <- NewStyle.function.getCounterpartyByIban(toIban, cc.callContext)
+                  (toCounterparty, callContext) <- NewStyle.function.getCounterpartyByIbanAndBankAccountId(toIban, fromAccount.bankId, fromAccount.accountId, cc.callContext)
                   toAccount <- NewStyle.function.getBankAccountFromCounterparty(toCounterparty, true, callContext)
                   _ <- Helper.booleanToFuture(s"$CounterpartyBeneficiaryPermit") {
                     toCounterparty.isBeneficiary

--- a/obp-api/src/main/scala/code/bankconnectors/Connector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/Connector.scala
@@ -541,6 +541,8 @@ trait Connector extends MdcLoggable {
     */
   def getCounterpartyByIban(iban: String, callContext: Option[CallContext]) : OBPReturnType[Box[CounterpartyTrait]] = Future {(Failure(setUnimplementedError), callContext)}
 
+  def getCounterpartyByIbanAndBankAccountId(iban: String, bankId: BankId, accountId: AccountId, callContext: Option[CallContext]) : OBPReturnType[Box[CounterpartyTrait]] = Future {(Failure(setUnimplementedError), callContext)}
+
   def getCounterpartiesLegacy(thisBankId: BankId, thisAccountId: AccountId, viewId :ViewId, callContext: Option[CallContext] = None): Box[(List[CounterpartyTrait], Option[CallContext])]= Failure(setUnimplementedError)
 
   def getCounterparties(thisBankId: BankId, thisAccountId: AccountId, viewId: ViewId, callContext: Option[CallContext] = None): OBPReturnType[Box[List[CounterpartyTrait]]] = Future {(Failure(setUnimplementedError), callContext)}

--- a/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -793,6 +793,10 @@ object LocalMappedConnector extends Connector with MdcLoggable {
     Future(Counterparties.counterparties.vend.getCounterpartyByIban(iban), callContext)
   }
 
+  override def getCounterpartyByIbanAndBankAccountId(iban: String, bankId: BankId, accountId: AccountId, callContext: Option[CallContext]) = {
+    Future(Counterparties.counterparties.vend.getCounterpartyByIbanAndBankAccountId(iban, bankId, accountId), callContext)
+  }
+
 
   override def getPhysicalCardsForUser(user: User): Box[List[PhysicalCard]] = {
     val list = code.cards.PhysicalCard.physicalCardProvider.vend.getPhysicalCards(user)

--- a/obp-api/src/main/scala/code/metadata/counterparties/Counterparties.scala
+++ b/obp-api/src/main/scala/code/metadata/counterparties/Counterparties.scala
@@ -36,6 +36,8 @@ trait Counterparties {
 
   def getCounterpartyByIban(iban : String): Box[CounterpartyTrait]
 
+  def getCounterpartyByIbanAndBankAccountId(iban: String, bankId: BankId, accountId: AccountId): Box[CounterpartyTrait]
+
   def getCounterparties(thisBankId: BankId, thisAccountId: AccountId, viewId: ViewId): Box[List[CounterpartyTrait]]
 
   def createCounterparty(
@@ -96,6 +98,8 @@ class RemotedataCounterpartiesCaseClasses {
   case class getCounterparty(counterpartyId: String)
 
   case class getCounterpartyByIban(iban: String)
+
+  case class getCounterpartyByIbanAndBankAccountId(iban: String, bankId: BankId, accountId: AccountId)
 
   case class getCounterparties(thisBankId: BankId, thisAccountId: AccountId, viewId: ViewId)
 

--- a/obp-api/src/main/scala/code/metadata/counterparties/MapperCounterparties.scala
+++ b/obp-api/src/main/scala/code/metadata/counterparties/MapperCounterparties.scala
@@ -133,6 +133,14 @@ object MapperCounterparties extends Counterparties with MdcLoggable {
     )
   }
 
+  def getCounterpartyByIbanAndBankAccountId(iban : String, bankId: BankId, accountId: AccountId) = {
+    MappedCounterparty.find(
+      By(MappedCounterparty.mOtherAccountSecondaryRoutingAddress, iban),
+      By(MappedCounterparty.mThisBankId, bankId.value),
+      By(MappedCounterparty.mThisAccountId, accountId.value)
+    )
+  }
+
   override def getCounterparties(thisBankId: BankId, thisAccountId: AccountId, viewId: ViewId): Box[List[CounterpartyTrait]] = {
     Full(MappedCounterparty.findAll(By(MappedCounterparty.mThisAccountId, thisAccountId.value),
       By(MappedCounterparty.mThisBankId, thisBankId.value),

--- a/obp-api/src/main/scala/code/metadata/counterparties/MongoCounterparties.scala
+++ b/obp-api/src/main/scala/code/metadata/counterparties/MongoCounterparties.scala
@@ -109,7 +109,9 @@ object MongoCounterparties extends Counterparties with MdcLoggable {
 
   override def getCounterparty(counterpartyId : String): Box[CounterpartyTrait] = Empty
 
-  override def getCounterpartyByIban(counterpartyId : String): Box[CounterpartyTrait] = Empty
+  override def getCounterpartyByIban(iban : String): Box[CounterpartyTrait] = Empty
+
+  override def getCounterpartyByIbanAndBankAccountId(iban : String, bankId: BankId, accountId: AccountId): Box[CounterpartyTrait] = Empty
 
   override def createCounterparty(
                                    createdByUserId: String,

--- a/obp-api/src/main/scala/code/remotedata/RemotedataCounterparties.scala
+++ b/obp-api/src/main/scala/code/remotedata/RemotedataCounterparties.scala
@@ -36,6 +36,10 @@ object RemotedataCounterparties extends ObpActorInit with Counterparties {
     (actor ? cc.getCounterpartyByIban(iban: String)).mapTo[Box[CounterpartyTrait]]
   )
 
+  override def getCounterpartyByIbanAndBankAccountId(iban: String, bankId: BankId, accountId: AccountId): Box[CounterpartyTrait] = getValueFromFuture(
+    (actor ? cc.getCounterpartyByIbanAndBankAccountId(iban: String, bankId: BankId, accountId: AccountId)).mapTo[Box[CounterpartyTrait]]
+  )
+
   override def getCounterparties(thisBankId: BankId, thisAccountId: AccountId, viewId: ViewId): Box[List[CounterpartyTrait]] = getValueFromFuture(
     (actor ? cc.getCounterparties(thisBankId, thisAccountId, viewId)).mapTo[Box[List[CounterpartyTrait]]]
   )

--- a/obp-api/src/test/scala/code/api/v2_1_0/TransactionRequestsTest.scala
+++ b/obp-api/src/test/scala/code/api/v2_1_0/TransactionRequestsTest.scala
@@ -100,9 +100,9 @@ class TransactionRequestsTest extends V210ServerSetup with DefaultUsers {
 
       //prepare for counterparty and SEPA stuff
       //For SEPA, otherAccountRoutingScheme must be 'IBAN'
-      val counterpartySEPA = createCounterparty(bankId.value, accountId2.value, true, UUID.randomUUID.toString);
+      val counterpartySEPA = createCounterparty(bankId.value, accountId1.value, accountId2.value, true, UUID.randomUUID.toString);
       //For Counterpart local mapper, the  mOtherAccountRoutingScheme='OBP' and  mOtherBankRoutingScheme = 'OBP'
-      val counterpartyCounterparty = createCounterparty(bankId.value, accountId2.value, true, UUID.randomUUID.toString);
+      val counterpartyCounterparty = createCounterparty(bankId.value, accountId1.value, accountId2.value, true, UUID.randomUUID.toString);
 
       var transactionRequestBodySEPA = TransactionRequestBodySEPAJSON(bodyValue, IbanJson(counterpartySEPA.otherAccountSecondaryRoutingAddress), description, sharedChargePolicy)
 

--- a/obp-api/src/test/scala/code/api/v4_0_0/TransactionRequestsTest.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/TransactionRequestsTest.scala
@@ -113,9 +113,9 @@ class TransactionRequestsTest extends V400ServerSetup with DefaultUsers {
 
       //prepare for counterparty and SEPA stuff
       //For SEPA, otherAccountRoutingScheme must be 'IBAN'
-      val counterpartySEPA = createCounterparty(bankId.value, accountId2.value, true, UUID.randomUUID.toString);
+      val counterpartySEPA = createCounterparty(bankId.value, accountId1.value, accountId2.value, true, UUID.randomUUID.toString);
       //For Counterpart local mapper, the  mOtherAccountRoutingScheme='OBP' and  mOtherBankRoutingScheme = 'OBP'
-      val counterpartyCounterparty = createCounterparty(bankId.value, accountId2.value, true, UUID.randomUUID.toString);
+      val counterpartyCounterparty = createCounterparty(bankId.value, accountId1.value, accountId2.value, true, UUID.randomUUID.toString);
 
       var transactionRequestBodySEPA = TransactionRequestBodySEPAJSON(bodyValue, IbanJson(counterpartySEPA.otherAccountSecondaryRoutingAddress), description, sharedChargePolicy)
 

--- a/obp-api/src/test/scala/code/setup/LocalMappedConnectorTestSetup.scala
+++ b/obp-api/src/test/scala/code/setup/LocalMappedConnectorTestSetup.scala
@@ -35,7 +35,7 @@ trait LocalMappedConnectorTestSetup extends TestConnectorSetupWithStandardPermis
           .saveMe
   }
 
-  override protected def createCounterparty(bankId: String, accountId: String, isBeneficiary: Boolean, createdByUserId:String): CounterpartyTrait = {
+  override protected def createCounterparty(bankId: String, accountId: String, counterpartyObpRoutingAddress: String, isBeneficiary: Boolean, createdByUserId:String): CounterpartyTrait = {
     Counterparties.counterparties.vend.createCounterparty(
       createdByUserId = createdByUserId,
       thisBankId = bankId,
@@ -43,7 +43,7 @@ trait LocalMappedConnectorTestSetup extends TestConnectorSetupWithStandardPermis
       thisViewId = "",
       name = APIUtil.generateUUID(),
       otherAccountRoutingScheme = "OBP",
-      otherAccountRoutingAddress = accountId,
+      otherAccountRoutingAddress = counterpartyObpRoutingAddress,
       otherBankRoutingScheme = "OBP",
       otherBankRoutingAddress = bankId,
       otherBranchRoutingScheme ="OBP",

--- a/obp-api/src/test/scala/code/setup/TestConnectorSetup.scala
+++ b/obp-api/src/test/scala/code/setup/TestConnectorSetup.scala
@@ -21,7 +21,7 @@ trait TestConnectorSetup {
   protected def createTransactionRequest(account: BankAccount): List[MappedTransactionRequest]
   protected def updateAccountCurrency(bankId: BankId, accountId : AccountId, currency : String) : BankAccount
 
-  protected def createCounterparty(bankId: String, accountId: String, isBeneficiary: Boolean, createdByUserId:String): CounterpartyTrait
+  protected def createCounterparty(bankId: String, accountId: String, counterpartyObpRoutingAddress: String, isBeneficiary: Boolean, createdByUserId:String): CounterpartyTrait
   
   /**
     * This method, will do 4 things:


### PR DESCRIPTION
This new connector method is used to target precisely a counterparty linked to an account. This method should be used to replace the old one (getCounterpartyByIban)

[Jenkins tests passed](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/59/)