### PR TITLE
Reject a transaction request challenge [SEPA Adapter]

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -16,7 +16,7 @@ import code.api.v3_0_0.JSONFactory300.createBranchJsonV300
 import code.api.v3_0_0.custom.JSONFactoryCustom300
 import code.api.v3_0_0.{LobbyJsonV330, _}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, CustomerWithAttributesJsonV310, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
-import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, ModeratedFirehoseAccountJsonV400, ModeratedFirehoseAccountsJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestRefundFrom, TransactionRequestRefundTo, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
+import code.api.v4_0_0.{APIInfoJson400, AccountTagJSON, AccountTagsJSON, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, ChallengeAnswerJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, ModeratedFirehoseAccountJsonV400, ModeratedFirehoseAccountsJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestRefundFrom, TransactionRequestRefundTo, TransactionRequestWithChargeJSON400, UserLockStatusJson, When}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
 import code.branches.Branches.{Branch, DriveUpString, LobbyString}
 import code.consent.ConsentStatus
@@ -1177,6 +1177,13 @@ object SwaggerDefinitionsJSON {
   val challengeAnswerJSON = ChallengeAnswerJSON(
     id = "This is challenge.id, you can get it from `Create Transaction Request.` response, only is useful if status ==`INITIATED` there.",
     answer = "123"
+  )
+
+  val challengeAnswerJson400 = ChallengeAnswerJson400(
+    id = "This is challenge.id, you can get it from `Create Transaction Request.` response, only is useful if status ==`INITIATED` there.",
+    answer = "123",
+    Some("[Optional] Reason code for REJECT answer (e.g. 'CUST')"),
+    Some("[Optional] Additional description for REJECT answer")
   )
 
   val postCustomerJson = PostCustomerJson(

--- a/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
+++ b/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
@@ -416,7 +416,7 @@ object ErrorMessages {
   val InvalidPhoneNumber = "OBP-40017: Invalid Phone Number. Please specify a valid value for PHONE_NUMBER. Eg:+9722398746 "
   val TransactionRequestsNotEnabled = "OBP-40018: Sorry, Transaction Requests are not enabled in this API instance."
   val NextChallengePending = s"OBP-40019: Cannot create transaction due to transaction request is in status: ${NEXT_CHALLENGE_PENDING}."
-  val TransactionRequestStatusNotInitiatedOrPending = s"OBP-40020: Transaction Request Status is not ${INITIATED} or ${NEXT_CHALLENGE_PENDING}."
+  val TransactionRequestStatusNotInitiatedOrPendingOrForwarded = s"OBP-40020: Transaction Request Status is not ${INITIATED} or ${NEXT_CHALLENGE_PENDING} or ${FORWARDED}."
   val InvalidChallengeTransactionRequestId = "OBP-40021: Invalid Challenge PaymentId or TRANSACTION_REQUEST_ID. "
   val InvalidChallengeChallengeId = "OBP-40022: Invalid ChallengeId. "
 
@@ -480,6 +480,7 @@ object ErrorMessages {
   val AdapterUnknownError = "OBP-60013: Adapter Unknown Error. "
   val AdapterTimeOurError = "OBP-60014: Adapter Timeout Error. "
   val AdapterFunctionNotImplemented = "OBP-60015: Adapter Function Not Implemented."
+  val SaveTransactionRequestDescriptionException = "OBP-60016: Save Transaction Request Description Exception. "
 
   // MethodRouting Exceptions (OBP-7XXXX)
   val InvalidBankIdRegex = "OBP-70001: Incorrect regex for bankIdPattern."

--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -788,7 +788,7 @@ object NewStyle {
       }
     }
 
-    def notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]): OBPReturnType[TransactionRequestStatus.Value] = {
+    def notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]): OBPReturnType[TransactionRequestStatusValue] = {
       Connector.connector.vend.notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]) map { i =>
         (unboxFullOrFail(i._1, callContext, s"$TransactionRequestStatusNotInitiated Can't notify TransactionRequestId(${transactionRequest.id}) ", 400), i._2)
       }

--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -982,7 +982,7 @@ trait APIMethods400 {
         |In case REQUIRED_CHALLENGE_ANSWERS is not defined as an account attribute default value is 1.
         |
       """.stripMargin,
-      challengeAnswerJSON,
+      challengeAnswerJson400,
       transactionRequestWithChargeJson,
       List(
         $UserNotLoggedIn,
@@ -1012,8 +1012,8 @@ trait APIMethods400 {
             _ <- Helper.booleanToFuture(InvalidBankIdFormat) {
               isValidID(bankId.value)
             }
-            challengeAnswerJson <- NewStyle.function.tryons(s"$InvalidJsonFormat The Json body should be the $ChallengeAnswerJSON ", 400, cc.callContext) {
-              json.extract[ChallengeAnswerJSON]
+            challengeAnswerJson <- NewStyle.function.tryons(s"$InvalidJsonFormat The Json body should be the $ChallengeAnswerJson400", 400, cc.callContext) {
+              json.extract[ChallengeAnswerJson400]
             }
 
             account = BankIdAccountId(fromAccount.bankId, fromAccount.accountId)
@@ -1022,10 +1022,11 @@ trait APIMethods400 {
             // Check transReqId is valid
             (existingTransactionRequest, callContext) <- NewStyle.function.getTransactionRequestImpl(transReqId, cc.callContext)
 
-            // Check the Transaction Request is still INITIATED or NEXT_CHALLENGE_PENDING
-            _ <- Helper.booleanToFuture(TransactionRequestStatusNotInitiatedOrPending) {
+            // Check the Transaction Request is still INITIATED or NEXT_CHALLENGE_PENDING or FORWARDED
+            _ <- Helper.booleanToFuture(TransactionRequestStatusNotInitiatedOrPendingOrForwarded) {
               existingTransactionRequest.status.equals(TransactionRequestStatus.INITIATED.toString) ||
-              existingTransactionRequest.status.equals(TransactionRequestStatus.NEXT_CHALLENGE_PENDING.toString)
+              existingTransactionRequest.status.equals(TransactionRequestStatus.NEXT_CHALLENGE_PENDING.toString) ||
+              existingTransactionRequest.status.equals(TransactionRequestStatus.FORWARDED.toString)
             }
 
             // Check the input transactionRequestType is the same as when the user created the TransactionRequest
@@ -1047,54 +1048,87 @@ trait APIMethods400 {
               ).exists(_ == existingTransactionRequest.challenge.challenge_type)
             }
 
-
-            // Check the challengeId is valid for this existingTransactionRequest
-            _ <- Helper.booleanToFuture(s"${InvalidTransactionRequestChallengeId}") {
-              if (APIUtil.isDataFromOBPSide("validateChallengeAnswer")) {
-                MappedExpectedChallengeAnswer
-                  .findAll(By(MappedExpectedChallengeAnswer.mTransactionRequestId, transReqId.value))
-                  .exists(_.challengeId == challengeAnswerJson.id)
-              }else{
-                existingTransactionRequest.challenge.id.equals(challengeAnswerJson.id)
-              }
-            }
-
-            (challengeAnswerIsValidated, callContext) <- NewStyle.function.validateChallengeAnswer(challengeAnswerJson.id, challengeAnswerJson.answer, callContext)
-
-            _ <- Helper.booleanToFuture(s"${InvalidChallengeAnswer} ") {
-              challengeAnswerIsValidated
-            }
-
-            
-            //TODO, this is a temporary solution, we only checked single challenge Id for remote connectors. here is only for the localMapped Connector logic
-            _ <- if (APIUtil.isDataFromOBPSide("validateChallengeAnswer")){
-              for{
-                accountAttributes <- Connector.connector.vend.getAccountAttributesByAccount(bankId, accountId, None)
-                _ <- Helper.booleanToFuture(s"$NextChallengePending") {
-                  val quorum = accountAttributes._1.toList.flatten.find(_.name == "REQUIRED_CHALLENGE_ANSWERS").map(_.value).getOrElse("1").toInt
-                  MappedExpectedChallengeAnswer
-                    .findAll(By(MappedExpectedChallengeAnswer.mTransactionRequestId, transReqId.value))
-                    .count(_.successful == true) match {
-                    case number if number >= quorum => true
-                    case _ =>
-                      MappedTransactionRequestProvider.saveTransactionRequestStatusImpl(transReqId, TransactionRequestStatus.NEXT_CHALLENGE_PENDING.toString)
-                      false
+            (transactionRequest, callContext) <- challengeAnswerJson.answer match {
+              // If the challenge answer is `REJECT` - Currently only to Reject a SEPA transaction request REFUND
+              case "REJECT" =>
+                val transactionRequest = existingTransactionRequest.copy(status = TransactionRequestStatus.REJECTED.toString,
+                  body = existingTransactionRequest.body.copy(description =
+                    s"${existingTransactionRequest.body.description} - Reject reason code : ${challengeAnswerJson.reason_code.getOrElse("")} - Reject additional information : ${challengeAnswerJson.additional_information.getOrElse("")}"))
+                for {
+                  (fromAccount, toAccount, callContext) <- {
+                    // If the transaction request comes from the account to debit
+                    if (fromAccount.accountId.value == transactionRequest.from.account_id) {
+                      val toCounterpartyIban = transactionRequest.other_account_routing_address
+                      for {
+                        (toCounterparty, callContext) <- NewStyle.function.getCounterpartyByIbanAndBankAccountId(toCounterpartyIban, fromAccount.bankId, fromAccount.accountId, callContext)
+                        toAccount <- NewStyle.function.getBankAccountFromCounterparty(toCounterparty, true, callContext)
+                      } yield (fromAccount, toAccount, callContext)
+                    } else {
+                      // Else, the transaction request debit a counterparty (Iban)
+                      val fromCounterpartyIban = transactionRequest.from.account_id
+                      // and the creditor is the obp account owner
+                      val toAccount = fromAccount
+                      for {
+                        (fromCounterparty, callContext) <- NewStyle.function.getCounterpartyByIbanAndBankAccountId(fromCounterpartyIban, toAccount.bankId, toAccount.accountId, callContext)
+                        fromAccount <- NewStyle.function.getBankAccountFromCounterparty(fromCounterparty, false, callContext)
+                      } yield (fromAccount, toAccount, callContext)
+                    }
                   }
-                }
-              } yield {
-                true
-              }
-            } else{
-            Future{true}
-          } 
-            
-          // All Good, proceed with the Transaction creation...
-          (transactionRequest, callContext) <- TransactionRequestTypes.withName(transactionRequestType.value) match {
-            case TRANSFER_TO_PHONE | TRANSFER_TO_ATM | TRANSFER_TO_ACCOUNT =>
-              NewStyle.function.createTransactionAfterChallengeV300(u, fromAccount, transReqId, transactionRequestType, callContext)
-            case _ =>
-              NewStyle.function.createTransactionAfterChallengeV210(fromAccount, existingTransactionRequest, callContext)
-          }
+                  _ <- NewStyle.function.notifyTransactionRequest(fromAccount, toAccount, transactionRequest, callContext)
+                  _ <- Future(Connector.connector.vend.saveTransactionRequestStatusImpl(transactionRequest.id, transactionRequest.status))
+                  _ <- Future(Connector.connector.vend.saveTransactionRequestDescriptionImpl(transactionRequest.id, transactionRequest.body.description))
+                } yield (transactionRequest, callContext)
+              case _ =>
+                for {
+                  // Check the challengeId is valid for this existingTransactionRequest
+                  _ <- Helper.booleanToFuture(s"${InvalidTransactionRequestChallengeId}") {
+                    if (APIUtil.isDataFromOBPSide("validateChallengeAnswer")) {
+                      MappedExpectedChallengeAnswer
+                        .findAll(By(MappedExpectedChallengeAnswer.mTransactionRequestId, transReqId.value))
+                        .exists(_.challengeId == challengeAnswerJson.id)
+                    }else{
+                      existingTransactionRequest.challenge.id.equals(challengeAnswerJson.id)
+                    }
+                  }
+
+                  (challengeAnswerIsValidated, callContext) <- NewStyle.function.validateChallengeAnswer(challengeAnswerJson.id, challengeAnswerJson.answer, callContext)
+
+                  _ <- Helper.booleanToFuture(s"${InvalidChallengeAnswer} ") {
+                    challengeAnswerIsValidated
+                  }
+
+
+                  //TODO, this is a temporary solution, we only checked single challenge Id for remote connectors. here is only for the localMapped Connector logic
+                  _ <- if (APIUtil.isDataFromOBPSide("validateChallengeAnswer")){
+                    for{
+                      accountAttributes <- Connector.connector.vend.getAccountAttributesByAccount(bankId, accountId, None)
+                      _ <- Helper.booleanToFuture(s"$NextChallengePending") {
+                        val quorum = accountAttributes._1.toList.flatten.find(_.name == "REQUIRED_CHALLENGE_ANSWERS").map(_.value).getOrElse("1").toInt
+                        MappedExpectedChallengeAnswer
+                          .findAll(By(MappedExpectedChallengeAnswer.mTransactionRequestId, transReqId.value))
+                          .count(_.successful == true) match {
+                          case number if number >= quorum => true
+                          case _ =>
+                            MappedTransactionRequestProvider.saveTransactionRequestStatusImpl(transReqId, TransactionRequestStatus.NEXT_CHALLENGE_PENDING.toString)
+                            false
+                        }
+                      }
+                    } yield {
+                      true
+                    }
+                  } else{
+                    Future{true}
+                  }
+
+                  // All Good, proceed with the Transaction creation...
+                  (transactionRequest, callContext) <- TransactionRequestTypes.withName(transactionRequestType.value) match {
+                    case TRANSFER_TO_PHONE | TRANSFER_TO_ATM | TRANSFER_TO_ACCOUNT =>
+                      NewStyle.function.createTransactionAfterChallengeV300(u, fromAccount, transReqId, transactionRequestType, callContext)
+                    case _ =>
+                      NewStyle.function.createTransactionAfterChallengeV210(fromAccount, existingTransactionRequest, callContext)
+                  }
+                } yield (transactionRequest, callContext)
+            }
           } yield {
 
             (JSONFactory210.createTransactionRequestWithChargeJSON(transactionRequest), HttpCode.`202`(callContext))

--- a/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
@@ -458,6 +458,13 @@ case class BankAccountRoutingJson(
                                  account_routing: AccountRoutingJsonV121
                                  )
 
+case class ChallengeAnswerJson400 (
+                                 id: String,
+                                 answer: String,
+                                 reason_code: Option[String] = None,
+                                 additional_information: Option[String] = None
+                               )
+
 
 object JSONFactory400 {
   def createBankJSON400(bank: Bank): BankJson400 = {

--- a/obp-api/src/main/scala/code/bankconnectors/Connector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/Connector.scala
@@ -1042,7 +1042,7 @@ trait Connector extends MdcLoggable {
                                                 charge: TransactionRequestCharge,
                                                 chargePolicy: String): Box[TransactionRequest] = Failure(setUnimplementedError)
 
-  def notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestStatus.Value]] =
+  def notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestStatusValue]] =
     Future{(Failure(setUnimplementedError), callContext)}
 
   def saveTransactionRequestTransaction(transactionRequestId: TransactionRequestId, transactionId: TransactionId): Box[Boolean] = {
@@ -1059,7 +1059,9 @@ trait Connector extends MdcLoggable {
 
   protected def saveTransactionRequestChallengeImpl(transactionRequestId: TransactionRequestId, challenge: TransactionRequestChallenge): Box[Boolean] = TransactionRequests.transactionRequestProvider.vend.saveTransactionRequestChallengeImpl(transactionRequestId, challenge)
 
-  protected def saveTransactionRequestStatusImpl(transactionRequestId: TransactionRequestId, status: String): Box[Boolean] = TransactionRequests.transactionRequestProvider.vend.saveTransactionRequestStatusImpl(transactionRequestId, status)
+  def saveTransactionRequestStatusImpl(transactionRequestId: TransactionRequestId, status: String): Box[Boolean] = TransactionRequests.transactionRequestProvider.vend.saveTransactionRequestStatusImpl(transactionRequestId, status)
+
+  def saveTransactionRequestDescriptionImpl(transactionRequestId: TransactionRequestId, description: String): Box[Boolean] = TransactionRequests.transactionRequestProvider.vend.saveTransactionRequestDescriptionImpl(transactionRequestId, description)
 
   def getTransactionRequests(initiator : User, fromAccount : BankAccount) : Box[List[TransactionRequest]] = {
     val transactionRequests =

--- a/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -1533,6 +1533,10 @@ object LocalMappedConnector extends Connector with MdcLoggable {
     TransactionRequests.transactionRequestProvider.vend.saveTransactionRequestStatusImpl(transactionRequestId, status)
   }
 
+  override def saveTransactionRequestDescriptionImpl(transactionRequestId: TransactionRequestId, description: String): Box[Boolean] = {
+    TransactionRequests.transactionRequestProvider.vend.saveTransactionRequestDescriptionImpl(transactionRequestId, description)
+  }
+
 
   override def getTransactionRequestsImpl(fromAccount: BankAccount): Box[List[TransactionRequest]] = {
     TransactionRequests.transactionRequestProvider.vend.getTransactionRequests(fromAccount.bankId, fromAccount.accountId)
@@ -4141,8 +4145,8 @@ object LocalMappedConnector extends Connector with MdcLoggable {
     }
   }
 
-  override def notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestStatus.Value]] =
-    Future((Full(TransactionRequestStatus.withName(transactionRequest.status)), callContext))
+  override def notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestStatusValue]] =
+    Future((Full(TransactionRequestStatusValue(transactionRequest.status)), callContext))
 
   override def saveTransactionRequestTransaction(transactionRequestId: TransactionRequestId, transactionId: TransactionId) = {
     //put connector agnostic logic here if necessary

--- a/obp-api/src/main/scala/code/bankconnectors/akka/AkkaConnector_vDec2018.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/akka/AkkaConnector_vDec2018.scala
@@ -15,7 +15,7 @@ import code.bankconnectors.akka.actor.{AkkaConnectorActorInit, AkkaConnectorHelp
 import com.openbankproject.commons.ExecutionContext.Implicits.global
 import com.openbankproject.commons.dto._
 import com.openbankproject.commons.model._
-import com.openbankproject.commons.model.enums.{AccountAttributeType, CardAttributeType, CustomerAttributeType, ProductAttributeType, StrongCustomerAuthentication, TransactionAttributeType}
+import com.openbankproject.commons.model.enums.{AccountAttributeType, CardAttributeType, CustomerAttributeType, ProductAttributeType, StrongCustomerAuthentication, TransactionAttributeType, TransactionRequestStatus}
 import com.sksamuel.avro4s.SchemaFor
 import net.liftweb.common.{Box, Full}
 import net.liftweb.json.parse
@@ -1499,8 +1499,127 @@ object AkkaConnector_vDec2018 extends Connector with AkkaConnectorActorInit {
         val response: Future[Box[InBound]] = (southSideActor ? req).mapTo[InBound].recoverWith(recoverFunction).map(Box !! _) 
         response.map(convertToTuple[TransactionRequest](callContext))        
   }
-          
-          
+
+  messageDocs += notifyTransactionRequestDoc
+  def notifyTransactionRequestDoc = MessageDoc(
+    process = "obp.notifyTransactionRequest",
+    messageFormat = messageFormat,
+    description = "Notify Transaction Request",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = OutBoundNotifyTransactionRequest(outboundAdapterCallContext = MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      fromAccount = BankAccountCommons(accountId = AccountId(accountIdExample.value),
+        accountType = accountTypeExample.value,
+        balance = BigDecimal(balanceAmountExample.value),
+        currency = currencyExample.value,
+        name = bankAccountNameExample.value,
+        label = labelExample.value,
+        number = bankAccountNumberExample.value,
+        bankId = BankId(bankIdExample.value),
+        lastUpdate = parseDate(bankAccountLastUpdateExample.value).getOrElse(sys.error("bankAccountLastUpdateExample.value is not validate date format.")),
+        branchId = branchIdExample.value,
+        accountRoutings = List(AccountRouting(scheme = accountRoutingSchemeExample.value,
+          address = accountRoutingAddressExample.value)),
+        accountRules = List(AccountRule(scheme = accountRuleSchemeExample.value,
+          value = accountRuleValueExample.value)),
+        accountHolder = bankAccountAccountHolderExample.value),
+      toAccount = BankAccountCommons(accountId = AccountId(accountIdExample.value),
+        accountType = accountTypeExample.value,
+        balance = BigDecimal(balanceAmountExample.value),
+        currency = currencyExample.value,
+        name = bankAccountNameExample.value,
+        label = labelExample.value,
+        number = bankAccountNumberExample.value,
+        bankId = BankId(bankIdExample.value),
+        lastUpdate = parseDate(bankAccountLastUpdateExample.value).getOrElse(sys.error("bankAccountLastUpdateExample.value is not validate date format.")),
+        branchId = branchIdExample.value,
+        accountRoutings = List(AccountRouting(scheme = accountRoutingSchemeExample.value,
+          address = accountRoutingAddressExample.value)),
+        accountRules = List(AccountRule(scheme = accountRuleSchemeExample.value,
+          value = accountRuleValueExample.value)),
+        accountHolder = bankAccountAccountHolderExample.value),
+      transactionRequest = TransactionRequest(id = TransactionRequestId("string"),
+        `type` = transactionRequestTypeExample.value,
+        from = TransactionRequestAccount(bank_id = "string",
+          account_id = "string"),
+        body = TransactionRequestBodyAllTypes(to_sandbox_tan = Some(TransactionRequestAccount(bank_id = "string",
+          account_id = "string")),
+          to_sepa = Some(TransactionRequestIban("string")),
+          to_counterparty = Some(TransactionRequestCounterpartyId("string")),
+          to_transfer_to_phone = Some(TransactionRequestTransferToPhone(value = AmountOfMoneyJsonV121(currency = currencyExample.value,
+            amount = "string"),
+            description = "string",
+            message = "string",
+            from = FromAccountTransfer(mobile_phone_number = "string",
+              nickname = "string"),
+            to = ToAccountTransferToPhone("string"))),
+          to_transfer_to_atm = Some(TransactionRequestTransferToAtm(value = AmountOfMoneyJsonV121(currency = currencyExample.value,
+            amount = "string"),
+            description = "string",
+            message = "string",
+            from = FromAccountTransfer(mobile_phone_number = "string",
+              nickname = "string"),
+            to = ToAccountTransferToAtm(legal_name = "string",
+              date_of_birth = "string",
+              mobile_phone_number = "string",
+              kyc_document = ToAccountTransferToAtmKycDocument(`type` = "string",
+                number = "string")))),
+          to_transfer_to_account = Some(TransactionRequestTransferToAccount(value = AmountOfMoneyJsonV121(currency = currencyExample.value,
+            amount = "string"),
+            description = "string",
+            transfer_type = "string",
+            future_date = "string",
+            to = ToAccountTransferToAccount(name = "string",
+              bank_code = "string",
+              branch_number = "string",
+              account = ToAccountTransferToAccountAccount(number = accountNumberExample.value,
+                iban = ibanExample.value)))),
+          to_sepa_credit_transfers = Some(SepaCreditTransfers(debtorAccount = PaymentAccount("string"),
+            instructedAmount = AmountOfMoneyJsonV121(currency = currencyExample.value,
+              amount = "string"),
+            creditorAccount = PaymentAccount("string"),
+            creditorName = "string")),
+          value = AmountOfMoney(currency = currencyExample.value,
+            amount = "string"),
+          description = "string"),
+        transaction_ids = "string",
+        status = "string",
+        start_date = new Date(),
+        end_date = new Date(),
+        challenge = TransactionRequestChallenge(id = "string",
+          allowed_attempts = 123,
+          challenge_type = "string"),
+        charge = TransactionRequestCharge(summary = "string",
+          value = AmountOfMoney(currency = currencyExample.value,
+            amount = "string")),
+        charge_policy = "string",
+        counterparty_id = CounterpartyId(counterpartyIdExample.value),
+        name = "string",
+        this_bank_id = BankId(bankIdExample.value),
+        this_account_id = AccountId(accountIdExample.value),
+        this_view_id = ViewId(viewIdExample.value),
+        other_account_routing_scheme = "string",
+        other_account_routing_address = "string",
+        other_bank_routing_scheme = "string",
+        other_bank_routing_address = "string",
+        is_beneficiary = true,
+        future_date = Some("string"))
+    ),
+    exampleInboundMessage = InBoundNotifyTransactionRequest(
+      inboundAdapterCallContext = MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status = MessageDocsSwaggerDefinitions.inboundStatus,
+      data = TransactionRequestStatusValue(TransactionRequestStatus.FORWARDED.toString)
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestStatusValue]] = {
+    import com.openbankproject.commons.dto.{OutBoundNotifyTransactionRequest => OutBound, InBoundNotifyTransactionRequest => InBound}
+    val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, fromAccount, toAccount, transactionRequest)
+    val response: Future[Box[InBound]] = (southSideActor ? req).mapTo[InBound].recoverWith(recoverFunction).map(Box !! _)
+    response.map(convertToTuple[TransactionRequestStatusValue](callContext))
+  }
+
   messageDocs += getTransactionRequests210Doc
   def getTransactionRequests210Doc = MessageDoc(
     process = "obp.getTransactionRequests210",

--- a/obp-api/src/main/scala/code/remotedata/RemotedataTransactionRequests.scala
+++ b/obp-api/src/main/scala/code/remotedata/RemotedataTransactionRequests.scala
@@ -78,6 +78,10 @@ object RemotedataTransactionRequests extends ObpActorInit with TransactionReques
     (actor ? cc.saveTransactionRequestStatusImpl(transactionRequestId, status)).mapTo[Box[Boolean]]
   )
 
+  def saveTransactionRequestDescriptionImpl(transactionRequestId: TransactionRequestId, description: String): Box[Boolean] = getValueFromFuture(
+    (actor ? cc.saveTransactionRequestDescriptionImpl(transactionRequestId, description)).mapTo[Box[Boolean]]
+  )
+
   def bulkDeleteTransactionRequests(): Boolean = getValueFromFuture(
     (actor ? cc.bulkDeleteTransactionRequests()).mapTo[Boolean]
   )

--- a/obp-api/src/main/scala/code/transactionrequests/MappedTransactionRequestProvider.scala
+++ b/obp-api/src/main/scala/code/transactionrequests/MappedTransactionRequestProvider.scala
@@ -173,6 +173,14 @@ object MappedTransactionRequestProvider extends TransactionRequestProvider {
     }
   }
 
+  override def saveTransactionRequestDescriptionImpl(transactionRequestId: TransactionRequestId, description: String): Box[Boolean] = {
+    val mappedTransactionRequest = MappedTransactionRequest.find(By(MappedTransactionRequest.mTransactionRequestId, transactionRequestId.value))
+    mappedTransactionRequest match {
+      case Full(tr: MappedTransactionRequest) => Full(tr.mBody_Description(description).save)
+      case _ => Failure(s"$SaveTransactionRequestDescriptionException Couldn't find transaction request ${transactionRequestId} to set description")
+    }
+  }
+
 }
 
 class MappedTransactionRequest extends LongKeyedMapper[MappedTransactionRequest] with IdPK with CreatedUpdated with CustomJsonFormats {

--- a/obp-api/src/main/scala/code/transactionrequests/TransactionRequests.scala
+++ b/obp-api/src/main/scala/code/transactionrequests/TransactionRequests.scala
@@ -86,6 +86,7 @@ trait TransactionRequestProvider {
   def saveTransactionRequestTransactionImpl(transactionRequestId: TransactionRequestId, transactionId: TransactionId): Box[Boolean]
   def saveTransactionRequestChallengeImpl(transactionRequestId: TransactionRequestId, challenge: TransactionRequestChallenge): Box[Boolean]
   def saveTransactionRequestStatusImpl(transactionRequestId: TransactionRequestId, status: String): Box[Boolean]
+  def saveTransactionRequestDescriptionImpl(transactionRequestId: TransactionRequestId, description: String): Box[Boolean]
   def bulkDeleteTransactionRequestsByTransactionId(transactionId: TransactionId): Boolean
   def bulkDeleteTransactionRequests(): Boolean
 }
@@ -114,6 +115,7 @@ class RemotedataTransactionRequestsCaseClasses {
   case class saveTransactionRequestTransactionImpl(transactionRequestId: TransactionRequestId, transactionId: TransactionId)
   case class saveTransactionRequestChallengeImpl(transactionRequestId: TransactionRequestId, challenge: TransactionRequestChallenge)
   case class saveTransactionRequestStatusImpl(transactionRequestId: TransactionRequestId, status: String)
+  case class saveTransactionRequestDescriptionImpl(transactionRequestId: TransactionRequestId, description: String)
   case class bulkDeleteTransactionRequestsByTransactionId(transactionId: TransactionId)
   case class bulkDeleteTransactionRequests()
 }

--- a/obp-api/src/test/scala/code/api/v4_0_0/TransactionRequestsTest.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/TransactionRequestsTest.scala
@@ -109,7 +109,7 @@ class TransactionRequestsTest extends V400ServerSetup with DefaultUsers {
       // prepare for Answer Transaction Request Challenge endpoint
       var challengeId = ""
       var transRequestId = ""
-      var answerJson = ChallengeAnswerJSON(id = challengeId, answer = "123")
+      var answerJson = ChallengeAnswerJson400(id = challengeId, answer = "123")
 
       //prepare for counterparty and SEPA stuff
       //For SEPA, otherAccountRoutingScheme must be 'IBAN'
@@ -124,7 +124,7 @@ class TransactionRequestsTest extends V400ServerSetup with DefaultUsers {
       def setAnswerTransactionRequest(challengeId: String = this.challengeId, transRequestId: String = this.transRequestId, consumerAndToken: Option[(Consumer, Token)] = user1) = {
         this.challengeId = challengeId
         this.transRequestId = transRequestId
-        answerJson = ChallengeAnswerJSON(id = challengeId, answer = "123")
+        answerJson = ChallengeAnswerJson400(id = challengeId, answer = "123")
         val answerRequestNew = (v4_0_0_Request / "banks" / testBank.bankId.value / "accounts" / fromAccount.accountId.value /
           CUSTOM_OWNER_VIEW_ID / "transaction-request-types" / transactionRequestType / "transaction-requests" / transRequestId / "challenge").POST <@ (consumerAndToken)
         answerRequest = answerRequestNew

--- a/obp-commons/src/main/scala/com/openbankproject/commons/dto/JsonsTransfer.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/dto/JsonsTransfer.scala
@@ -161,7 +161,7 @@ case class OutBoundNotifyTransactionRequest(outboundAdapterCallContext: Outbound
                                             transactionRequest: TransactionRequest) extends TopicTrait
 
 case class InBoundNotifyTransactionRequest(inboundAdapterCallContext: InboundAdapterCallContext,
-                                           status: Status, data: TransactionRequestStatus.Value) extends InBoundTrait[TransactionRequestStatus.Value]
+                                           status: Status, data: TransactionRequestStatusValue) extends InBoundTrait[TransactionRequestStatusValue]
 
 case class OutBoundMakePaymentV400(outboundAdapterCallContext: OutboundAdapterCallContext,
                                    transactionRequest: TransactionRequest,

--- a/obp-commons/src/main/scala/com/openbankproject/commons/model/BankingModel.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/model/BankingModel.scala
@@ -96,6 +96,10 @@ case class TransactionRequestType(value : String) {
   override def toString = value
 }
 
+case class TransactionRequestStatusValue(value : String) {
+  override def toString = value
+}
+
 //Note: change case class -> trait, for kafka extends it
 trait TransactionRequestStatus{
   def transactionRequestId : String


### PR DESCRIPTION
This PR add the support to reject a transaction request challenge.
Two optional fields `reason_code` and `additional_information` can be used to provide more information about the reject cause.
This feature is currently only supported for SEPA purpose.

I've also refactored the NotifyTransactionRequest method to add it to the Akka connector.

[Jenkins tests passed](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/68/)