### PR TITLE
bugfix/unknown_jvalueToCaseclass 

### DIFF
--- a/obp-api/src/main/scala/code/api/v1_4_0/JSONFactory1_4_0.scala
+++ b/obp-api/src/main/scala/code/api/v1_4_0/JSONFactory1_4_0.scala
@@ -1,7 +1,8 @@
 package code.api.v1_4_0
 
-import java.util.Date
+import code.api.berlin.group.v1_3.JvalueCaseClass
 
+import java.util.Date
 import code.api.util.APIUtil.{EmptyBody, PrimaryDataBody, ResourceDoc}
 import code.api.util.Glossary.glossaryItems
 import code.api.util.{APIUtil, ApiRole, ConnectorField, CustomJsonFormats, ExampleValue, PegdownOptions}
@@ -420,7 +421,11 @@ object JSONFactory1_4_0 extends MdcLoggable{
 
   def prepareJsonFieldDescription(jsonBody: scala.Product, jsonType: String): String = {
 
-    val jsonBodyJValue = decompose(jsonBody)
+    val jsonBodyJValue = jsonBody match {
+      case JvalueCaseClass(jValue) =>
+        jValue
+      case _ => decompose(jsonBody)
+    }
 
     val jsonBodyFields =JsonUtils.collectFieldNames(jsonBodyJValue).keySet.toList.sorted
 


### PR DESCRIPTION
fix the explorer show `jvalueToCaseclass: jvalueToCaseclass` in JSON response body fields

### Jenkins job is passed, please merge this pull request. 

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/369)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/126/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/236/)