### PR TITLE
Add "get account by account routing" endpoint [SEPA Adapter]

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -16,7 +16,7 @@ import code.api.v3_0_0.JSONFactory300.createBranchJsonV300
 import code.api.v3_0_0.custom.JSONFactoryCustom300
 import code.api.v3_0_0.{LobbyJsonV330, _}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, CustomerWithAttributesJsonV310, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
-import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankJson400, BanksJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestWithChargeJSON400, UserLockStatusJson, When, PostCounterpartyJson400}
+import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
 import code.branches.Branches.{Branch, DriveUpString, LobbyString}
 import code.consent.ConsentStatus
@@ -545,6 +545,11 @@ object SwaggerDefinitionsJSON {
   val accountRoutingJsonV121 = AccountRoutingJsonV121(
     scheme = "AccountNumber",
     address = "4930396"
+  )
+
+  val bankAccountRoutingJson = BankAccountRoutingJson(
+    bank_id = Some(bankIdExample.value),
+    account_routing = accountRoutingJsonV121
   )
 
   val accountRuleJsonV300 = AccountRuleJsonV300(

--- a/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
@@ -424,6 +424,11 @@ case class CounterpartiesJson400(
                                    counterparties: List[CounterpartyJson400]
                                  )
 
+case class BankAccountRoutingJson(
+                                 bank_id: Option[String],
+                                 account_routing: AccountRoutingJsonV121
+                                 )
+
 
 object JSONFactory400 {
   def createBankJSON400(bank: Bank): BankJson400 = {

--- a/obp-api/src/test/scala/code/api/v4_0_0/AccountTest.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/AccountTest.scala
@@ -7,7 +7,7 @@ import code.api.ResourceDocs1_4_0.SwaggerDefinitionsJSON.accountAttributeJson
 import code.api.util.APIUtil.OAuth._
 import code.api.util.{APIUtil, ApiRole}
 import code.api.util.ApiRole.CanCreateAccountAttributeAtOneBank
-import code.api.util.ErrorMessages.{UserHasMissingRoles, UserNotLoggedIn}
+import code.api.util.ErrorMessages.{BankAccountNotFoundByAccountRouting, UserHasMissingRoles, UserNotLoggedIn}
 import code.api.v2_0_0.{BasicAccountJSON, BasicAccountsJSON}
 import code.api.v3_1_0.{AccountAttributeResponseJson, CreateAccountResponseJsonV310, PostPutProductJsonV310, ProductJsonV310}
 import code.api.v4_0_0.OBPAPI4_0_0.Implementations4_0_0
@@ -35,12 +35,14 @@ class AccountTest extends V400ServerSetup {
   object ApiEndpoint2 extends Tag(nameOf(Implementations4_0_0.getPrivateAccountByIdFull))
   object ApiEndpoint3 extends Tag(nameOf(Implementations4_0_0.addAccount))
   object ApiEndpoint4 extends Tag(nameOf(Implementations4_0_0.getPrivateAccountsAtOneBank))
+  object ApiEndpoint5 extends Tag(nameOf(Implementations4_0_0.getAccountByAccountRouting))
 
   lazy val testBankId = testBankId1
   lazy val addAccountJson = SwaggerDefinitionsJSON.createAccountRequestJsonV310.copy(user_id = resourceUser1.userId, balance = AmountOfMoneyJsonV121("EUR","0"))
   lazy val addAccountJsonOtherUser = SwaggerDefinitionsJSON.createAccountRequestJsonV310
     .copy(user_id = resourceUser2.userId, balance = AmountOfMoneyJsonV121("EUR","0"),
       account_routings = List(AccountRoutingJsonV121(Random.nextString(4), Random.nextString(4))))
+  lazy val getAccountByRoutingJson = SwaggerDefinitionsJSON.bankAccountRoutingJson
   
   
   feature(s"test $ApiEndpoint1") {
@@ -237,6 +239,84 @@ class AccountTest extends V400ServerSetup {
       Then("We should get a 200 and check the response body")
       response2.code should equal(200)
       response2.body.extract[List[BasicAccountJSON]].length should be (0)
+
+    }
+  }
+
+  feature(s"test $ApiEndpoint5 - Unauthorized access") {
+    scenario("We will call the endpoint without user credentials", ApiEndpoint5, VersionOfApi) {
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "management" / "accounts" / "account-routing-query").POST
+      val response400 = makePostRequest(request400, write(getAccountByRoutingJson))
+      Then("We should get a 401")
+      response400.code should equal(401)
+      And("error should be " + UserNotLoggedIn)
+      response400.body.extract[ErrorMessage].message should equal (UserNotLoggedIn)
+    }
+  }
+
+  feature(s"test $ApiEndpoint5 - Authorized access") {
+    scenario("We will call the endpoint with user credentials", ApiEndpoint5, VersionOfApi) {
+      Given("We create an account with account routings")
+
+      val accountRoutingSchemeTest = "AccountNumber"
+      val accountRoutingAddressTest = "1567564589535564"
+
+      val createdAccountJson = SwaggerDefinitionsJSON.createAccountRequestJsonV310
+        .copy(user_id = resourceUser1.userId, balance = AmountOfMoneyJsonV121("EUR", "0"),
+          account_routings = List(
+            AccountRoutingJsonV121(accountRoutingSchemeTest, accountRoutingAddressTest)
+          ))
+
+      createAccountViaEndpoint(testBankId.value, createdAccountJson, user1)
+
+
+      When("We make a request to get the account with an existing account routing without specifying bankId")
+      val getAccountByRoutingWithNoBankJson = getAccountByRoutingJson.copy(bank_id = None, AccountRoutingJsonV121(accountRoutingSchemeTest, accountRoutingAddressTest))
+
+      val requestNoBank = (v4_0_0_Request / "management" / "accounts" / "account-routing-query").POST <@ (user1)
+      val responseNoBank = makePostRequest(requestNoBank, write(getAccountByRoutingWithNoBankJson))
+
+      Then("We should get a 200 and check the response body")
+      responseNoBank.code should equal(200)
+      val account1 = responseNoBank.body.extract[ModeratedAccountJSON400]
+      account1.account_routings.find(_.scheme == getAccountByRoutingWithNoBankJson.account_routing.scheme)
+        .map(_.address) shouldBe Some(getAccountByRoutingWithNoBankJson.account_routing.address)
+
+
+      When("We make a request to get the account with an existing account routing with specifying correct bankId")
+      val getAccountByRoutingWithBankJson = getAccountByRoutingJson.copy(Some(testBankId.value), AccountRoutingJsonV121(accountRoutingSchemeTest, accountRoutingAddressTest))
+
+      val requestWithBank = (v4_0_0_Request / "management" / "accounts" / "account-routing-query").POST <@ (user1)
+      val responseWithBank = makePostRequest(requestWithBank, write(getAccountByRoutingWithBankJson))
+
+      Then("We should get a 200 and check the response body")
+      responseWithBank.code should equal(200)
+      val account2 = responseWithBank.body.extract[ModeratedAccountJSON400]
+      account2.account_routings.find(_.scheme == getAccountByRoutingWithNoBankJson.account_routing.scheme)
+        .map(_.address) shouldBe Some(getAccountByRoutingWithNoBankJson.account_routing.address)
+
+
+      When("We make a request to get the account with an existing account routing with specifying incorrect bankId")
+      val getAccountByRoutingIncorrectBankJson = getAccountByRoutingJson.copy(Some(testBankId2.value), AccountRoutingJsonV121(accountRoutingSchemeTest, accountRoutingAddressTest))
+
+      val requestIncorrectBank = (v4_0_0_Request / "management" / "accounts" / "account-routing-query").POST <@ (user1)
+      val responseIncorrectBank = makePostRequest(requestIncorrectBank, write(getAccountByRoutingIncorrectBankJson))
+
+      Then("We should get a 404 with an error message")
+      responseIncorrectBank.code should equal(404)
+      responseIncorrectBank.body.extract[ErrorMessage].message contains BankAccountNotFoundByAccountRouting should be (true)
+
+
+      When("We make a request to get the account with an non-existing account routing")
+      val getAccountByRoutingIncorrectRouting = getAccountByRoutingJson.copy(bank_id = None, account_routing = AccountRoutingJsonV121("UnknownScheme", "UnknownAddress"))
+
+      val requestIncorrectRouting = (v4_0_0_Request / "management" / "accounts" / "account-routing-query").POST <@ (user1)
+      val responseIncorrectRouting = makePostRequest(requestIncorrectRouting, write(getAccountByRoutingIncorrectRouting))
+
+      Then("We should get a 404 with an error message")
+      responseIncorrectBank.code should equal(404)
+      responseIncorrectBank.body.extract[ErrorMessage].message contains BankAccountNotFoundByAccountRouting should be (true)
 
     }
   }


### PR DESCRIPTION
This new endpoint returns the account (if it exists) linked with the provided account routing. There is a `bank_id` field which is optional and if provided, it guarantee that the returned account is unique across all the banks.

Example with no `bank_id` provided:
![image](https://user-images.githubusercontent.com/17991359/94132868-318f1e80-fe60-11ea-877f-8fdf68d1c140.png)

Example with an incorrect `bank_id`:
![image](https://user-images.githubusercontent.com/17991359/94133394-e0cbf580-fe60-11ea-8dc6-bac896a837dc.png)

I've also added some tests to verify the correct behaviour of this new endpoint.

[Jenkins tests passed](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/60/)

**This PR should be reviewed by a technical team member, mainly about the user / view management in the endpoint which I'm not sure about.**