### PR TITLE
Get double entry transaction

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -16,7 +16,7 @@ import code.api.v3_0_0.JSONFactory300.createBranchJsonV300
 import code.api.v3_0_0.custom.JSONFactoryCustom300
 import code.api.v3_0_0.{LobbyJsonV330, _}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, CustomerWithAttributesJsonV310, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
-import code.api.v4_0_0.{APIInfoJson400, AccountBalanceJsonV400, AccountTagJSON, AccountTagsJSON, AccountsBalancesJsonV400, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, AttributeJsonV400, BalanceJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, ChallengeAnswerJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, EnergySource400, HostedAt400, HostedBy400, IbanCheckerJsonV400, IbanDetailsJsonV400, JsonSchemaV400, JsonValidationV400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, ModeratedFirehoseAccountJsonV400, ModeratedFirehoseAccountsJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostRevokeGrantAccountAccessJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, Properties, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionRequestAttributeJsonV400, TransactionRequestAttributeResponseJson, TransactionRequestAttributesResponseJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestRefundFrom, TransactionRequestRefundTo, TransactionRequestWithChargeJSON400, UpdateAccountJsonV400, UserLockStatusJson, When, XxxId}
+import code.api.v4_0_0.{APIInfoJson400, AccountBalanceJsonV400, AccountTagJSON, AccountTagsJSON, AccountsBalancesJsonV400, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, AttributeJsonV400, BalanceJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, ChallengeAnswerJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, DoubleEntryTransactionJson, EnergySource400, HostedAt400, HostedBy400, IbanCheckerJsonV400, IbanDetailsJsonV400, JsonSchemaV400, JsonValidationV400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, ModeratedFirehoseAccountJsonV400, ModeratedFirehoseAccountsJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostRevokeGrantAccountAccessJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, Properties, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionBankAccountJson, TransactionRequestAttributeJsonV400, TransactionRequestAttributeResponseJson, TransactionRequestAttributesResponseJson, TransactionRequestBankAccountJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestRefundFrom, TransactionRequestRefundTo, TransactionRequestWithChargeJSON400, UpdateAccountJsonV400, UserLockStatusJson, When, XxxId}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
 import code.branches.Branches.{Branch, DriveUpString, LobbyString}
 import code.consent.ConsentStatus
@@ -3847,6 +3847,24 @@ object SwaggerDefinitionsJSON {
 
   val settlementAccountsJson = SettlementAccountsJson(
     settlement_accounts = List(settlementAccountJson)
+  )
+
+  val doubleEntryTransactionJson = DoubleEntryTransactionJson(
+    transaction_request = TransactionRequestBankAccountJson(
+      bank_id = bankIdExample.value,
+      account_id = accountIdExample.value,
+      transaction_request_id = transactionRequestIdExample.value
+    ),
+    debit_transaction = TransactionBankAccountJson(
+      bank_id = bankIdExample.value,
+      account_id = accountIdExample.value,
+      transaction_id = transactionIdExample.value
+    ),
+    credit_transaction = TransactionBankAccountJson(
+      bank_id = bankIdExample.value,
+      account_id = accountIdExample.value,
+      transaction_id = transactionIdExample.value
+    )
   )
 
   val postAccountAccessJsonV400 = PostAccountAccessJsonV400(userIdExample.value, PostViewJsonV400(ExampleValue.viewIdExample.value, true))

--- a/obp-api/src/main/scala/code/api/util/ApiRole.scala
+++ b/obp-api/src/main/scala/code/api/util/ApiRole.scala
@@ -543,6 +543,9 @@ object ApiRole {
   case class CanGetTransactionRequestAttributeAtOneBank(requiresBankId: Boolean = true) extends ApiRole
   lazy val canGetTransactionRequestAttributeAtOneBank = CanGetTransactionRequestAttributeAtOneBank()
 
+  case class CanGetDoubleEntryTransactionAtOneBank(requiresBankId: Boolean = true) extends ApiRole
+  lazy val canGetDoubleEntryTransactionAtOneBank = CanGetDoubleEntryTransactionAtOneBank()
+
   case class CanReadResourceDoc(requiresBankId: Boolean = false) extends ApiRole
   lazy val canReadResourceDoc = CanReadResourceDoc()
   

--- a/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
+++ b/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
@@ -306,6 +306,8 @@ object ErrorMessages {
 
   val TransactionRequestAttributeNotFound = "OBP-30078: Transaction Request Attribute not found. Please specify a valid value for TRANSACTION_REQUEST_ATTRIBUTE_ID."
 
+  val DoubleEntryTransactionNotFound = "OBP-30079: Double Entry Transaction not found."
+
   // Meetings
   val MeetingsNotSupported = "OBP-30101: Meetings are not supported on this server."
   val MeetingApiKeyNotConfigured = "OBP-30102: Meeting provider API Key is not configured."

--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -1096,6 +1096,11 @@ object NewStyle {
         (unboxFullOrFail(i._1, callContext, s"$InvalidConnectorResponseForSaveDoubleEntryBookTransaction ", 400), i._2)
       }
 
+    def getDoubleEntryBookTransaction(bankId: BankId, accountId: AccountId, transactionId: TransactionId, callContext: Option[CallContext]): OBPReturnType[DoubleEntryTransaction] =
+      Connector.connector.vend.getDoubleEntryBookTransaction(bankId: BankId, accountId: AccountId, transactionId: TransactionId, callContext: Option[CallContext]) map { i =>
+        (unboxFullOrFail(i._1, callContext, s"$DoubleEntryTransactionNotFound ", 404), i._2)
+      }
+
     def cancelPaymentV400(transactionId: TransactionId, callContext: Option[CallContext]): OBPReturnType[CancelPayment] = {
       Connector.connector.vend.cancelPaymentV400(transactionId: TransactionId, callContext) map { i =>
         (unboxFullOrFail(i._1, callContext, s"$InvalidConnectorResponseForCancelPayment ",400), i._2)

--- a/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
@@ -537,6 +537,24 @@ case class IbanDetailsJsonV400(bank_routings: List[BankRoutingJsonV121],
                                attributes: List[AttributeJsonV400]
                               )
 
+case class DoubleEntryTransactionJson(
+                                         transaction_request: TransactionRequestBankAccountJson,
+                                         debit_transaction: TransactionBankAccountJson,
+                                         credit_transaction: TransactionBankAccountJson
+                                         )
+
+case class TransactionRequestBankAccountJson(
+                                        bank_id: String,
+                                        account_id: String,
+                                        transaction_request_id: String
+                                        )
+
+case class TransactionBankAccountJson(
+                                  bank_id: String,
+                                  account_id: String,
+                                  transaction_id: String
+                                  )
+
 object JSONFactory400 {
   def createBankJSON400(bank: Bank): BankJson400 = {
     val obp = BankRoutingJsonV121("OBP", bank.bankId.value)
@@ -974,6 +992,29 @@ object JSONFactory400 {
       details
     )
   }
+
+  def createDoubleEntryTransactionJson(doubleEntryBookTransaction: DoubleEntryTransaction): DoubleEntryTransactionJson =
+    DoubleEntryTransactionJson(
+      transaction_request = (for {
+        transactionRequestBankId <- doubleEntryBookTransaction.transactionRequestBankId
+        transactionRequestAccountId <- doubleEntryBookTransaction.transactionRequestAccountId
+        transactionRequestId <- doubleEntryBookTransaction.transactionRequestId
+      } yield TransactionRequestBankAccountJson(
+        transactionRequestBankId.value,
+        transactionRequestAccountId.value,
+        transactionRequestId.value
+      )).orNull,
+      debit_transaction = TransactionBankAccountJson(
+        doubleEntryBookTransaction.debitTransactionBankId.value,
+        doubleEntryBookTransaction.debitTransactionAccountId.value,
+        doubleEntryBookTransaction.debitTransactionId.value
+      ),
+      credit_transaction = TransactionBankAccountJson(
+        doubleEntryBookTransaction.creditTransactionBankId.value,
+        doubleEntryBookTransaction.creditTransactionAccountId.value,
+        doubleEntryBookTransaction.creditTransactionId.value
+      )
+    )
   
 }
 

--- a/obp-api/src/main/scala/code/bankconnectors/Connector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/Connector.scala
@@ -720,6 +720,9 @@ trait Connector extends MdcLoggable {
   def saveDoubleEntryBookTransaction(doubleEntryTransaction: DoubleEntryTransaction,
                                      callContext: Option[CallContext]): OBPReturnType[Box[DoubleEntryTransaction]]= Future{(Failure(setUnimplementedError), callContext)}
 
+  def getDoubleEntryBookTransaction(bankId: BankId, accountId: AccountId, transactionId: TransactionId,
+                                     callContext: Option[CallContext]): OBPReturnType[Box[DoubleEntryTransaction]]= Future{(Failure(setUnimplementedError), callContext)}
+
   protected def makePaymentImpl(fromAccount: BankAccount, toAccount: BankAccount, transactionRequestCommonBody: TransactionRequestCommonBodyJSON, amt: BigDecimal, description: String, transactionRequestType: TransactionRequestType, chargePolicy: String): Box[TransactionId]= Failure(setUnimplementedError)
 
 

--- a/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -1253,6 +1253,21 @@ object LocalMappedConnector extends Connector with MdcLoggable {
   ).map(doubleEntryTransaction => (doubleEntryTransaction, callContext))
   }
 
+  override def getDoubleEntryBookTransaction(bankId: BankId, accountId: AccountId, transactionId: TransactionId,
+                                              callContext: Option[CallContext]): OBPReturnType[Box[DoubleEntryTransaction]] = {
+    Future(
+      DoubleEntryBookTransaction.find(
+          By(DoubleEntryBookTransaction.DebitTransactionBankId, bankId.value),
+          By(DoubleEntryBookTransaction.DebitTransactionAccountId, accountId.value),
+          By(DoubleEntryBookTransaction.DebitTransactionId, transactionId.value)
+        ).or(DoubleEntryBookTransaction.find(
+        By(DoubleEntryBookTransaction.CreditTransactionBankId, bankId.value),
+        By(DoubleEntryBookTransaction.CreditTransactionAccountId, accountId.value),
+        By(DoubleEntryBookTransaction.CreditTransactionId, transactionId.value)
+      ))
+    ).map(doubleEntryTransaction => (doubleEntryTransaction, callContext))
+  }
+
   override def makePaymentV400(transactionRequest: TransactionRequest,
                                reasons: Option[List[TransactionRequestReason]],
                                callContext: Option[CallContext]): Future[Box[(TransactionId, Option[CallContext])]] = Future {

--- a/obp-api/src/test/scala/code/api/v4_0_0/DoubleEntryTransactionTest.scala
+++ b/obp-api/src/test/scala/code/api/v4_0_0/DoubleEntryTransactionTest.scala
@@ -1,0 +1,95 @@
+package code.api.v4_0_0
+
+import code.api.util.APIUtil.OAuth._
+import code.api.util.ApiRole
+import code.api.util.ErrorMessages.{UserHasMissingRoles, UserNotLoggedIn}
+import code.api.v4_0_0.OBPAPI4_0_0.Implementations4_0_0
+import code.entitlement.Entitlement
+import com.github.dwickern.macros.NameOf.nameOf
+import com.openbankproject.commons.model.{AccountId, BankId, ErrorMessage}
+import com.openbankproject.commons.util.ApiVersion
+import net.liftweb.common.Box
+import org.scalatest.Tag
+
+class DoubleEntryTransactionTest extends V400ServerSetup {
+
+  lazy val testBankId: BankId = testBankId1
+  lazy val testAccountId: AccountId = testAccountId1
+  lazy val view = "owner"
+
+  /**
+   * Test tags
+   * Example: To run tests with tag "getPermissions":
+   * mvn test -D tagsToInclude
+   *
+   * This is made possible by the scalatest maven plugin
+   */
+  object VersionOfApi extends Tag(ApiVersion.v4_0_0.toString())
+
+  object GetDoubleEntryTransactionEndpoint extends Tag(nameOf(Implementations4_0_0.getDoubleEntryTransaction))
+
+  feature(s"test $GetDoubleEntryTransactionEndpoint - Unauthorized access") {
+    scenario("We will call the endpoint without user credentials", GetDoubleEntryTransactionEndpoint, VersionOfApi) {
+      Given("a random transaction")
+      lazy val transaction = randomTransactionViaEndpoint(testBankId.value, testAccountId.value, view)
+
+      When("We make a request v4.0.0")
+      val request400 = (v4_0_0_Request / "banks" / testBankId.value / "accounts" / testAccountId.value / view / "transactions" / transaction.id / "double-entry-transaction").GET
+      val response400 = makeGetRequest(request400)
+      Then("We should get a 401")
+      response400.code should equal(401)
+      And("error should be " + UserNotLoggedIn)
+      response400.body.extract[ErrorMessage].message should equal(UserNotLoggedIn)
+    }
+  }
+  feature(s"test $GetDoubleEntryTransactionEndpoint - Authorized access") {
+    scenario("We will call the endpoint with user credentials", GetDoubleEntryTransactionEndpoint, VersionOfApi) {
+      Given("a created transaction ")
+      Entitlement.entitlement.vend.addEntitlement("", resourceUser1.userId, ApiRole.CanCreateHistoricalTransaction.toString)
+      val transaction = saveHistoricalTransactionViaEndpoint(testBankId, testAccountId, testBankId2, testAccountId0, BigDecimal(156.96), "a transaction", user1)
+
+      When("We make a request v4.0.0")
+      val addedEntitlement: Box[Entitlement] = Entitlement.entitlement.vend.addEntitlement(testBankId.value, resourceUser1.userId, ApiRole.CanGetDoubleEntryTransactionAtOneBank.toString)
+      val response400 = try {
+        val request400 = (v4_0_0_Request / "banks" / testBankId.value / "accounts" / testAccountId.value / view / "transactions" / transaction.transaction_id / "double-entry-transaction").GET <@ (user1)
+        makeGetRequest(request400)
+      } finally {
+        Entitlement.entitlement.vend.deleteEntitlement(addedEntitlement)
+      }
+
+
+      Then("We should get a 200")
+      response400.code should equal(200)
+      val doubleEntryTransaction = response400.body.extract[DoubleEntryTransactionJson]
+      doubleEntryTransaction.transaction_request should be(null)
+      doubleEntryTransaction.debit_transaction.bank_id should be(testBankId.value)
+      doubleEntryTransaction.debit_transaction.account_id should be(testAccountId.value)
+      doubleEntryTransaction.debit_transaction.transaction_id should be(transaction.transaction_id)
+      doubleEntryTransaction.credit_transaction.bank_id should be(testBankId2.value)
+      doubleEntryTransaction.credit_transaction.account_id should be(testAccountId0.value)
+      doubleEntryTransaction.credit_transaction.transaction_id should not be empty
+
+
+      Then("We make a request v4.0.0 but with other user")
+      val requestWithNewAccountId = (v4_0_0_Request / "banks" / testBankId.value / "accounts" / testAccountId.value / view / "transactions" / transaction.transaction_id / "double-entry-transaction").GET <@ (user1)
+      val responseWithNoRole = makeGetRequest(requestWithNewAccountId)
+      Then("We should get a 403 and some error message")
+      responseWithNoRole.code should equal(403)
+      responseWithNoRole.body.toString contains (s"$UserHasMissingRoles") should be(true)
+
+
+      Then("We grant the roles and test it again")
+      Entitlement.entitlement.vend.addEntitlement(testBankId.value, resourceUser1.userId, ApiRole.CanGetDoubleEntryTransactionAtOneBank.toString)
+      val responseWithOtherUser = makeGetRequest(requestWithNewAccountId)
+
+      val doubleEntryTransaction2 = responseWithOtherUser.body.extract[DoubleEntryTransactionJson]
+      doubleEntryTransaction2.transaction_request should be(null)
+      doubleEntryTransaction2.debit_transaction.bank_id should be(testBankId.value)
+      doubleEntryTransaction2.debit_transaction.account_id should be(testAccountId.value)
+      doubleEntryTransaction2.debit_transaction.transaction_id should be(transaction.transaction_id)
+      doubleEntryTransaction2.credit_transaction.bank_id should be(testBankId2.value)
+      doubleEntryTransaction2.credit_transaction.account_id should be(testAccountId0.value)
+      doubleEntryTransaction2.credit_transaction.transaction_id should not be empty
+    }
+  }
+}


### PR DESCRIPTION
Add an endpoint to get the double entry book transaction table information.

The endpoint require a new role : `CanGetDoubleEntryTransactionAtOneBank`

The endpoint returns the 
- `credit_transaction`
- `debit_transaction`
- `transaction_request` if any, else the value is `null`
This works with any existing transaction present in the doubleEntryBookTransaction table, it doesn't matter whether the transaction is a debit or a credit.

Example with a debit transaction (with a transaction request) :
![image](https://user-images.githubusercontent.com/17991359/102071613-084bb200-3e01-11eb-9bf9-252bccdd8862.png)

Example with a credit ransaction (without a transaction request) :
![image](https://user-images.githubusercontent.com/17991359/102071761-392be700-3e01-11eb-9fe6-4e2837033193.png)

[Jenkins Tests](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/84/)
