### PR TITLE
feature/split_dynamic_and_static:split ResourceDocs to dynamic and static

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
@@ -411,7 +411,7 @@ trait ResourceDocsAPIMethods extends MdcLoggable with APIMethods220 with APIMeth
                   case _ =>
                     val dynamicDocs: Box[JValue] = getResourceDocsObpDynamic(requestedApiVersion, tags, partialFunctions)
                     val staticDocs: Box[JValue] = getResourceDocsObpCached(requestedApiVersion, tags, partialFunctions)
-                    println()
+
                     for {
                       dDocs <- dynamicDocs
                       sDocs <- staticDocs

--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
@@ -237,6 +237,7 @@ trait ResourceDocsAPIMethods extends MdcLoggable with APIMethods220 with APIMeth
                                          partialFunctionNames: Option[List[String]]
                                         ): Option[JValue] = {
       val dynamicDocs = (DynamicEntityHelper.doc ++ DynamicEndpointHelper.doc)
+        .filter(rd => rd.implementedInApiVersion == requestedApiVersion)
         .map(it => it.specifiedUrl match {
           case Some(_) => it
           case _ =>
@@ -244,7 +245,24 @@ trait ResourceDocsAPIMethods extends MdcLoggable with APIMethods220 with APIMeth
             it
         })
         .toList
-      val resourceDocJson = resourceDocsToResourceDocJson(Some(dynamicDocs), resourceDocTags, partialFunctionNames)
+
+      val filteredDocs = resourceDocTags match {
+        // We have tags
+        case Some(tags) => {
+          // This can create duplicates to use toSet below
+          for {
+            r <- dynamicDocs
+            t <- tags
+            if r.tags.contains(t)
+          } yield {
+            r
+          }
+        }
+        // tags param was not mentioned in url or was empty, so return all
+        case None => dynamicDocs
+      }
+
+      val resourceDocJson = resourceDocsToResourceDocJson(Some(filteredDocs), resourceDocTags, partialFunctionNames)
       resourceDocJson.map(resourceDocsJsonToJsonResponse)
     }
 

--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONFactory.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerJSONFactory.scala
@@ -748,7 +748,7 @@ object SwaggerJSONFactory extends MdcLoggable {
           JField(name, v) <- jFields
         } yield s""" "$name": ${buildSwaggerSchema(JsonUtils.getType(v), v)} """
 
-        val requiredFields = if (jFields.isEmpty) "" else  jFields.map(_.name).map(name => s""" "$name" """).mkString("[", ",", "]")
+        val requiredFields = if (jFields.isEmpty) "[]" else  jFields.map(_.name).map(name => s""" "$name" """).mkString("[", ",", "]")
 
         s""" {"type":"object", "properties": { ${allFields.mkString(",")} }, "required": $requiredFields }"""
 

--- a/obp-api/src/main/scala/code/api/util/APIUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/APIUtil.scala
@@ -1199,7 +1199,7 @@ object APIUtil extends MdcLoggable with CustomJsonFormats{
                           var roles: Option[List[ApiRole]] = None,
                           isFeatured: Boolean = false,
                           specialInstructions: Option[String] = None,
-                          specifiedUrl: Option[String] = None // A derived value: Contains the called version (added at run time). See the resource doc for resource doc!
+                          var specifiedUrl: Option[String] = None // A derived value: Contains the called version (added at run time). See the resource doc for resource doc!
                         ) {
     // this code block will be merged to constructor.
     {

--- a/obp-api/src/main/scala/code/api/util/ApiRole.scala
+++ b/obp-api/src/main/scala/code/api/util/ApiRole.scala
@@ -1,15 +1,18 @@
 package code.api.util
 
 import java.util.concurrent.ConcurrentHashMap
-
 import code.api.v4_0_0.{DynamicEndpointHelper, DynamicEntityHelper}
-import com.openbankproject.commons.util.ReflectUtils
+import com.openbankproject.commons.util.{JsonAble, ReflectUtils}
+import net.liftweb.json.{Formats, JsonAST}
+import net.liftweb.json.JsonDSL._
 
-sealed trait ApiRole{
+sealed trait ApiRole extends JsonAble {
   val requiresBankId: Boolean
   override def toString() = getClass().getSimpleName
 
   def & (apiRole: ApiRole): RoleCombination = RoleCombination(this, apiRole)
+
+  override def toJValue(implicit format: Formats): JsonAST.JValue = ("role", this.toString()) ~ ("requires_bank_id", requiresBankId)
 }
 
 /**

--- a/obp-api/src/main/scala/code/api/v4_0_0/OBPAPI4_0_0.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/OBPAPI4_0_0.scala
@@ -68,8 +68,7 @@ object OBPAPI4_0_0 extends OBPRestHelper with APIMethods130 with APIMethods140 w
 
   // if old version ResourceDoc objects have the same name endpoint with new version, omit old version ResourceDoc.
   def allResourceDocs = collectResourceDocs(OBPAPI3_1_0.allResourceDocs,
-                                            Implementations4_0_0.resourceDocs,
-                                            DynamicEntityHelper.doc, DynamicEndpointHelper.doc)
+                                            Implementations4_0_0.resourceDocs)
      .filterNot(it => it.partialFunctionName.matches(excludeEndpoints.mkString("|")))
     //TODO exclude two endpoints, after training we need add logic to exclude endpoints
 


### PR DESCRIPTION
Static ResourceDocs have a long cache time, dynamic ResourceDocs have a default 5 seconds cache time

### Jenkins job is passed, please merge this pull request. 

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/374)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/132/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/241/)