### PR TITLE
docfix/Change the documentation response of createTransactionRequest and answerTransactionRequestChallenge endpoints

### DIFF
--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -429,7 +429,7 @@ trait APIMethods400 {
          |
        """.stripMargin,
       transactionRequestBodyJsonV200,
-      transactionRequestWithChargeJSON210,
+      transactionRequestWithChargeJSON400,
       List(
         $UserNotLoggedIn,
         InvalidBankIdFormat,
@@ -465,7 +465,7 @@ trait APIMethods400 {
          |
        """.stripMargin,
       transactionRequestBodyJsonV200,
-      transactionRequestWithChargeJSON210,
+      transactionRequestWithChargeJSON400,
       List(
         $UserNotLoggedIn,
         InvalidBankIdFormat,
@@ -503,7 +503,7 @@ trait APIMethods400 {
          |
        """.stripMargin,
       transactionRequestBodyCounterpartyJSON,
-      transactionRequestWithChargeJSON210,
+      transactionRequestWithChargeJSON400,
       List(
         $UserNotLoggedIn,
         InvalidBankIdFormat,
@@ -545,7 +545,7 @@ trait APIMethods400 {
          |
        """.stripMargin,
       transactionRequestBodySEPAJsonV400,
-      transactionRequestWithChargeJSON210,
+      transactionRequestWithChargeJSON400,
       List(
         $UserNotLoggedIn,
         InvalidBankIdFormat,
@@ -589,7 +589,7 @@ trait APIMethods400 {
          |
        """.stripMargin,
       transactionRequestBodyRefundJsonV400,
-      transactionRequestWithChargeJSON210,
+      transactionRequestWithChargeJSON400,
       List(
         $UserNotLoggedIn,
         InvalidBankIdFormat,
@@ -621,7 +621,7 @@ trait APIMethods400 {
          |
        """.stripMargin,
       transactionRequestBodyFreeFormJSON,
-      transactionRequestWithChargeJSON210,
+      transactionRequestWithChargeJSON400,
       List(
         $UserNotLoggedIn,
         InvalidBankIdFormat,
@@ -983,7 +983,7 @@ trait APIMethods400 {
         |
       """.stripMargin,
       challengeAnswerJson400,
-      transactionRequestWithChargeJson,
+      transactionRequestWithChargeJSON210,
       List(
         $UserNotLoggedIn,
         InvalidBankIdFormat,


### PR DESCRIPTION
I've observed an inconsistency between the documentation of the createTransactionRequest and answerTransactionRequestChallenge endpoints and the real reposponse of those endpoints.

### Example for createTransactionRequest 
Part of the response in the documentation :
![image](https://user-images.githubusercontent.com/17991359/98123722-8471e200-1eb2-11eb-92bc-944fcf25bdc3.png)

Part of the real response :
![image](https://user-images.githubusercontent.com/17991359/98123602-5e4c4200-1eb2-11eb-9053-180434e0b1c0.png)

**This PR solve this inconsistency.**