### PR TITLE
Add Transaction Request Attribute

### DIFF
--- a/obp-api/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/obp-api/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -101,6 +101,7 @@ import code.taxresidence.MappedTaxResidence
 import code.token.OpenIDConnectToken
 import code.transaction.MappedTransaction
 import code.transactionChallenge.MappedExpectedChallengeAnswer
+import code.transactionRequestAttribute.MappedTransactionRequestAttribute
 import code.transactionStatusScheduler.TransactionStatusScheduler
 import code.transaction_types.MappedTransactionType
 import code.transactionattribute.MappedTransactionAttribute
@@ -799,6 +800,7 @@ object ToSchemify {
     MappedCounterpartyMetadata,
     MappedCounterpartyWhereTag,
     MappedTransactionRequest,
+    MappedTransactionRequestAttribute,
     MappedMetric,
     MapperAccountHolders,
     MappedEntitlement,

--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -3933,7 +3933,18 @@ object SwaggerDefinitionsJSON {
   )    
   val cardAttributeDefinitionsResponseJsonV400 = AttributeDefinitionsResponseJsonV400(
     attributes = List(cardAttributeDefinitionResponseJsonV400)
-  )    
+  )
+
+  val transactionRequestAttributeDefinitionJsonV400 =
+    templateAttributeDefinitionJsonV400.copy(category = AttributeCategory.TransactionRequest.toString)
+
+  val transactionRequestAttributeDefinitionResponseJsonV400 =
+    templateAttributeDefinitionResponseJsonV400.copy(category = AttributeCategory.TransactionRequest.toString)
+
+  val transactionRequestAttributeDefinitionsResponseJsonV400 = AttributeDefinitionsResponseJsonV400(
+    attributes = List(transactionRequestAttributeDefinitionResponseJsonV400)
+  )
+  
   val accountAttributeDefinitionsResponseJsonV400 = AttributeDefinitionsResponseJsonV400(
     attributes = List(accountAttributeDefinitionResponseJsonV400)
   )    

--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -16,7 +16,7 @@ import code.api.v3_0_0.JSONFactory300.createBranchJsonV300
 import code.api.v3_0_0.custom.JSONFactoryCustom300
 import code.api.v3_0_0.{LobbyJsonV330, _}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, CustomerWithAttributesJsonV310, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
-import code.api.v4_0_0.{APIInfoJson400, AccountBalanceJsonV400, AccountTagJSON, AccountTagsJSON, AccountsBalancesJsonV400, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BalanceJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, ChallengeAnswerJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, ModeratedFirehoseAccountJsonV400, ModeratedFirehoseAccountsJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestRefundFrom, TransactionRequestRefundTo, TransactionRequestWithChargeJSON400, UpdateAccountJsonV400, UserLockStatusJson, When}
+import code.api.v4_0_0.{APIInfoJson400, AccountBalanceJsonV400, AccountTagJSON, AccountTagsJSON, AccountsBalancesJsonV400, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, BalanceJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, ChallengeAnswerJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, ModeratedFirehoseAccountJsonV400, ModeratedFirehoseAccountsJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestAttributeJsonV400, TransactionRequestAttributeResponseJson, TransactionRequestAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestRefundFrom, TransactionRequestRefundTo, TransactionRequestWithChargeJSON400, UpdateAccountJsonV400, UserLockStatusJson, When}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
 import code.branches.Branches.{Branch, DriveUpString, LobbyString}
 import code.consent.ConsentStatus
@@ -3858,6 +3858,23 @@ object SwaggerDefinitionsJSON {
     name = transactionAttributeNameExample.value,
     `type` = transactionAttributeTypeExample.value,
     value = transactionAttributeValueExample.value
+  )
+
+  val transactionRequestAttributeResponseJson = TransactionRequestAttributeResponseJson(
+    transaction_request_attribute_id = transactionRequestAttributeIdExample.value,
+    name = transactionRequestAttributeNameExample.value,
+    `type` = transactionRequestAttributeTypeExample.value,
+    value = transactionRequestAttributeValueExample.value
+  )
+  
+  val transactionRequestAttributeJsonV400 = TransactionRequestAttributeJsonV400(
+    name = transactionRequestAttributeNameExample.value,
+    `type` = transactionRequestAttributeTypeExample.value,
+    value = transactionRequestAttributeValueExample.value
+  )
+
+  val transactionRequestAttributesResponseJson = TransactionRequestAttributesResponseJson(
+    transaction_request_attributes = List(transactionRequestAttributeResponseJson)
   )
   
   val templateAttributeDefinitionJsonV400 = AttributeDefinitionJsonV400(

--- a/obp-api/src/main/scala/code/api/util/ApiRole.scala
+++ b/obp-api/src/main/scala/code/api/util/ApiRole.scala
@@ -585,6 +585,15 @@ object ApiRole {
   case class CanGetTransactionAttributeDefinitionAtOneBank(requiresBankId: Boolean = true) extends ApiRole
   lazy val canGetTransactionAttributeDefinitionAtOneBank = CanGetTransactionAttributeDefinitionAtOneBank() 
   
+  case class CanCreateTransactionRequestAttributeDefinitionAtOneBank(requiresBankId: Boolean = true) extends ApiRole
+  lazy val canCreateTransactionRequestAttributeDefinitionAtOneBank = CanCreateTransactionRequestAttributeDefinitionAtOneBank()
+
+  case class CanDeleteTransactionRequestAttributeDefinitionAtOneBank(requiresBankId: Boolean = true) extends ApiRole
+  lazy val canDeleteTransactionRequestAttributeDefinitionAtOneBank = CanDeleteTransactionRequestAttributeDefinitionAtOneBank()
+
+  case class CanGetTransactionRequestAttributeDefinitionAtOneBank(requiresBankId: Boolean = true) extends ApiRole
+  lazy val canGetTransactionRequestAttributeDefinitionAtOneBank = CanGetTransactionRequestAttributeDefinitionAtOneBank()
+
   case class CanGetCardAttributeDefinitionAtOneBank(requiresBankId: Boolean = true) extends ApiRole
   lazy val canGetCardAttributeDefinitionAtOneBank = CanGetCardAttributeDefinitionAtOneBank()
 

--- a/obp-api/src/main/scala/code/api/util/ApiRole.scala
+++ b/obp-api/src/main/scala/code/api/util/ApiRole.scala
@@ -528,6 +528,21 @@ object ApiRole {
   case class CanGetTransactionAttributeAtOneBank(requiresBankId: Boolean = true) extends ApiRole
   lazy val canGetTransactionAttributeAtOneBank = CanGetTransactionAttributeAtOneBank()
 
+  case class CanCreateTransactionRequestAttributeAtOneBank(requiresBankId: Boolean = true) extends ApiRole
+  lazy val canCreateTransactionRequestAttributeAtOneBank = CanCreateTransactionRequestAttributeAtOneBank()
+
+  case class CanUpdateTransactionRequestAttributeAtOneBank(requiresBankId: Boolean = true) extends ApiRole
+  lazy val canUpdateTransactionRequestAttributeAtOneBank = CanUpdateTransactionRequestAttributeAtOneBank()
+
+  case class CanDeleteTransactionRequestAttributeAtOneBank(requiresBankId: Boolean = true) extends ApiRole
+  lazy val canDeleteTransactionRequestAttributeAtOneBank = CanDeleteTransactionRequestAttributeAtOneBank()
+
+  case class CanGetTransactionRequestAttributesAtOneBank(requiresBankId: Boolean = true) extends ApiRole
+  lazy val canGetTransactionRequestAttributesAtOneBank = CanGetTransactionRequestAttributesAtOneBank()
+
+  case class CanGetTransactionRequestAttributeAtOneBank(requiresBankId: Boolean = true) extends ApiRole
+  lazy val canGetTransactionRequestAttributeAtOneBank = CanGetTransactionRequestAttributeAtOneBank()
+
   case class CanReadResourceDoc(requiresBankId: Boolean = false) extends ApiRole
   lazy val canReadResourceDoc = CanReadResourceDoc()
   

--- a/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
+++ b/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
@@ -300,7 +300,9 @@ object ErrorMessages {
   val BankAccountNotFoundByIban = "OBP-30074: Bank Account not found. Please specify a valid value for iban."
   val AccountRoutingNotFound = "OBP-30075: Account routing not found, Please specify valid values for account routing scheme and address"
   val BankAccountNotFoundByAccountId = "OBP-30076: Bank Account not found. Please specify a valid value for ACCOUNT_ID."
-  
+
+  val TransactionRequestAttributeNotFound = "OBP-30078: Transaction Request Attribute not found. Please specify a valid value for TRANSACTION_REQUEST_ATTRIBUTE_ID."
+
   // Meetings
   val MeetingsNotSupported = "OBP-30101: Meetings are not supported on this server."
   val MeetingApiKeyNotConfigured = "OBP-30102: Meeting provider API Key is not configured."

--- a/obp-api/src/main/scala/code/api/util/ExampleValue.scala
+++ b/obp-api/src/main/scala/code/api/util/ExampleValue.scala
@@ -164,6 +164,18 @@ object ExampleValue {
   lazy val transactionAttributeValueExample = ConnectorField("123456789", s"Transaction attribute value.")
   glossaryItems += makeGlossaryItem("Transaction.attributeValue", transactionAttributeValueExample)
 
+  lazy val transactionRequestAttributeIdExample = ConnectorField("7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh", s"Transaction Request attribute id")
+  glossaryItems += makeGlossaryItem("Transaction Requests.attributeId", transactionRequestAttributeIdExample)
+
+  lazy val transactionRequestAttributeNameExample = ConnectorField("HOUSE_RENT", s"Transaction Request attribute name")
+  glossaryItems += makeGlossaryItem("Transaction Requests.attributeName", transactionRequestAttributeNameExample)
+
+  lazy val transactionRequestAttributeTypeExample = ConnectorField("DATE_WITH_DAY", s"Transaction Request attribute type.")
+  glossaryItems += makeGlossaryItem("Transaction Requests.attributeType", transactionRequestAttributeTypeExample)
+
+  lazy val transactionRequestAttributeValueExample = ConnectorField("123456789", s"Transaction Request attribute value.")
+  glossaryItems += makeGlossaryItem("Transaction Requests.attributeValue", transactionRequestAttributeValueExample)
+
   lazy val transactionDescriptionExample = ConnectorField("For the piano lesson in June 2018 - Invoice No: 68", s"A description or reference for the transaction")
   glossaryItems += makeGlossaryItem("Transaction.transactionDescription", transactionDescriptionExample)
 

--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -1987,6 +1987,108 @@ object NewStyle {
         i => (connectorEmptyResponse(i._1, callContext), i._2)
       }
     }
+
+    def getTransactionRequestAttributesFromProvider(transactionRequestId: TransactionRequestId,
+                                                    callContext: Option[CallContext]): OBPReturnType[List[TransactionRequestAttribute]] = {
+      Connector.connector.vend.getTransactionRequestAttributesFromProvider(
+        transactionRequestId: TransactionRequestId,
+        callContext: Option[CallContext]
+      ) map {
+        i => (connectorEmptyResponse(i._1, callContext), i._2)
+      }
+    }
+
+    def getTransactionRequestAttributes(bankId: BankId,
+                                        transactionRequestId: TransactionRequestId,
+                                        callContext: Option[CallContext]): OBPReturnType[List[TransactionRequestAttribute]] = {
+      Connector.connector.vend.getTransactionRequestAttributes(
+        bankId: BankId,
+        transactionRequestId: TransactionRequestId,
+        callContext: Option[CallContext]
+      ) map {
+        i => (connectorEmptyResponse(i._1, callContext), i._2)
+      }
+    }
+
+    def getTransactionRequestAttributesCanBeSeenOnView(bankId: BankId,
+                                                       transactionRequestId: TransactionRequestId,
+                                                       viewId: ViewId,
+                                                       callContext: Option[CallContext]): OBPReturnType[List[TransactionRequestAttribute]] = {
+      Connector.connector.vend.getTransactionRequestAttributesCanBeSeenOnView(
+        bankId: BankId,
+        transactionRequestId: TransactionRequestId,
+        viewId: ViewId,
+        callContext: Option[CallContext]
+      ) map {
+        i => (connectorEmptyResponse(i._1, callContext), i._2)
+      }
+    }
+
+    def getTransactionRequestAttributeById(transactionRequestAttributeId: String,
+                                           callContext: Option[CallContext]): OBPReturnType[TransactionRequestAttribute] = {
+      Connector.connector.vend.getTransactionRequestAttributeById(
+        transactionRequestAttributeId: String,
+        callContext: Option[CallContext]
+      ) map {
+        x => (unboxFullOrFail(x._1, callContext, TransactionRequestAttributeNotFound, 400), x._2)
+      }
+    }
+
+    def getTransactionRequestIdsByAttributeNameValues(bankId: BankId, params: Map[String, List[String]],
+                                                      callContext: Option[CallContext]): OBPReturnType[List[String]] = {
+      Connector.connector.vend.getTransactionRequestIdsByAttributeNameValues(
+        bankId: BankId,
+        params: Map[String, List[String]],
+        callContext: Option[CallContext]
+      ) map {
+        i => (connectorEmptyResponse(i._1, callContext), i._2)
+      }
+    }
+
+    def createOrUpdateTransactionRequestAttribute(bankId: BankId,
+                                                  transactionRequestId: TransactionRequestId,
+                                                  transactionRequestAttributeId: Option[String],
+                                                  name: String,
+                                                  attributeType: TransactionRequestAttributeType.Value,
+                                                  value: String,
+                                                  callContext: Option[CallContext]): OBPReturnType[TransactionRequestAttribute] = {
+      Connector.connector.vend.createOrUpdateTransactionRequestAttribute(
+        bankId: BankId,
+        transactionRequestId: TransactionRequestId,
+        transactionRequestAttributeId: Option[String],
+        name: String,
+        attributeType: TransactionRequestAttributeType.Value,
+        value: String,
+        callContext: Option[CallContext]
+      ) map {
+        i => (connectorEmptyResponse(i._1, callContext), i._2)
+      }
+    }
+
+    def createTransactionRequestAttributes(bankId: BankId,
+                                           transactionRequestId: TransactionRequestId,
+                                           transactionRequestAttributes: List[TransactionRequestAttribute],
+                                           callContext: Option[CallContext]): OBPReturnType[List[TransactionRequestAttribute]] = {
+      Connector.connector.vend.createTransactionRequestAttributes(
+        bankId: BankId,
+        transactionRequestId: TransactionRequestId,
+        transactionRequestAttributes: List[TransactionRequestAttribute],
+        callContext: Option[CallContext]
+      ) map {
+        i => (connectorEmptyResponse(i._1, callContext), i._2)
+      }
+    }
+
+    def deleteTransactionRequestAttribute(transactionRequestAttributeId: String,
+                                          callContext: Option[CallContext]): OBPReturnType[Boolean] = {
+      Connector.connector.vend.deleteTransactionRequestAttribute(
+        transactionRequestAttributeId: String,
+        callContext: Option[CallContext]
+      ) map {
+        i => (connectorEmptyResponse(i._1, callContext), i._2)
+      }
+    }
+
     def createOrUpdateMethodRouting(methodRouting: MethodRoutingT) = Future {
       MethodRoutingProvider.connectorMethodProvider.vend.createOrUpdate(methodRouting)
      }

--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -1136,6 +1136,203 @@ trait APIMethods400 {
       }
     }
 
+
+    staticResourceDocs += ResourceDoc(
+      createTransactionRequestAttribute,
+      implementedInApiVersion,
+      nameOf(createTransactionRequestAttribute),
+      "POST",
+      "/banks/BANK_ID/accounts/ACCOUNT_ID/transaction-requests/TRANSACTION_REQUEST_ID/attribute",
+      "Create Transaction Request Attribute",
+      s""" Create Transaction Request Attribute
+         |
+         |The type field must be one of "STRING", "INTEGER", "DOUBLE" or DATE_WITH_DAY"
+         |
+         |${authenticationRequiredMessage(true)}
+         |
+         |""",
+      transactionRequestAttributeJsonV400,
+      transactionRequestAttributeResponseJson,
+      List(
+        $UserNotLoggedIn,
+        $BankNotFound,
+        $BankAccountNotFound,
+        InvalidJsonFormat,
+        UnknownError
+      ),
+      List(apiTagTransactionRequest, apiTagNewStyle),
+      Some(List(canCreateTransactionRequestAttributeAtOneBank))
+    )
+
+    lazy val createTransactionRequestAttribute : OBPEndpoint = {
+      case "banks" ::  BankId(bankId) :: "accounts" :: AccountId(accountId) :: "transaction-requests" :: TransactionRequestId(transactionRequestId) :: "attribute" :: Nil JsonPost json -> _=> {
+        cc =>
+          val failMsg = s"$InvalidJsonFormat The Json body should be the $transactionRequestAttributeJsonV400 "
+          for {
+            (_, callContext) <- NewStyle.function.getTransactionRequestImpl(transactionRequestId, cc.callContext)
+            postedData <- NewStyle.function.tryons(failMsg, 400,  cc.callContext) {
+              json.extract[TransactionRequestAttributeJsonV400]
+            }
+            failMsg = s"$InvalidJsonFormat The `Type` field can only accept the following field: " +
+              s"${TransactionRequestAttributeType.DOUBLE}(12.1234), ${TransactionRequestAttributeType.STRING}(TAX_NUMBER), ${TransactionRequestAttributeType.INTEGER}(123) and ${TransactionRequestAttributeType.DATE_WITH_DAY}(2012-04-23)"
+            transactionRequestAttributeType <- NewStyle.function.tryons(failMsg, 400,  cc.callContext) {
+              TransactionRequestAttributeType.withName(postedData.`type`)
+            }
+            (transactionRequestAttribute, callContext) <- NewStyle.function.createOrUpdateTransactionRequestAttribute(
+              bankId,
+              transactionRequestId,
+              None,
+              postedData.name,
+              transactionRequestAttributeType,
+              postedData.value,
+              cc.callContext
+            )
+          } yield {
+            (JSONFactory400.createTransactionRequestAttributeJson(transactionRequestAttribute), HttpCode.`201`(callContext))
+          }
+      }
+    }
+
+
+    staticResourceDocs += ResourceDoc(
+      getTransactionRequestAttributeById,
+      implementedInApiVersion,
+      nameOf(getTransactionRequestAttributeById),
+      "GET",
+      "/banks/BANK_ID/accounts/ACCOUNT_ID/transaction-requests/TRANSACTION_REQUEST_ID/attributes/ATTRIBUTE_ID",
+      "Get Transaction Request Attribute By Id",
+      s""" Get Transaction Request Attribute By Id
+         |
+         |${authenticationRequiredMessage(true)}
+         |
+         |""",
+      emptyObjectJson,
+      transactionRequestAttributeResponseJson,
+      List(
+        $UserNotLoggedIn,
+        $BankNotFound,
+        $BankAccountNotFound,
+        InvalidJsonFormat,
+        UnknownError
+      ),
+      List(apiTagTransactionRequest, apiTagNewStyle),
+      Some(List(canGetTransactionRequestAttributeAtOneBank))
+    )
+
+    lazy val getTransactionRequestAttributeById : OBPEndpoint = {
+      case "banks" :: BankId(bankId) :: "accounts" :: AccountId(accountId) ::  "transaction-requests" :: TransactionRequestId(transactionRequestId) :: "attributes" :: transactionRequestAttributeId :: Nil JsonGet _ => {
+        cc =>
+          for {
+            (_, callContext) <- NewStyle.function.getTransactionRequestImpl(transactionRequestId, cc.callContext)
+            (transactionRequestAttribute, callContext) <- NewStyle.function.getTransactionRequestAttributeById(
+              transactionRequestAttributeId,
+              callContext
+            )
+          } yield {
+            (JSONFactory400.createTransactionRequestAttributeJson(transactionRequestAttribute), HttpCode.`200`(callContext))
+          }
+      }
+    }
+
+
+    staticResourceDocs += ResourceDoc(
+      getTransactionRequestAttributes,
+      implementedInApiVersion,
+      nameOf(getTransactionRequestAttributes),
+      "GET",
+      "/banks/BANK_ID/accounts/ACCOUNT_ID/transaction-requests/TRANSACTION_REQUEST_ID/attributes",
+      "Get Transaction Request Attributes",
+      s""" Get Transaction Request Attributes
+         |
+         |${authenticationRequiredMessage(true)}
+         |
+         |""",
+      emptyObjectJson,
+      transactionRequestAttributesResponseJson,
+      List(
+        $UserNotLoggedIn,
+        $BankNotFound,
+        $BankAccountNotFound,
+        InvalidJsonFormat,
+        UnknownError
+      ),
+      List(apiTagTransactionRequest, apiTagNewStyle),
+      Some(List(canGetTransactionRequestAttributesAtOneBank))
+    )
+
+    lazy val getTransactionRequestAttributes : OBPEndpoint = {
+      case "banks" :: BankId(bankId) :: "accounts" :: AccountId(accountId) :: "transaction-requests" :: TransactionRequestId(transactionRequestId) :: "attributes" :: Nil JsonGet _ => {
+        cc =>
+          for {
+            (_, callContext) <- NewStyle.function.getTransactionRequestImpl(transactionRequestId, cc.callContext)
+            (transactionRequestAttribute, callContext) <- NewStyle.function.getTransactionRequestAttributes(
+              bankId,
+              transactionRequestId,
+              cc.callContext
+            )
+          } yield {
+            (JSONFactory400.createTransactionRequestAttributesJson(transactionRequestAttribute), HttpCode.`200`(callContext))
+          }
+      }
+    }
+
+
+    staticResourceDocs += ResourceDoc(
+      updateTransactionRequestAttribute,
+      implementedInApiVersion,
+      nameOf(updateTransactionRequestAttribute),
+      "PUT",
+      "/banks/BANK_ID/accounts/ACCOUNT_ID/transaction-requests/TRANSACTION_REQUEST_ID/attributes/ATTRIBUTE_ID",
+      "Update Transaction Request Attribute",
+      s""" Update Transaction Request Attribute
+         |
+         |${authenticationRequiredMessage(true)}
+         |
+         |""",
+      transactionRequestAttributeJsonV400,
+      transactionRequestAttributeResponseJson,
+      List(
+        $UserNotLoggedIn,
+        $BankNotFound,
+        $BankAccountNotFound,
+        InvalidJsonFormat,
+        UnknownError
+      ),
+      List(apiTagTransactionRequest, apiTagNewStyle),
+      Some(List(canUpdateTransactionRequestAttributeAtOneBank))
+    )
+
+    lazy val updateTransactionRequestAttribute : OBPEndpoint = {
+      case "banks" ::  BankId(bankId) :: "accounts" :: AccountId(accountId) :: "transaction-requests" :: TransactionRequestId(transactionRequestId) :: "attributes" :: transactionRequestAttributeId :: Nil JsonPut json -> _=> {
+        cc =>
+          val failMsg = s"$InvalidJsonFormat The Json body should be the $TransactionRequestAttributeJsonV400"
+          for {
+            (_, callContext) <- NewStyle.function.getTransactionRequestImpl(transactionRequestId, cc.callContext)
+            postedData <- NewStyle.function.tryons(failMsg, 400,  cc.callContext) {
+              json.extract[TransactionRequestAttributeJsonV400]
+            }
+            failMsg = s"$InvalidJsonFormat The `Type` field can only accept the following field: " +
+              s"${TransactionRequestAttributeType.DOUBLE}(12.1234), ${TransactionRequestAttributeType.STRING}(TAX_NUMBER), ${TransactionRequestAttributeType.INTEGER}(123) and ${TransactionRequestAttributeType.DATE_WITH_DAY}(2012-04-23)"
+            transactionRequestAttributeType <- NewStyle.function.tryons(failMsg, 400,  cc.callContext) {
+              TransactionRequestAttributeType.withName(postedData.`type`)
+            }
+            (_, callContext) <- NewStyle.function.getTransactionRequestAttributeById(transactionRequestAttributeId, cc.callContext)
+            (transactionRequestAttribute, callContext) <- NewStyle.function.createOrUpdateTransactionRequestAttribute(
+              bankId,
+              transactionRequestId,
+              Some(transactionRequestAttributeId),
+              postedData.name,
+              transactionRequestAttributeType,
+              postedData.value,
+              callContext
+            )
+          } yield {
+            (JSONFactory400.createTransactionRequestAttributeJson(transactionRequestAttribute), HttpCode.`200`(callContext))
+          }
+      }
+    }
+
+
     staticResourceDocs += ResourceDoc(
       getDynamicEntities,
       implementedInApiVersion,

--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -1334,6 +1334,144 @@ trait APIMethods400 {
 
 
     staticResourceDocs += ResourceDoc(
+      createOrUpdateTransactionRequestAttributeDefinition,
+      implementedInApiVersion,
+      nameOf(createOrUpdateTransactionRequestAttributeDefinition),
+      "PUT",
+      "/banks/BANK_ID/attribute-definitions/transaction-request",
+      "Create or Update Transaction Request Attribute Definition",
+      s""" Create or Update Transaction Request Attribute Definition
+         |
+         |The category field must be ${AttributeCategory.TransactionRequest}
+         |
+         |The type field must be one of: ${AttributeType.DOUBLE}, ${AttributeType.STRING}, ${AttributeType.INTEGER} and ${AttributeType.DATE_WITH_DAY}
+         |
+         |${authenticationRequiredMessage(true)}
+         |
+         |""",
+      transactionRequestAttributeDefinitionJsonV400,
+      transactionRequestAttributeDefinitionResponseJsonV400,
+      List(
+        $UserNotLoggedIn,
+        $BankNotFound,
+        InvalidJsonFormat,
+        UnknownError
+      ),
+      List(apiTagTransactionRequest, apiTagNewStyle),
+      Some(List(canCreateTransactionRequestAttributeDefinitionAtOneBank)))
+
+    lazy val createOrUpdateTransactionRequestAttributeDefinition : OBPEndpoint = {
+      case "banks" :: BankId(bankId) :: "attribute-definitions" :: "transaction-request" :: Nil JsonPut json -> _=> {
+        cc =>
+          val failMsg = s"$InvalidJsonFormat The Json body should be the $AttributeDefinitionJsonV400 "
+          for {
+            postedData <- NewStyle.function.tryons(failMsg, 400,  cc.callContext) {
+              json.extract[AttributeDefinitionJsonV400]
+            }
+            failMsg = s"$InvalidJsonFormat The `Type` field can only accept the following field: " +
+              s"${AttributeType.DOUBLE}(12.1234), ${AttributeType.STRING}(TAX_NUMBER), ${AttributeType.INTEGER}(123) and ${AttributeType.DATE_WITH_DAY}(2012-04-23)"
+            attributeType <- NewStyle.function.tryons(failMsg, 400,  cc.callContext) {
+              AttributeType.withName(postedData.`type`)
+            }
+            failMsg = s"$InvalidJsonFormat The `Category` field can only accept the following field: " +
+              s"${AttributeCategory.TransactionRequest}"
+            category <- NewStyle.function.tryons(failMsg, 400,  cc.callContext) {
+              AttributeCategory.withName(postedData.category)
+            }
+            (attributeDefinition, callContext) <- createOrUpdateAttributeDefinition(
+              bankId,
+              postedData.name,
+              category,
+              attributeType,
+              postedData.description,
+              postedData.alias,
+              postedData.can_be_seen_on_views,
+              postedData.is_active,
+              cc.callContext
+            )
+          } yield {
+            (JSONFactory400.createAttributeDefinitionJson(attributeDefinition), HttpCode.`201`(callContext))
+          }
+      }
+    }
+
+
+    staticResourceDocs += ResourceDoc(
+      getTransactionRequestAttributeDefinition,
+      implementedInApiVersion,
+      nameOf(getTransactionRequestAttributeDefinition),
+      "GET",
+      "/banks/BANK_ID/attribute-definitions/transaction-request",
+      "Get Transaction Request Attribute Definition",
+      s""" Get Transaction Request Attribute Definition
+         |
+         |${authenticationRequiredMessage(true)}
+         |
+         |""",
+      emptyObjectJson,
+      transactionRequestAttributeDefinitionsResponseJsonV400,
+      List(
+        $UserNotLoggedIn,
+        $BankNotFound,
+        UnknownError
+      ),
+      List(apiTagTransactionRequest, apiTagNewStyle),
+      Some(List(canGetTransactionRequestAttributeDefinitionAtOneBank)))
+
+    lazy val getTransactionRequestAttributeDefinition : OBPEndpoint = {
+      case "banks" :: BankId(bankId) :: "attribute-definitions" :: "transaction-request" :: Nil JsonGet _ => {
+        cc =>
+          for {
+            (attributeDefinitions, callContext) <- getAttributeDefinition(
+              AttributeCategory.withName(AttributeCategory.TransactionRequest.toString),
+              cc.callContext
+            )
+          } yield {
+            (JSONFactory400.createAttributeDefinitionsJson(attributeDefinitions), HttpCode.`200`(callContext))
+          }
+      }
+    }
+
+
+    staticResourceDocs += ResourceDoc(
+      deleteTransactionRequestAttributeDefinition,
+      implementedInApiVersion,
+      nameOf(deleteTransactionRequestAttributeDefinition),
+      "DELETE",
+      "/banks/BANK_ID/attribute-definitions/ATTRIBUTE_DEFINITION_ID/transaction-request",
+      "Delete Transaction Request Attribute Definition",
+      s""" Delete Transaction Request Attribute Definition by ATTRIBUTE_DEFINITION_ID
+         |
+         |${authenticationRequiredMessage(true)}
+         |
+         |""",
+      emptyObjectJson,
+      Full(true),
+      List(
+        $UserNotLoggedIn,
+        $BankNotFound,
+        UnknownError
+      ),
+      List(apiTagTransactionRequest, apiTagNewStyle),
+      Some(List(canDeleteTransactionRequestAttributeDefinitionAtOneBank)))
+
+    lazy val deleteTransactionRequestAttributeDefinition : OBPEndpoint = {
+      case "banks" :: BankId(bankId) :: "attribute-definitions" :: attributeDefinitionId :: "transaction-request" :: Nil JsonDelete _ => {
+        cc =>
+          for {
+            (deleted, callContext) <- deleteAttributeDefinition(
+              attributeDefinitionId,
+              AttributeCategory.withName(AttributeCategory.TransactionRequest.toString),
+              cc.callContext
+            )
+          } yield {
+            (Full(deleted), HttpCode.`200`(callContext))
+          }
+      }
+    }
+    
+    
+    staticResourceDocs += ResourceDoc(
       getDynamicEntities,
       implementedInApiVersion,
       nameOf(getDynamicEntities),

--- a/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
@@ -315,6 +315,23 @@ case class TransactionAttributesResponseJson(
   transaction_attributes: List[TransactionAttributeResponseJson]
 )
 
+case class TransactionRequestAttributeJsonV400(
+  name: String,
+  `type`: String,
+  value: String,
+)
+
+case class TransactionRequestAttributeResponseJson(
+  transaction_request_attribute_id: String,
+  name: String,
+  `type`: String,
+  value: String
+)
+
+case class TransactionRequestAttributesResponseJson(
+  transaction_request_attributes: List[TransactionRequestAttributeResponseJson]
+)
+
 case class ConsumerJson(consumer_id: String,
                         key: String,
                         secret: String,
@@ -739,6 +756,24 @@ object JSONFactory400 {
       name = transactionAttribute.name,
       `type` = transactionAttribute.attributeType.toString,
       value = transactionAttribute.value
+    )))
+  }
+
+  def createTransactionRequestAttributeJson(transactionRequestAttribute: TransactionRequestAttribute) : TransactionRequestAttributeResponseJson = {
+    TransactionRequestAttributeResponseJson(
+      transaction_request_attribute_id = transactionRequestAttribute.transactionRequestAttributeId,
+      name = transactionRequestAttribute.name,
+      `type` = transactionRequestAttribute.attributeType.toString,
+      value = transactionRequestAttribute.value
+    )
+  }
+
+  def createTransactionRequestAttributesJson(transactionRequestAttributes: List[TransactionRequestAttribute]) : TransactionRequestAttributesResponseJson = {
+    TransactionRequestAttributesResponseJson (transactionRequestAttributes.map( transactionRequestAttribute => TransactionRequestAttributeResponseJson(
+      transaction_request_attribute_id = transactionRequestAttribute.transactionRequestAttributeId,
+      name = transactionRequestAttribute.name,
+      `type` = transactionRequestAttribute.attributeType.toString,
+      value = transactionRequestAttribute.value
     )))
   }
 

--- a/obp-api/src/main/scala/code/bankconnectors/Connector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/Connector.scala
@@ -39,7 +39,7 @@ import code.users.Users
 import code.util.Helper._
 import com.openbankproject.commons.util.JsonUtils
 import code.views.Views
-import com.openbankproject.commons.model.enums.{AccountAttributeType, AttributeCategory, AttributeType, CardAttributeType, ChallengeType, CustomerAttributeType, DynamicEntityOperation, ProductAttributeType, TransactionAttributeType, TransactionRequestStatus}
+import com.openbankproject.commons.model.enums.{AccountAttributeType, AttributeCategory, AttributeType, CardAttributeType, ChallengeType, CustomerAttributeType, DynamicEntityOperation, ProductAttributeType, TransactionAttributeType, TransactionRequestAttributeType, TransactionRequestStatus}
 import com.openbankproject.commons.model.{AccountApplication, Bank, CounterpartyTrait, CustomerAddress, Product, ProductCollection, ProductCollectionItem, TaxResidence, TransactionRequestStatus, UserAuthContext, UserAuthContextUpdate, _}
 import com.tesobe.CacheKeyFromArguments
 import net.liftweb.common.{Box, Empty, EmptyBox, Failure, Full, ParamFailure}
@@ -2090,6 +2090,40 @@ trait Connector extends MdcLoggable {
   def getCardAttributeById(cardAttributeId: String, callContext:Option[CallContext]): OBPReturnType[Box[CardAttribute]] = Future{(Failure(setUnimplementedError), callContext)}
   
   def getCardAttributesFromProvider(cardId: String, callContext: Option[CallContext]): OBPReturnType[Box[List[CardAttribute]]] = Future{(Failure(setUnimplementedError), callContext)}
+
+  def getTransactionRequestAttributesFromProvider(transactionRequestId: TransactionRequestId,
+                                                  callContext: Option[CallContext]): OBPReturnType[Box[List[TransactionRequestAttribute]]] = Future{(Failure(setUnimplementedError), callContext)}
+
+  def getTransactionRequestAttributes(bankId: BankId,
+                                      transactionRequestId: TransactionRequestId,
+                                      callContext: Option[CallContext]): OBPReturnType[Box[List[TransactionRequestAttribute]]] = Future{(Failure(setUnimplementedError), callContext)}
+
+  def getTransactionRequestAttributesCanBeSeenOnView(bankId: BankId,
+                                                     transactionRequestId: TransactionRequestId,
+                                                     viewId: ViewId,
+                                                     callContext: Option[CallContext]): OBPReturnType[Box[List[TransactionRequestAttribute]]] = Future{(Failure(setUnimplementedError), callContext)}
+
+  def getTransactionRequestAttributeById(transactionRequestAttributeId: String,
+                                         callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestAttribute]] = Future{(Failure(setUnimplementedError), callContext)}
+
+  def getTransactionRequestIdsByAttributeNameValues(bankId: BankId, params: Map[String, List[String]],
+                                                    callContext: Option[CallContext]): OBPReturnType[Box[List[String]]] = Future{(Failure(setUnimplementedError), callContext)}
+
+  def createOrUpdateTransactionRequestAttribute(bankId: BankId,
+                                                transactionRequestId: TransactionRequestId,
+                                                transactionRequestAttributeId: Option[String],
+                                                name: String,
+                                                attributeType: TransactionRequestAttributeType.Value,
+                                                value: String,
+                                                callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestAttribute]] = Future{(Failure(setUnimplementedError), callContext)}
+
+  def createTransactionRequestAttributes(bankId: BankId,
+                                         transactionRequestId: TransactionRequestId,
+                                         transactionRequestAttributes: List[TransactionRequestAttribute],
+                                         callContext: Option[CallContext]): OBPReturnType[Box[List[TransactionRequestAttribute]]] = Future{(Failure(setUnimplementedError), callContext)}
+
+  def deleteTransactionRequestAttribute(transactionRequestAttributeId: String,
+                                        callContext: Option[CallContext]): OBPReturnType[Box[Boolean]] = Future{(Failure(setUnimplementedError), callContext)}
 
   def createAccountApplication(
                                 productCode: ProductCode,

--- a/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -57,6 +57,7 @@ import code.standingorders.{StandingOrderTrait, StandingOrders}
 import code.taxresidence.TaxResidenceX
 import code.transaction.MappedTransaction
 import code.transactionChallenge.{Challenges, MappedExpectedChallengeAnswer}
+import code.transactionRequestAttribute.TransactionRequestAttributeX
 import code.transactionattribute.TransactionAttributeX
 import code.transactionrequests.TransactionRequests.TransactionRequestTypes._
 import code.transactionrequests.TransactionRequests.{TransactionChallengeTypes, TransactionRequestTypes}
@@ -1092,6 +1093,83 @@ object LocalMappedConnector extends Connector with MdcLoggable {
     CardAttributeX.cardAttributeProvider.vend.getCardAttributesFromProvider(cardId: String) map {
       (_, callContext)
     }
+  }
+
+  override def getTransactionRequestAttributesFromProvider(transactionRequestId: TransactionRequestId,
+                                                           callContext: Option[CallContext]): OBPReturnType[Box[List[TransactionRequestAttribute]]] = {
+    TransactionRequestAttributeX.transactionRequestAttributeProvider.vend.getTransactionRequestAttributesFromProvider(
+      transactionRequestId: TransactionRequestId
+    ).map((_, callContext))
+  }
+
+  override def getTransactionRequestAttributes(bankId: BankId,
+                                               transactionRequestId: TransactionRequestId,
+                                               callContext: Option[CallContext]): OBPReturnType[Box[List[TransactionRequestAttribute]]] = {
+    TransactionRequestAttributeX.transactionRequestAttributeProvider.vend.getTransactionRequestAttributes(
+      bankId: BankId,
+      transactionRequestId: TransactionRequestId
+    ).map((_, callContext))
+  }
+
+  override def getTransactionRequestAttributesCanBeSeenOnView(bankId: BankId,
+                                                              transactionRequestId: TransactionRequestId,
+                                                              viewId: ViewId,
+                                                              callContext: Option[CallContext]): OBPReturnType[Box[List[TransactionRequestAttribute]]] = {
+    TransactionRequestAttributeX.transactionRequestAttributeProvider.vend.getTransactionRequestAttributesCanBeSeenOnView(
+      bankId: BankId,
+      transactionRequestId: TransactionRequestId,
+      viewId: ViewId
+    ).map((_, callContext))
+  }
+
+  override def getTransactionRequestAttributeById(transactionRequestAttributeId: String,
+                                                  callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestAttribute]] = {
+    TransactionRequestAttributeX.transactionRequestAttributeProvider.vend.getTransactionRequestAttributeById(
+      transactionRequestAttributeId: String
+    ).map((_, callContext))
+  }
+
+  override def getTransactionRequestIdsByAttributeNameValues(bankId: BankId, params: Map[String, List[String]],
+                                                             callContext: Option[CallContext]): OBPReturnType[Box[List[String]]] = {
+    TransactionRequestAttributeX.transactionRequestAttributeProvider.vend.getTransactionRequestIdsByAttributeNameValues(
+      bankId: BankId,
+      params: Map[String, List[String]]
+    ).map((_, callContext))
+  }
+
+  override def createOrUpdateTransactionRequestAttribute(bankId: BankId,
+                                                         transactionRequestId: TransactionRequestId,
+                                                         transactionRequestAttributeId: Option[String],
+                                                         name: String,
+                                                         attributeType: TransactionRequestAttributeType.Value,
+                                                         value: String,
+                                                         callContext: Option[CallContext]): OBPReturnType[Box[TransactionRequestAttribute]] = {
+    TransactionRequestAttributeX.transactionRequestAttributeProvider.vend.createOrUpdateTransactionRequestAttribute(
+      bankId: BankId,
+      transactionRequestId: TransactionRequestId,
+      transactionRequestAttributeId: Option[String],
+      name: String,
+      attributeType: TransactionRequestAttributeType.Value,
+      value: String
+    ).map((_, callContext))
+  }
+
+  override def createTransactionRequestAttributes(bankId: BankId,
+                                                  transactionRequestId: TransactionRequestId,
+                                                  transactionRequestAttributes: List[TransactionRequestAttribute],
+                                                  callContext: Option[CallContext]): OBPReturnType[Box[List[TransactionRequestAttribute]]] = {
+    TransactionRequestAttributeX.transactionRequestAttributeProvider.vend.createTransactionRequestAttributes(
+      bankId: BankId,
+      transactionRequestId: TransactionRequestId,
+      transactionRequestAttributes: List[TransactionRequestAttribute]
+    ).map((_, callContext))
+  }
+
+  override def deleteTransactionRequestAttribute(transactionRequestAttributeId: String,
+                                                 callContext: Option[CallContext]): OBPReturnType[Box[Boolean]] = {
+    TransactionRequestAttributeX.transactionRequestAttributeProvider.vend.deleteTransactionRequestAttribute(
+      transactionRequestAttributeId: String
+    ).map((_, callContext))
   }
 
   /**

--- a/obp-api/src/main/scala/code/remotedata/RemotedataTransactionRequestAttribute.scala
+++ b/obp-api/src/main/scala/code/remotedata/RemotedataTransactionRequestAttribute.scala
@@ -1,0 +1,51 @@
+package code.remotedata
+
+import akka.pattern.ask
+import code.actorsystem.ObpActorInit
+import code.transactionRequestAttribute.{RemotedataTransactionRequestAttributeCaseClasses, TransactionRequestAttributeProvider}
+import com.openbankproject.commons.model._
+import com.openbankproject.commons.model.enums.TransactionRequestAttributeType
+import net.liftweb.common.Box
+
+import scala.collection.immutable.List
+import scala.concurrent.Future
+
+
+object RemotedataTransactionRequestAttribute extends ObpActorInit with TransactionRequestAttributeProvider {
+
+  val cc: RemotedataTransactionRequestAttributeCaseClasses.type = RemotedataTransactionRequestAttributeCaseClasses
+
+  override def getTransactionRequestAttributesFromProvider(transactionRequestId: TransactionRequestId): Future[Box[List[TransactionRequestAttribute]]] =
+    (actor ? cc.getTransactionRequestAttributesFromProvider(transactionRequestId)).mapTo[Box[List[TransactionRequestAttribute]]]
+
+  override def getTransactionRequestAttributes(bankId: BankId,
+                                               transactionRequestId: TransactionRequestId): Future[Box[List[TransactionRequestAttribute]]] =
+    (actor ? cc.getTransactionRequestAttributes(bankId, transactionRequestId)).mapTo[Box[List[TransactionRequestAttribute]]]
+
+  override def getTransactionRequestAttributesCanBeSeenOnView(bankId: BankId,
+                                                              transactionRequestId: TransactionRequestId,
+                                                              viewId: ViewId): Future[Box[List[TransactionRequestAttribute]]] =
+    (actor ? cc.getTransactionRequestAttributesCanBeSeenOnView(bankId, transactionRequestId, viewId)).mapTo[Box[List[TransactionRequestAttribute]]]
+
+  override def getTransactionRequestAttributeById(transactionRequestAttributeId: String): Future[Box[TransactionRequestAttribute]] =
+    (actor ? cc.getTransactionRequestAttributeById(transactionRequestAttributeId)).mapTo[Box[TransactionRequestAttribute]]
+
+  override def getTransactionRequestIdsByAttributeNameValues(bankId: BankId, params: Map[String, List[String]]): Future[Box[List[String]]] =
+    (actor ? cc.getTransactionRequestIdsByAttributeNameValues(bankId: BankId, params: Map[String, List[String]])).mapTo[Box[List[String]]]
+
+  override def createOrUpdateTransactionRequestAttribute(bankId: BankId,
+                                                         transactionRequestId: TransactionRequestId,
+                                                         transactionRequestAttributeId: Option[String],
+                                                         name: String,
+                                                         attributeType: TransactionRequestAttributeType.Value,
+                                                         value: String): Future[Box[TransactionRequestAttribute]] =
+    (actor ? cc.createOrUpdateTransactionRequestAttribute(bankId, transactionRequestId, transactionRequestAttributeId, name, attributeType, value)).mapTo[Box[TransactionRequestAttribute]]
+
+  override def createTransactionRequestAttributes(bankId: BankId,
+                                                  transactionRequestId: TransactionRequestId,
+                                                  transactionRequestAttributes: List[TransactionRequestAttribute]): Future[Box[List[TransactionRequestAttribute]]] =
+    (actor ? cc.createTransactionRequestAttributes(bankId, transactionRequestId, transactionRequestAttributes)).mapTo[Box[List[TransactionRequestAttribute]]]
+
+  override def deleteTransactionRequestAttribute(transactionRequestAttributeId: String): Future[Box[Boolean]] =
+    (actor ? cc.deleteTransactionRequestAttribute(transactionRequestAttributeId)).mapTo[Box[Boolean]]
+}

--- a/obp-api/src/main/scala/code/transactionRequestAttribute/MappedTransactionRequestAttribute.scala
+++ b/obp-api/src/main/scala/code/transactionRequestAttribute/MappedTransactionRequestAttribute.scala
@@ -1,0 +1,46 @@
+package code.transactionRequestAttribute
+
+import code.util.{AttributeQueryTrait, MappedUUID, UUIDString}
+import com.openbankproject.commons.model.enums.TransactionRequestAttributeType
+import com.openbankproject.commons.model.{BankId, TransactionRequestAttribute, TransactionRequestId}
+import net.liftweb.mapper._
+
+import scala.collection.immutable.List
+
+
+class MappedTransactionRequestAttribute extends TransactionRequestAttribute with LongKeyedMapper[MappedTransactionRequestAttribute] with IdPK {
+  override def getSingleton = MappedTransactionRequestAttribute
+
+  override def bankId: BankId = BankId(mBankId.get)
+
+  override def transactionRequestId: TransactionRequestId = TransactionRequestId(mTransactionRequestId.get)
+
+  override def transactionRequestAttributeId: String = mTransactionRequestAttributeId.get
+
+  override def name: String = mName.get
+
+  override def attributeType: TransactionRequestAttributeType.Value = TransactionRequestAttributeType.withName(mType.get)
+
+  override def value: String = mValue.get
+
+  object mBankId extends UUIDString(this) // combination of this
+
+  object mTransactionRequestId extends UUIDString(this) // combination of this
+
+  object mTransactionRequestAttributeId extends MappedUUID(this)
+
+  object mName extends MappedString(this, 50)
+
+  object mType extends MappedString(this, 50)
+
+  object mValue extends MappedString(this, 255)
+
+}
+
+object MappedTransactionRequestAttribute extends MappedTransactionRequestAttribute with LongKeyedMetaMapper[MappedTransactionRequestAttribute]
+  with AttributeQueryTrait {
+  override val mParentId: BaseMappedField = mTransactionRequestId
+
+  override def dbIndexes: List[BaseIndex[MappedTransactionRequestAttribute]] = Index(mTransactionRequestId) :: Index(mTransactionRequestAttributeId) :: super.dbIndexes
+}
+

--- a/obp-api/src/main/scala/code/transactionRequestAttribute/MappedTransactionRequestAttributeProvider.scala
+++ b/obp-api/src/main/scala/code/transactionRequestAttribute/MappedTransactionRequestAttributeProvider.scala
@@ -1,0 +1,146 @@
+package code.transactionRequestAttribute
+
+import code.api.attributedefinition.AttributeDefinition
+import com.openbankproject.commons.model.enums.{AttributeCategory, TransactionRequestAttributeType}
+import com.openbankproject.commons.model.{BankId, TransactionRequestAttribute, TransactionRequestId, ViewId}
+import net.liftweb.common.{Box, Empty, Full}
+import net.liftweb.mapper.{By, BySql, IHaveValidatedThisSQL}
+import net.liftweb.util.Helpers.tryo
+
+import scala.collection.immutable.List
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+object MappedTransactionRequestAttributeProvider extends TransactionRequestAttributeProvider {
+
+  override def getTransactionRequestAttributesFromProvider(transactionRequestId: TransactionRequestId): Future[Box[List[TransactionRequestAttribute]]] =
+    Future {
+      Box !! MappedTransactionRequestAttribute.findAll(
+        By(MappedTransactionRequestAttribute.mTransactionRequestId, transactionRequestId.value)
+      )
+    }
+
+  override def getTransactionRequestAttributes(
+                                                bankId: BankId,
+                                                transactionRequestId: TransactionRequestId
+                                              ): Future[Box[List[TransactionRequestAttribute]]] = {
+    Future {
+      Box !! MappedTransactionRequestAttribute.findAll(
+        By(MappedTransactionRequestAttribute.mBankId, bankId.value),
+        By(MappedTransactionRequestAttribute.mTransactionRequestId, transactionRequestId.value)
+      )
+    }
+  }
+
+  override def getTransactionRequestAttributesCanBeSeenOnView(bankId: BankId,
+                                                              transactionRequestId: TransactionRequestId,
+                                                              viewId: ViewId): Future[Box[List[TransactionRequestAttribute]]] = {
+    Future {
+      val attributeDefinitions = AttributeDefinition.findAll(
+        By(AttributeDefinition.BankId, bankId.value),
+        By(AttributeDefinition.Category, AttributeCategory.Account.toString)
+      ).filter(_.canBeSeenOnViews.exists(_ == viewId.value)) // Filter by view_id
+      val transactionRequestAttributes = MappedTransactionRequestAttribute.findAll(
+        By(MappedTransactionRequestAttribute.mBankId, bankId.value),
+        By(MappedTransactionRequestAttribute.mTransactionRequestId, transactionRequestId.value)
+      )
+      val filteredTransactionRequestAttributes = for {
+        definition <- attributeDefinitions
+        attribute <- transactionRequestAttributes
+        if definition.bankId.value == attribute.bankId.value && definition.name == attribute.name
+      } yield {
+        attribute
+      }
+      Full(filteredTransactionRequestAttributes)
+    }
+  }
+
+  override def getTransactionRequestAttributeById(transactionRequestAttributeId: String): Future[Box[TransactionRequestAttribute]] = Future {
+    MappedTransactionRequestAttribute.find(By(MappedTransactionRequestAttribute.mTransactionRequestAttributeId, transactionRequestAttributeId))
+  }
+
+  override def getTransactionRequestIdsByAttributeNameValues(bankId: BankId, params: Map[String, List[String]]): Future[Box[List[String]]] =
+    Future {
+      Box !! {
+        if (params.isEmpty) {
+          MappedTransactionRequestAttribute.findAll(By(MappedTransactionRequestAttribute.mBankId, bankId.value)).map(_.transactionRequestId.value)
+        } else {
+          val paramList = params.toList
+          val parameters: List[String] = MappedTransactionRequestAttribute.getParameters(paramList)
+          val sqlParametersFilter = MappedTransactionRequestAttribute.getSqlParametersFilter(paramList)
+          val transactionRequestIdList = paramList.isEmpty match {
+            case true =>
+              MappedTransactionRequestAttribute.findAll(
+                By(MappedTransactionRequestAttribute.mBankId, bankId.value)
+              ).map(_.transactionRequestId.value)
+            case false =>
+              MappedTransactionRequestAttribute.findAll(
+                By(MappedTransactionRequestAttribute.mBankId, bankId.value),
+                BySql(sqlParametersFilter, IHaveValidatedThisSQL("developer", "2020-06-28"), parameters: _*)
+              ).map(_.transactionRequestId.value)
+          }
+          transactionRequestIdList
+        }
+      }
+    }
+
+  override def createOrUpdateTransactionRequestAttribute(bankId: BankId,
+                                                         transactionRequestId: TransactionRequestId,
+                                                         transactionRequestAttributeId: Option[String],
+                                                         name: String,
+                                                         attributeType: TransactionRequestAttributeType.Value,
+                                                         value: String): Future[Box[TransactionRequestAttribute]] = {
+    transactionRequestAttributeId match {
+      case Some(id) => Future {
+        MappedTransactionRequestAttribute.find(By(MappedTransactionRequestAttribute.mTransactionRequestAttributeId, id)) match {
+          case Full(attribute) => tryo {
+            attribute
+              .mBankId(bankId.value)
+              .mTransactionRequestId(transactionRequestId.value)
+              .mName(name)
+              .mType(attributeType.toString)
+              .mValue(value)
+              .saveMe()
+          }
+          case _ => Empty
+        }
+      }
+      case None => Future {
+        Full {
+          MappedTransactionRequestAttribute.create
+            .mBankId(bankId.value)
+            .mTransactionRequestId(transactionRequestId.value)
+            .mName(name)
+            .mType(attributeType.toString())
+            .mValue(value)
+            .saveMe()
+        }
+      }
+    }
+  }
+
+  override def createTransactionRequestAttributes(bankId: BankId,
+                                                  transactionRequestId: TransactionRequestId,
+                                                  transactionRequestAttributes: List[TransactionRequestAttribute]): Future[Box[List[TransactionRequestAttribute]]] = {
+    Future {
+      tryo {
+        for {
+          transactionRequestAttribute <- transactionRequestAttributes
+        } yield {
+          MappedTransactionRequestAttribute.create.mTransactionRequestId(transactionRequestId.value)
+            .mBankId(bankId.value)
+            .mName(transactionRequestAttribute.name)
+            .mType(transactionRequestAttribute.attributeType.toString())
+            .mValue(transactionRequestAttribute.value)
+            .saveMe()
+        }
+      }
+    }
+  }
+
+  override def deleteTransactionRequestAttribute(transactionRequestAttributeId: String): Future[Box[Boolean]] = Future {
+    Some(
+      MappedTransactionRequestAttribute.bulkDelete_!!(By(MappedTransactionRequestAttribute.mTransactionRequestAttributeId, transactionRequestAttributeId))
+    )
+  }
+}

--- a/obp-api/src/main/scala/code/transactionRequestAttribute/RemotedataTransactionRequestAttributeCaseClasses.scala
+++ b/obp-api/src/main/scala/code/transactionRequestAttribute/RemotedataTransactionRequestAttributeCaseClasses.scala
@@ -1,0 +1,38 @@
+package code.transactionRequestAttribute
+
+import com.openbankproject.commons.model.enums.TransactionRequestAttributeType
+import com.openbankproject.commons.model.{BankId, TransactionRequestAttribute, TransactionRequestId, ViewId}
+
+import scala.collection.immutable.List
+
+class RemotedataTransactionRequestAttributeCaseClasses {
+
+  case class getTransactionRequestAttributesFromProvider(transactionRequestId: TransactionRequestId)
+
+  case class getTransactionRequestAttributes(bankId: BankId,
+                                             transactionRequestId: TransactionRequestId)
+
+  case class getTransactionRequestAttributesCanBeSeenOnView(bankId: BankId,
+                                                            transactionRequestId: TransactionRequestId,
+                                                            viewId: ViewId)
+
+  case class getTransactionRequestAttributeById(transactionRequestAttributeId: String)
+
+  case class getTransactionRequestIdsByAttributeNameValues(bankId: BankId, params: Map[String, List[String]])
+
+  case class createOrUpdateTransactionRequestAttribute(bankId: BankId,
+                                                       transactionRequestId: TransactionRequestId,
+                                                       transactionRequestAttributeId: Option[String],
+                                                       name: String,
+                                                       attributeType: TransactionRequestAttributeType.Value,
+                                                       value: String)
+
+  case class createTransactionRequestAttributes(bankId: BankId,
+                                                transactionRequestId: TransactionRequestId,
+                                                transactionRequestAttributes: List[TransactionRequestAttribute])
+
+  case class deleteTransactionRequestAttribute(transactionRequestAttributeId: String)
+
+}
+
+object RemotedataTransactionRequestAttributeCaseClasses extends RemotedataTransactionRequestAttributeCaseClasses

--- a/obp-api/src/main/scala/code/transactionRequestAttribute/TransactionRequestAttributeProvider.scala
+++ b/obp-api/src/main/scala/code/transactionRequestAttribute/TransactionRequestAttributeProvider.scala
@@ -1,0 +1,40 @@
+package code.transactionRequestAttribute
+
+import com.openbankproject.commons.model.enums.TransactionRequestAttributeType
+import com.openbankproject.commons.model.{BankId, TransactionRequestAttribute, TransactionRequestId, ViewId}
+import net.liftweb.common.{Box, Logger}
+
+import scala.collection.immutable.List
+import scala.concurrent.Future
+
+trait TransactionRequestAttributeProvider {
+
+  private val logger = Logger(classOf[TransactionRequestAttributeProvider])
+
+  def getTransactionRequestAttributesFromProvider(transactionRequestId: TransactionRequestId): Future[Box[List[TransactionRequestAttribute]]]
+
+  def getTransactionRequestAttributes(bankId: BankId,
+                                      transactionRequestId: TransactionRequestId): Future[Box[List[TransactionRequestAttribute]]]
+
+  def getTransactionRequestAttributesCanBeSeenOnView(bankId: BankId,
+                                                     transactionRequestId: TransactionRequestId,
+                                                     viewId: ViewId): Future[Box[List[TransactionRequestAttribute]]]
+
+  def getTransactionRequestAttributeById(transactionRequestAttributeId: String): Future[Box[TransactionRequestAttribute]]
+
+  def getTransactionRequestIdsByAttributeNameValues(bankId: BankId, params: Map[String, List[String]]): Future[Box[List[String]]]
+
+  def createOrUpdateTransactionRequestAttribute(bankId: BankId,
+                                                transactionRequestId: TransactionRequestId,
+                                                transactionRequestAttributeId: Option[String],
+                                                name: String,
+                                                attributeType: TransactionRequestAttributeType.Value,
+                                                value: String): Future[Box[TransactionRequestAttribute]]
+
+  def createTransactionRequestAttributes(bankId: BankId,
+                                         transactionRequestId: TransactionRequestId,
+                                         transactionRequestAttributes: List[TransactionRequestAttribute]): Future[Box[List[TransactionRequestAttribute]]]
+
+  def deleteTransactionRequestAttribute(transactionRequestAttributeId: String): Future[Box[Boolean]]
+
+}

--- a/obp-api/src/main/scala/code/transactionRequestAttribute/TransactionRequestAttributeX.scala
+++ b/obp-api/src/main/scala/code/transactionRequestAttribute/TransactionRequestAttributeX.scala
@@ -1,0 +1,29 @@
+package code.transactionRequestAttribute
+
+import code.api.util.APIUtil
+import code.remotedata.RemotedataTransactionRequestAttribute
+import com.openbankproject.commons.model.TransactionRequestAttribute
+import net.liftweb.util.SimpleInjector
+
+import scala.collection.immutable.List
+
+object TransactionRequestAttributeX extends SimpleInjector {
+
+  val transactionRequestAttributeProvider = new Inject(buildOne _) {}
+
+  def buildOne: TransactionRequestAttributeProvider =
+    if (APIUtil.getPropsAsBoolValue("use_akka", defaultValue = false)) {
+      RemotedataTransactionRequestAttribute
+    } else {
+      MappedTransactionRequestAttributeProvider
+    }
+
+  // Helper to get the count out of an option
+  def countOfTransactionRequestAttribute(listOpt: Option[List[TransactionRequestAttribute]]): Int = {
+    val count = listOpt match {
+      case Some(list) => list.size
+      case None => 0
+    }
+    count
+  }
+}

--- a/obp-api/src/test/scala/code/api/v4_0_0/AttributeDefinitionTransactionRequestTest.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/AttributeDefinitionTransactionRequestTest.scala
@@ -1,0 +1,96 @@
+package code.api.v4_0_0
+
+import code.api.ResourceDocs1_4_0.SwaggerDefinitionsJSON
+import code.api.util.APIUtil.OAuth._
+import code.api.util.ErrorMessages.{UserHasMissingRoles, UserNotLoggedIn}
+import code.api.v4_0_0.OBPAPI4_0_0.Implementations4_0_0
+import com.github.dwickern.macros.NameOf.nameOf
+import com.openbankproject.commons.model.ErrorMessage
+import com.openbankproject.commons.util.ApiVersion
+import net.liftweb.json.Serialization.write
+import org.scalatest.Tag
+
+class AttributeDefinitionTransactionRequestTest extends V400ServerSetup {
+  /**
+   * Test tags
+   * Example: To run tests with tag "getPermissions":
+   * 	mvn test -D tagsToInclude
+   *
+   *  This is made possible by the scalatest maven plugin
+   */
+  object VersionOfApi extends Tag(ApiVersion.v4_0_0.toString)
+  object ApiEndpoint1 extends Tag(nameOf(Implementations4_0_0.createOrUpdateTransactionRequestAttributeDefinition))
+  object ApiEndpoint2 extends Tag(nameOf(Implementations4_0_0.getTransactionRequestAttributeDefinition))
+  object ApiEndpoint3 extends Tag(nameOf(Implementations4_0_0.deleteTransactionRequestAttributeDefinition))
+
+
+  lazy val bankId = randomBankId
+  lazy val putJson = SwaggerDefinitionsJSON.transactionRequestAttributeDefinitionJsonV400
+
+  feature(s"test $ApiEndpoint1 version $VersionOfApi - Unauthorized access") {
+    scenario("We will call the endpoint without user credentials", ApiEndpoint1, VersionOfApi) {
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "attribute-definitions" / "transaction-request").PUT
+      val response400 = makePutRequest(request400, write(putJson))
+      Then("We should get a 401")
+      response400.code should equal(401)
+      response400.body.extract[ErrorMessage].message should equal(UserNotLoggedIn)
+    }
+  }
+  feature(s"test $ApiEndpoint2 version $VersionOfApi - Unauthorized access") {
+    scenario("We will call the endpoint without user credentials", ApiEndpoint2, VersionOfApi) {
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "attribute-definitions" / "transaction-request").GET
+      val response400 = makeGetRequest(request400)
+      Then("We should get a 401")
+      response400.code should equal(401)
+      response400.body.extract[ErrorMessage].message should equal(UserNotLoggedIn)
+    }
+  }
+  feature(s"test $ApiEndpoint3 version $VersionOfApi - Unauthorized access") {
+    scenario("We will call the endpoint without user credentials", ApiEndpoint3, VersionOfApi) {
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "attribute-definitions"
+        / "ATTRIBUTE_DEFINITION_ID" / "transaction-request").DELETE
+      val response400 = makeDeleteRequest(request400)
+      Then("We should get a 401")
+      response400.code should equal(401)
+      response400.body.extract[ErrorMessage].message should equal(UserNotLoggedIn)
+    }
+  }
+
+  feature(s"test $ApiEndpoint1 version $VersionOfApi - authorized access- missing role") {
+    scenario("We will call the endpoint with user credentials", ApiEndpoint1, VersionOfApi) {
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "attribute-definitions" / "transaction-request").PUT <@ (user1)
+      val response400 = makePutRequest(request400, write(putJson))
+      Then("We should get a 403")
+      response400.code should equal(403)
+      response400.body.extract[ErrorMessage].message.toString contains (UserHasMissingRoles) should be (true)
+    }
+  }
+  feature(s"test $ApiEndpoint2 version $VersionOfApi - authorized access- missing role") {
+    scenario("We will call the endpoint with user credentials", ApiEndpoint2, VersionOfApi) {
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "attribute-definitions" / "transaction-request").GET <@ (user1)
+      val response400 = makeGetRequest(request400)
+      Then("We should get a 403")
+      response400.code should equal(403)
+      response400.body.extract[ErrorMessage].message.toString contains (UserHasMissingRoles) should be (true)
+    }
+  }
+  feature(s"test $ApiEndpoint3 version $VersionOfApi - authorized access- missing role") {
+    scenario("We will call the endpoint with user credentials", ApiEndpoint3, VersionOfApi) {
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "attribute-definitions"
+        / "ATTRIBUTE_DEFINITION_ID" / "transaction-request").DELETE <@ (user1)
+      val response400 = makeDeleteRequest(request400)
+      Then("We should get a 403")
+      response400.code should equal(403)
+      response400.body.extract[ErrorMessage].message.toString contains (UserHasMissingRoles) should be (true)
+    }
+  }
+
+
+
+}

--- a/obp-api/src/test/scala/code/api/v4_0_0/TransactionRequestAttributesTest.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/TransactionRequestAttributesTest.scala
@@ -1,0 +1,238 @@
+package code.api.v4_0_0
+
+import code.api.ResourceDocs1_4_0.SwaggerDefinitionsJSON
+import code.api.util.APIUtil.OAuth._
+import code.api.util.ApiRole._
+import code.api.util.ErrorMessages._
+import code.api.v4_0_0.OBPAPI4_0_0.Implementations4_0_0
+import code.entitlement.Entitlement
+import com.github.dwickern.macros.NameOf.nameOf
+import com.openbankproject.commons.model.ErrorMessage
+import com.openbankproject.commons.util.ApiVersion
+import net.liftweb.json.Serialization.write
+import org.scalatest.Tag
+
+
+class TransactionRequestAttributesTest extends V400ServerSetup {
+  /**
+    * Test tags
+    * Example: To run tests with tag "getPermissions":
+    * 	mvn test -D tagsToInclude
+    *
+    *  This is made possible by the scalatest maven plugin
+    */
+  object VersionOfApi extends Tag(ApiVersion.v4_0_0.toString())
+  object ApiEndpoint1 extends Tag(nameOf(Implementations4_0_0.createTransactionRequestAttribute))
+  object ApiEndpoint2 extends Tag(nameOf(Implementations4_0_0.updateTransactionRequestAttribute))
+  object ApiEndpoint3 extends Tag(nameOf(Implementations4_0_0.getTransactionRequestAttributes))
+  object ApiEndpoint4 extends Tag(nameOf(Implementations4_0_0.getTransactionRequestAttributeById))
+
+
+  lazy val bankId = testBankId1.value
+  lazy val accountId = testAccountId1.value
+  lazy val postTransactionRequestAttributeJsonV400 = SwaggerDefinitionsJSON.transactionRequestAttributeJsonV400
+  lazy val putTransactionRequestAttributeJsonV400 = SwaggerDefinitionsJSON.transactionRequestAttributeJsonV400.copy(name="test")
+  lazy val view = "owner"
+
+
+  feature(s"test $ApiEndpoint1 version $VersionOfApi - Unauthorized access") {
+    scenario("We will call the endpoint without user credentials", ApiEndpoint1, VersionOfApi) {
+      When("We make a request v4.0.0")
+      lazy val transactionRequest = randomTransactionRequestViaEndpoint(bankId, accountId, view, user1)
+      lazy val transactionRequestId = transactionRequest.id
+      
+      val request400 = (v4_0_0_Request / "banks" / bankId / "accounts" / accountId / "transaction-requests" / transactionRequestId / "attribute").POST
+      val response400 = makePostRequest(request400, write(postTransactionRequestAttributeJsonV400))
+      Then("We should get a 401")
+      response400.code should equal(401)
+      response400.body.extract[ErrorMessage].message should equal(UserNotLoggedIn)
+    }
+  }
+
+  feature(s"test $ApiEndpoint1 version $VersionOfApi - authorized access- missing role") {
+    scenario("We will call the endpoint with user credentials", ApiEndpoint1, VersionOfApi) {
+      lazy val transactionRequest = randomTransactionRequestViaEndpoint(bankId, accountId, view, user1)
+      lazy val transactionRequestId = transactionRequest.id
+      
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "accounts" / accountId / "transaction-requests" / transactionRequestId / "attribute").POST <@ (user1)
+      val response400 = makePostRequest(request400, write(postTransactionRequestAttributeJsonV400))
+      Then("We should get a 403")
+      response400.code should equal(403)
+      response400.body.extract[ErrorMessage].message should include (UserHasMissingRoles)
+    }
+  }
+
+  feature(s"test $ApiEndpoint1 version $VersionOfApi - authorized access - with role - should be success!") {
+    scenario("We will call the endpoint with user credentials", ApiEndpoint1, VersionOfApi) {
+      lazy val bankId = testBankId1.value
+      lazy val bankAccount = randomPrivateAccountViaEndpoint(bankId)
+      lazy val accountId = bankAccount.id
+      lazy val postTransactionRequestAttributeJsonV400 = SwaggerDefinitionsJSON.transactionRequestAttributeJsonV400
+      lazy val putTransactionRequestAttributeJsonV400 = SwaggerDefinitionsJSON.transactionRequestAttributeJsonV400.copy(name="test")
+      lazy val view = bankAccount.views_available.map(_.id).headOption.getOrElse("owner")
+      lazy val transactionRequest = randomTransactionRequestViaEndpoint(bankId, bankAccount.id, view, user1)
+      lazy val transactionRequestId = transactionRequest.id
+      
+      
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "accounts" / accountId / "transaction-requests" / transactionRequestId / "attribute").POST <@ (user1)
+      val response400 = makePostRequest(request400, write(putTransactionRequestAttributeJsonV400))
+      Then("We should get a 403")
+      response400.code should equal(403)
+      response400.body.extract[ErrorMessage].message should include (UserHasMissingRoles)
+
+      Then("We grant the role to the user1")
+      Entitlement.entitlement.vend.addEntitlement(bankId, resourceUser1.userId, canCreateTransactionRequestAttributeAtOneBank.toString())
+
+      val responseWithRole = makePostRequest(request400, write(putTransactionRequestAttributeJsonV400))
+      Then("We should get a 201")
+      responseWithRole.code should equal(201)
+      responseWithRole.body.extract[TransactionRequestAttributeResponseJson].name equals("test") should be (true)
+      responseWithRole.body.extract[TransactionRequestAttributeResponseJson].value equals(postTransactionRequestAttributeJsonV400.value) should be (true)
+      responseWithRole.body.extract[TransactionRequestAttributeResponseJson].`type` equals(postTransactionRequestAttributeJsonV400.`type`) should be (true)
+    }
+  }
+
+  feature(s"test $ApiEndpoint2 version $VersionOfApi - Unauthorized access") {
+    scenario("We will call the endpoint without user credentials", ApiEndpoint2, VersionOfApi) {
+      When("We make a request v4.0.0")
+      lazy val transactionRequest = randomTransactionRequestViaEndpoint(bankId, accountId, view, user1)
+      lazy val transactionRequestId = transactionRequest.id
+      val request400 = (v4_0_0_Request / "banks" / bankId / "accounts" / accountId / "transaction-requests" / transactionRequestId / "attributes" / "transactionRequestAttributeId").PUT
+      val response400 = makePutRequest(request400, write(putTransactionRequestAttributeJsonV400))
+      Then("We should get a 401")
+      response400.code should equal(401)
+      response400.body.extract[ErrorMessage].message should equal(UserNotLoggedIn)
+    }
+  }
+
+  feature(s"test $ApiEndpoint2 version $VersionOfApi - authorized access- missing role") {
+    scenario("We will call the endpoint with user credentials", ApiEndpoint2, VersionOfApi) {
+      lazy val transactionRequest = randomTransactionRequestViaEndpoint(bankId, accountId, view, user1)
+      lazy val transactionRequestId = transactionRequest.id
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "accounts" / accountId / "transaction-requests" / transactionRequestId / "attributes" / "transactionRequestAttributeId").PUT <@ (user1)
+      val response400 = makePutRequest(request400, write(putTransactionRequestAttributeJsonV400))
+      Then("We should get a 403")
+      response400.code should equal(403)
+      response400.body.extract[ErrorMessage].message should include (UserHasMissingRoles)
+    }
+  }
+
+  feature(s"test $ApiEndpoint2 version $VersionOfApi - authorized access - with role - should be success!") {
+    scenario("We will call the endpoint with user credentials", ApiEndpoint1, VersionOfApi) {
+      lazy val transactionRequest = randomTransactionRequestViaEndpoint(bankId, accountId, view, user1)
+      lazy val transactionRequestId = transactionRequest.id
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "accounts" / accountId / "transaction-requests" / transactionRequestId / "attribute").POST <@ (user1)
+      val response400 = makePostRequest(request400, write(putTransactionRequestAttributeJsonV400))
+      Then("We should get a 403")
+      response400.code should equal(403)
+      response400.body.extract[ErrorMessage].message should include (UserHasMissingRoles)
+
+      Then("We grant the role to the user1")
+      Entitlement.entitlement.vend.addEntitlement(bankId, resourceUser1.userId, canCreateTransactionRequestAttributeAtOneBank.toString())
+
+      val responseWithRole = makePostRequest(request400, write(putTransactionRequestAttributeJsonV400))
+      Then("We should get a 201")
+      responseWithRole.code should equal(201)
+      responseWithRole.body.extract[TransactionRequestAttributeResponseJson].name equals("test") should be (true)
+      responseWithRole.body.extract[TransactionRequestAttributeResponseJson].value equals(postTransactionRequestAttributeJsonV400.value) should be (true)
+      responseWithRole.body.extract[TransactionRequestAttributeResponseJson].`type` equals(postTransactionRequestAttributeJsonV400.`type`) should be (true)
+    }
+  }
+
+  feature(s"test $ApiEndpoint2 version $VersionOfApi - authorized access - with role - wrong transactionRequestAttributeId") {
+    scenario("We will call the endpoint without user credentials", ApiEndpoint2, VersionOfApi) {
+      lazy val transactionRequest = randomTransactionRequestViaEndpoint(bankId, accountId, view, user1)
+      lazy val transactionRequestId = transactionRequest.id
+      
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / bankId / "accounts" / accountId / "transaction-requests" / transactionRequestId / "attributes" / "transactionRequestAttributeId").PUT <@ (user1)
+      val response400 = makePutRequest(request400, write(putTransactionRequestAttributeJsonV400))
+      Then("We should get a 403")
+      response400.code should equal(403)
+      response400.body.extract[ErrorMessage].message should include (UserHasMissingRoles)
+
+      Then("We grant the role to the user1")
+      Entitlement.entitlement.vend.addEntitlement(bankId, resourceUser1.userId, canUpdateTransactionRequestAttributeAtOneBank.toString())
+
+      val responseWithRole = makePutRequest(request400, write(putTransactionRequestAttributeJsonV400))
+      Then("We should get a 400")
+      responseWithRole.code should equal(400)
+      responseWithRole.toString should include (TransactionRequestAttributeNotFound)
+
+    }
+  }
+
+  feature(s"test $ApiEndpoint2 version $VersionOfApi - authorized access - with role - with transactionRequestAttributeId") {
+    scenario("We will call the endpoint with user credentials", ApiEndpoint2, VersionOfApi) {
+
+      lazy val transactionRequest = randomTransactionRequestViaEndpoint(bankId, accountId, view, user1)
+      lazy val transactionRequestId = transactionRequest.id
+      
+      Then("We grant the role to the user1")
+      Entitlement.entitlement.vend.addEntitlement(bankId, resourceUser1.userId, canUpdateTransactionRequestAttributeAtOneBank.toString())
+
+      Then("we create the Transaction Request Attribute ")
+      val transactionRequestAttributeId = createTransactionRequestAttributeEndpoint(bankId:String, accountId:String, transactionRequestId:String,  user1)
+     
+
+      val requestWithId = (v4_0_0_Request / "banks" / bankId / "accounts" / accountId / "transaction-requests" / transactionRequestId / "attributes" / transactionRequestAttributeId).PUT <@ (user1)
+      val responseWithId = makePutRequest(requestWithId, write(putTransactionRequestAttributeJsonV400))
+
+      responseWithId.body.extract[TransactionRequestAttributeResponseJson].name  equals("test") should be (true)
+      responseWithId.body.extract[TransactionRequestAttributeResponseJson].value  equals(putTransactionRequestAttributeJsonV400.value) should be (true)
+      responseWithId.body.extract[TransactionRequestAttributeResponseJson].`type`  equals(putTransactionRequestAttributeJsonV400.`type`) should be (true)
+    }
+  }
+
+    feature(s"test $ApiEndpoint3 version $VersionOfApi - authorized access - with role - wrong transactionRequestAttributeId") {
+      scenario("We will call the endpoint without user credentials", ApiEndpoint2, VersionOfApi) {
+
+        lazy val transactionRequest = randomTransactionRequestViaEndpoint(bankId, accountId, view, user1)
+        lazy val transactionRequestId = transactionRequest.id
+        
+        When("We make a request v4.0.0")
+        Then("we create the Transaction Request Attribute ")
+        val transactionRequestAttributeId = createTransactionRequestAttributeEndpoint(bankId:String, accountId:String, transactionRequestId:String,  user1)
+
+
+        val request400 = (v4_0_0_Request / "banks" / bankId / "accounts" / accountId / "transaction-requests" / transactionRequestId / "attributes" ).GET <@ (user1)
+        val response400 = makeGetRequest(request400)
+        Then("We should get a 403")
+        response400.code should equal(403)
+        response400.body.extract[ErrorMessage].message should include (UserHasMissingRoles)
+
+        Then("We grant the role to the user1")
+        Entitlement.entitlement.vend.addEntitlement(bankId, resourceUser1.userId, CanGetTransactionRequestAttributesAtOneBank.toString)
+
+        val responseWithRole = makeGetRequest(request400)
+        Then("We should get a 200")
+        responseWithRole.code should equal(200)
+      }
+    }
+
+    feature(s"test $ApiEndpoint4 version $VersionOfApi - authorized access - with role - with transactionRequestAttributeId") {
+      scenario("We will call the endpoint with user credentials", ApiEndpoint2, VersionOfApi) {
+
+        lazy val transactionRequest = randomTransactionRequestViaEndpoint(bankId, accountId, view, user1)
+        lazy val transactionRequestId = transactionRequest.id
+        
+        Then("we create the Transaction Request Attribute ")
+        val transactionRequestAttributeId = createTransactionRequestAttributeEndpoint(bankId, accountId, transactionRequestId, user1)
+
+        Then("We grant the role to the user1")
+        Entitlement.entitlement.vend.addEntitlement(bankId, resourceUser1.userId, canGetTransactionRequestAttributeAtOneBank.toString())
+
+        val requestWithId = (v4_0_0_Request / "banks" / bankId / "accounts" / accountId / "transaction-requests" / transactionRequestId / "attributes" / transactionRequestAttributeId).GET <@ (user1)
+        val responseWithId = makeGetRequest(requestWithId)
+
+        responseWithId.body.extract[TransactionRequestAttributeResponseJson].name should equal(postTransactionRequestAttributeJsonV400.name)
+        responseWithId.body.extract[TransactionRequestAttributeResponseJson].value should equal(postTransactionRequestAttributeJsonV400.value)
+        responseWithId.body.extract[TransactionRequestAttributeResponseJson].`type` should equal(postTransactionRequestAttributeJsonV400.`type`)
+      }
+    }
+  
+}

--- a/obp-api/src/test/scala/code/api/v4_0_0/V400ServerSetup.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/V400ServerSetup.scala
@@ -190,6 +190,15 @@ trait V400ServerSetup extends ServerSetupWithTestData with DefaultUsers {
     responseWithRole.body.extract[TransactionAttributeResponseJson].transaction_attribute_id
   }
 
+  def createTransactionRequestAttributeEndpoint(bankId:String, accountId:String, transactionRequestId:String, consumerAndToken: Option[(Consumer, Token)]) = {
+    lazy val postTransactionRequestAttributeJsonV400 = SwaggerDefinitionsJSON.transactionRequestAttributeJsonV400
+    val request400 = (v4_0_0_Request / "banks" / bankId / "accounts"/ accountId /"transaction-requests" / transactionRequestId / "attribute").POST <@ (user1)
+    Entitlement.entitlement.vend.addEntitlement(bankId, resourceUser1.userId, canCreateTransactionRequestAttributeAtOneBank.toString())
+    val responseWithRole = makePostRequest(request400, write(postTransactionRequestAttributeJsonV400))
+    responseWithRole.code should equal(201)
+    responseWithRole.body.extract[TransactionRequestAttributeResponseJson].transaction_request_attribute_id
+  }
+
   def grantUserAccessToViewViaEndpoint(bankId: String,
                                        accountId: String,
                                        userId: String,

--- a/obp-api/src/test/scala/code/util/MappedClassNameTest.scala
+++ b/obp-api/src/test/scala/code/util/MappedClassNameTest.scala
@@ -98,6 +98,7 @@ class MappedClassNameTest extends FeatureSpec {
       "code.token.OpenIDConnectToken",
       "code.transactionattribute.MappedTransactionAttribute",
       "code.customerattribute.MappedCustomerAttribute",
+      "code.transactionRequestAttribute.MappedTransactionRequestAttribute",
       "code.cards.MappedPhysicalCard",
       "code.cardattribute.MappedCardAttribute",
       "code.model.dataAccess.ResourceUser",

--- a/obp-commons/src/main/scala/com/openbankproject/commons/model/CommonModelTrait.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/model/CommonModelTrait.scala
@@ -454,6 +454,15 @@ trait TransactionRequestReasonsTrait {
   def description: String
 }
 
+trait TransactionRequestAttribute {
+  def bankId: BankId
+  def transactionRequestId: TransactionRequestId
+  def transactionRequestAttributeId: String
+  def attributeType: TransactionRequestAttributeType.Value
+  def name: String
+  def value: String
+}
+
 trait DirectDebitTrait {
   def directDebitId: String
   def bankId: String

--- a/obp-commons/src/main/scala/com/openbankproject/commons/model/enums/Enumerations.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/model/enums/Enumerations.scala
@@ -200,6 +200,7 @@ object AttributeCategory extends OBPEnumeration[AttributeCategory]{
   object Account extends Value
   object Transaction extends Value
   object Card extends Value
+  object TransactionRequest extends Value
 }
 
 object TransactionRequestStatus extends Enumeration {

--- a/obp-commons/src/main/scala/com/openbankproject/commons/model/enums/Enumerations.scala
+++ b/obp-commons/src/main/scala/com/openbankproject/commons/model/enums/Enumerations.scala
@@ -47,6 +47,14 @@ object TransactionAttributeType extends  OBPEnumeration[TransactionAttributeType
   object DATE_WITH_DAY extends Value
 }
 
+sealed trait TransactionRequestAttributeType extends EnumValue
+object TransactionRequestAttributeType extends  OBPEnumeration[TransactionRequestAttributeType]{
+  object STRING        extends Value
+  object INTEGER       extends Value
+  object DOUBLE        extends Value
+  object DATE_WITH_DAY extends Value
+}
+
 //------api enumerations ----
 sealed trait StrongCustomerAuthentication extends EnumValue
 object StrongCustomerAuthentication extends OBPEnumeration[StrongCustomerAuthentication] {


### PR DESCRIPTION
Add Transaction Request Attributes to the OBP-API (inspired by the Transaction Attribute system).

One new table: 
- MappedTransactionRequestAttribute (based on the old `Mapped` system, because it must extends `AttributeQueryTrait`)

4 Transaction Attribute endpoints:
- createTransactionRequestAttribute
- getTransactionRequestAttributeById
- getTransactionRequestAttributes
- updateTransactionRequestAttribute

3 Transaction Attribute Definition endpoints:
- createOrUpdateTransactionRequestAttributeDefinition
- getTransactionRequestAttributeDefinition
- deleteTransactionRequestAttributeDefinition

This feature will be usefull to store custom tags linked to a Transaction Request like reason codes, refund reasons, original transaction id, ... instead of storing them in the description.

[Jenkins Tests](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/74/)