### PR TITLE
feature/Modify the TransactionRequestRefund endpoint [SEPA Adapter]

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -16,7 +16,7 @@ import code.api.v3_0_0.JSONFactory300.createBranchJsonV300
 import code.api.v3_0_0.custom.JSONFactoryCustom300
 import code.api.v3_0_0.{LobbyJsonV330, _}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, CustomerWithAttributesJsonV310, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
-import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, ModeratedFirehoseAccountJsonV400, ModeratedFirehoseAccountsJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
+import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, ModeratedFirehoseAccountJsonV400, ModeratedFirehoseAccountsJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestRefundFrom, TransactionRequestRefundTo, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
 import code.branches.Branches.{Branch, DriveUpString, LobbyString}
 import code.consent.ConsentStatus
@@ -3796,12 +3796,23 @@ object SwaggerDefinitionsJSON {
 
   val postAccountAccessJsonV400 = PostAccountAccessJsonV400(userIdExample.value, PostViewJsonV400(ExampleValue.viewIdExample.value, true))
   val revokedJsonV400 = RevokedJsonV400(true)
-  
+
+  val transactionRequestRefundTo = TransactionRequestRefundTo(
+    bank_id = Some(bankIdExample.value),
+    account_id = Some(accountIdExample.value),
+    counterparty_id = Some(counterpartyIdExample.value)
+  )
+
+  val transactionRequestRefundFrom = TransactionRequestRefundFrom(
+    counterparty_id = counterpartyIdExample.value
+  )
+
   val transactionRequestBodyRefundJsonV400 = TransactionRequestBodyRefundJsonV400(
-    to = transactionRequestAccountJsonV140,
+    to = Some(transactionRequestRefundTo),
+    from = Some(transactionRequestRefundFrom),
     value = amountOfMoneyJsonV121,
     description = "A refund description. ",
-    refund = RefundJson(transactionIdExample.value)
+    refund = RefundJson(transactionIdExample.value, transactionRequestRefundReasonCodeExample.value)
   )
 
   val customerAttributesResponseJson = CustomerAttributesResponseJson (

--- a/obp-api/src/main/scala/code/api/util/ExampleValue.scala
+++ b/obp-api/src/main/scala/code/api/util/ExampleValue.scala
@@ -188,8 +188,8 @@ object ExampleValue {
 
   lazy val hashOfSuppliedAnswerExample = ConnectorField(HashUtil.Sha256Hash("123"), s"Sha256 hash value of the ChallengeAnswer.challengeId")
   glossaryItems += makeGlossaryItem("ChallengeAnswer.hashOfSuppliedAnswer", hashOfSuppliedAnswerExample)
-  
-  
+
+
   lazy val gitCommitExample = ConnectorField("59623811dd8a41f6ffe67be46954eee11913dc28", "Identifies the code running on the OBP-API (Connector) or Adapter.")
 
   lazy val subExample = ConnectorField(s"${userNameExample.value}","An identifier for the user, unique among all OBP-API users and never reused")
@@ -247,7 +247,10 @@ object ExampleValue {
   glossaryItems += makeGlossaryItem("Transaction Requests.id", transactionRequestIdExample)
   
   lazy val transactionRequestCounterpartyIdExample = counterpartyIdExample
-  
+
+  lazy val transactionRequestRefundReasonCodeExample = ConnectorField("CUST", "Defines the reason code of a transaction refund request (e.g. a SEPA Credit Transfer Scheme reason code).")
+  glossaryItems += makeGlossaryItem("Transaction Requests.Transaction Request Refund Reason Code", transactionRequestRefundReasonCodeExample)
+
   lazy val currencyExample = balanceCurrencyExample
 
   lazy val paymentSystemExample = ConnectorField("SEPA", "A payment system can be SEPA, CARD, SWIFT ....")

--- a/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
@@ -254,15 +254,28 @@ case class TransactionRequestReasonJsonV400(
 }
 // the data from endpoint, extract as valid JSON
 case class TransactionRequestBodyRefundJsonV400(
-  to: TransactionRequestAccountJsonV140,
+  to: Option[TransactionRequestRefundTo],
+  from: Option[TransactionRequestRefundFrom],
   value: AmountOfMoneyJsonV121,
   description: String,
-  refund:RefundJson
+  refund: RefundJson
 ) extends TransactionRequestCommonBodyJSON
 
+case class TransactionRequestRefundTo(
+                                       bank_id: Option[String],
+                                       account_id : Option[String],
+                                       counterparty_id: Option[String]
+                                     )
+
+case class TransactionRequestRefundFrom(
+                                         counterparty_id: String
+                                       )
+
 case class RefundJson(
-  transaction_id: String
+  transaction_id: String,
+  reason_code: String
 )
+
 case class CustomerAttributeJsonV400(
   name: String,
   `type`: String,

--- a/obp-api/src/main/scala/code/model/BankingData.scala
+++ b/obp-api/src/main/scala/code/model/BankingData.scala
@@ -567,9 +567,9 @@ object BankAccountX {
       val counterpartyCurrency = if (counterparty.currency.nonEmpty) counterparty.currency else "EUR"
 
       Full(BankAccountCommons(
-        AccountId(""), "", 0,
+        AccountId(counterparty.otherAccountSecondaryRoutingAddress), "", 0,
         currency = counterpartyCurrency
-        , "", "", "", BankId(""), new Date(), "",
+        , "", "", "", BankId(counterparty.otherBankRoutingAddress), new Date(), "",
         accountRoutings = accountRouting1 ++ accountRouting2,
         List.empty, accountHolder = counterparty.name,
         Some(List(Attribute(


### PR DESCRIPTION
This PR add the following fields to the TransactionRequest Refund endpoint  : 

- `counterparty_id` to the `to` object : used to receive a refund request from a counterparty (after a received transaction)
- `counterparty_id` to the `from` object : used to send a refund request to an external counterparty (after a sent transaction)
- `reason_code` field to justify the refund request

A TODO also have been added to create transaction request attributes to avoir putting the original transaction id and reason code in the description.

[Jenkins tests passed](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/66/)