### PR TITLE
bugfix/Add makePaymentV400 and common conversions in Akka connector [SEPA Adapter]

### DIFF
--- a/obp-api/src/main/scala/code/bankconnectors/akka/AkkaConnector_vDec2018.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/akka/AkkaConnector_vDec2018.scala
@@ -1360,7 +1360,10 @@ object AkkaConnector_vDec2018 extends Connector with AkkaConnectorActorInit {
 
   override def makePaymentv210(fromAccount: BankAccount, toAccount: BankAccount, transactionRequestId: TransactionRequestId, transactionRequestCommonBody: TransactionRequestCommonBodyJSON, amount: BigDecimal, description: String, transactionRequestType: TransactionRequestType, chargePolicy: String, callContext: Option[CallContext]): OBPReturnType[Box[TransactionId]] = {
         import com.openbankproject.commons.dto.{OutBoundMakePaymentv210 => OutBound, InBoundMakePaymentv210 => InBound}
-        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, fromAccount, toAccount, transactionRequestId, transactionRequestCommonBody, amount, description, transactionRequestType, chargePolicy)
+        val fromAccountCommons: BankAccountCommons = fromAccount
+        val toAccountCommons: BankAccountCommons = toAccount
+        val transactionRequestCommonBodyJSONCommons: TransactionRequestCommonBodyJSONCommons = transactionRequestCommonBody
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, fromAccountCommons, toAccountCommons, transactionRequestId, transactionRequestCommonBodyJSONCommons, amount, description, transactionRequestType, chargePolicy)
         val response: Future[Box[InBound]] = (southSideActor ? req).mapTo[InBound].recoverWith(recoverFunction).map(Box !! _)
         response.map(convertToTuple[TransactionId](callContext))        
   }
@@ -1615,7 +1618,9 @@ object AkkaConnector_vDec2018 extends Connector with AkkaConnectorActorInit {
 
   override def notifyTransactionRequest(fromAccount: BankAccount, toAccount: BankAccount, transactionRequest: TransactionRequest, callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestStatusValue]] = {
     import com.openbankproject.commons.dto.{OutBoundNotifyTransactionRequest => OutBound, InBoundNotifyTransactionRequest => InBound}
-    val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, fromAccount, toAccount, transactionRequest)
+    val fromAccountCommons: BankAccountCommons = fromAccount
+    val toAccountCommons: BankAccountCommons = toAccount
+    val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, fromAccountCommons, toAccountCommons, transactionRequest)
     val response: Future[Box[InBound]] = (southSideActor ? req).mapTo[InBound].recoverWith(recoverFunction).map(Box !! _)
     response.map(convertToTuple[TransactionRequestStatusValue](callContext))
   }
@@ -2609,7 +2614,103 @@ object AkkaConnector_vDec2018 extends Connector with AkkaConnectorActorInit {
         val response: Future[Box[InBound]] = (southSideActor ? req).mapTo[InBound].recoverWith(recoverFunction).map(Box !! _) 
         response.map(convertToTuple[TransactionId](callContext))        
   }
-          
+
+  messageDocs += makePaymentV400Doc
+  def makePaymentV400Doc = MessageDoc(
+    process = "obp.makePaymentV400",
+    messageFormat = messageFormat,
+    description = "Make Payment V400",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+      OutBoundMakePaymentV400(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+        transactionRequest= TransactionRequest(id=TransactionRequestId(transactionRequestIdExample.value),
+          `type`=transactionRequestTypeExample.value,
+          from= TransactionRequestAccount(bank_id=bank_idExample.value,
+            account_id=account_idExample.value),
+          body= TransactionRequestBodyAllTypes(to_sandbox_tan=Some( TransactionRequestAccount(bank_id=bank_idExample.value,
+            account_id=account_idExample.value)),
+            to_sepa=Some(TransactionRequestIban(transactionRequestIban.value)),
+            to_counterparty=Some(TransactionRequestCounterpartyId(transactionRequestCounterpartyIdExample.value)),
+            to_transfer_to_phone=Some( TransactionRequestTransferToPhone(value= AmountOfMoneyJsonV121(currency=currencyExample.value,
+              amount=amountExample.value),
+              description=descriptionExample.value,
+              message=messageExample.value,
+              from= FromAccountTransfer(mobile_phone_number="string",
+                nickname=nicknameExample.value),
+              to=ToAccountTransferToPhone(toExample.value))),
+            to_transfer_to_atm=Some( TransactionRequestTransferToAtm(value= AmountOfMoneyJsonV121(currency=currencyExample.value,
+              amount=amountExample.value),
+              description=descriptionExample.value,
+              message=messageExample.value,
+              from= FromAccountTransfer(mobile_phone_number="string",
+                nickname=nicknameExample.value),
+              to= ToAccountTransferToAtm(legal_name="string",
+                date_of_birth="string",
+                mobile_phone_number="string",
+                kyc_document= ToAccountTransferToAtmKycDocument(`type`=typeExample.value,
+                  number=numberExample.value)))),
+            to_transfer_to_account=Some( TransactionRequestTransferToAccount(value= AmountOfMoneyJsonV121(currency=currencyExample.value,
+              amount=amountExample.value),
+              description=descriptionExample.value,
+              transfer_type="string",
+              future_date="string",
+              to= ToAccountTransferToAccount(name=nameExample.value,
+                bank_code="string",
+                branch_number="string",
+                account= ToAccountTransferToAccountAccount(number=accountNumberExample.value,
+                  iban=ibanExample.value)))),
+            to_sepa_credit_transfers=Some( SepaCreditTransfers(debtorAccount=PaymentAccount("string"),
+              instructedAmount= AmountOfMoneyJsonV121(currency=currencyExample.value,
+                amount=amountExample.value),
+              creditorAccount=PaymentAccount("string"),
+              creditorName="string")),
+            value= AmountOfMoney(currency=currencyExample.value,
+              amount=amountExample.value),
+            description=descriptionExample.value),
+          transaction_ids="string",
+          status=statusExample.value,
+          start_date=toDate(transactionRequestStartDateExample),
+          end_date=toDate(transactionRequestEndDateExample),
+          challenge= TransactionRequestChallenge(id=challengeIdExample.value,
+            allowed_attempts=123,
+            challenge_type="string"),
+          charge= TransactionRequestCharge(summary=summaryExample.value,
+            value= AmountOfMoney(currency=currencyExample.value,
+              amount=amountExample.value)),
+          charge_policy="string",
+          counterparty_id=CounterpartyId(transactionRequestCounterpartyIdExample.value),
+          name=nameExample.value,
+          this_bank_id=BankId(bankIdExample.value),
+          this_account_id=AccountId(accountIdExample.value),
+          this_view_id=ViewId(viewIdExample.value),
+          other_account_routing_scheme="string",
+          other_account_routing_address="string",
+          other_bank_routing_scheme="string",
+          other_bank_routing_address="string",
+          is_beneficiary=true,
+          future_date=Some("string")),
+        reasons=Some(List( TransactionRequestReason(code=codeExample.value,
+          documentNumber=Some(documentNumberExample.value),
+          amount=Some(amountExample.value),
+          currency=Some(currencyExample.value),
+          description=Some(descriptionExample.value)))))
+      ),
+    exampleInboundMessage = (
+      InBoundMakePaymentV400(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+        status=MessageDocsSwaggerDefinitions.inboundStatus,
+        data=TransactionId(transactionIdExample.value))
+      ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def makePaymentV400(transactionRequest: TransactionRequest, reasons: Option[List[TransactionRequestReason]], callContext: Option[CallContext]): Future[Box[(TransactionId, Option[CallContext])]] = {
+    import com.openbankproject.commons.dto.{InBoundMakePaymentV400 => InBound, OutBoundMakePaymentV400 => OutBound}
+    val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, transactionRequest, reasons)
+    val response: Future[Box[InBound]] = (southSideActor ? req).mapTo[InBound].recoverWith(recoverFunction).map(Box !! _)
+    response.map(convertToTuple[TransactionId](callContext))
+  }
+
   messageDocs += createTransactionRequestv300Doc
   def createTransactionRequestv300Doc = MessageDoc(
     process = "obp.createTransactionRequestv300",

--- a/obp-api/src/main/scala/code/model/BankingData.scala
+++ b/obp-api/src/main/scala/code/model/BankingData.scala
@@ -568,8 +568,9 @@ object BankAccountX {
 
       Full(BankAccountCommons(
         AccountId(counterparty.otherAccountSecondaryRoutingAddress), "", 0,
-        currency = counterpartyCurrency
-        , "", "", "", BankId(counterparty.otherBankRoutingAddress), new Date(), "",
+        currency = counterpartyCurrency,
+        name = counterparty.name,
+        "", "", BankId(counterparty.otherBankRoutingAddress), new Date(), "",
         accountRoutings = accountRouting1 ++ accountRouting2,
         List.empty, accountHolder = counterparty.name,
         Some(List(Attribute(

--- a/obp-commons/src/main/scala/com/openbankproject/commons/util/ReflectUtils.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/util/ReflectUtils.scala
@@ -667,7 +667,15 @@ object ReflectUtils {
 
     val paramNames = constructor.paramLists(0).map(_.name.toString)
     val mirrorObj = mirror.reflect(t)
-    val methodSymbols = paramNames.map(name => mirrorObj.symbol.info.decl(ru.TermName(name)).asMethod)
+    val info = mirrorObj.symbol.info
+    val methodSymbols = paramNames.map(name => {
+      val nameSymbol = info.decl(ru.TermName(name))
+      if(nameSymbol.isMethod) {
+        nameSymbol.asMethod
+      } else {
+        info.member(ru.TermName("attributes")).asMethod
+      }
+    })
     val methodMirrors: Seq[ru.MethodMirror] = methodSymbols.map(mirrorObj.reflectMethod(_))
     val seq = methodMirrors.map(_())
 


### PR DESCRIPTION
The last PR for SEPA Adapter integration with OBP-API develop branch.

- Add the akka connector method makePaymentV400
- Add conversion for common model in akka connector

[Jenkins tests passed](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/70/)