### PR TITLE
Add getAccountsByAccountRoutingRegex endpoint (for multi-currency accounts)

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -1,7 +1,6 @@
 package code.api.ResourceDocs1_4_0
 
 import java.util.Date
-
 import code.api.Constant._
 import code.api.Constant
 import code.api.UKOpenBanking.v2_0_0.JSONFactory_UKOpenBanking_200
@@ -16,7 +15,7 @@ import code.api.v3_0_0.JSONFactory300.createBranchJsonV300
 import code.api.v3_0_0.custom.JSONFactoryCustom300
 import code.api.v3_0_0.{LobbyJsonV330, _}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, CustomerWithAttributesJsonV310, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
-import code.api.v4_0_0.{APIInfoJson400, AccountBalanceJsonV400, AccountTagJSON, AccountTagsJSON, AccountsBalancesJsonV400, ApiCollectionEndpointJson400, ApiCollectionEndpointsJson400, ApiCollectionJson400, ApiCollectionsJson400, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, AttributeJsonV400, BalanceJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, CallLimitPostJsonV400, ChallengeAnswerJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, DoubleEntryTransactionJson, EnergySource400, HostedAt400, HostedBy400, IbanCheckerJsonV400, IbanDetailsJsonV400, JsonSchemaV400, JsonValidationV400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedCoreAccountJsonV400, ModeratedFirehoseAccountJsonV400, ModeratedFirehoseAccountsJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostApiCollectionEndpointJson400, PostApiCollectionJson400, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostRevokeGrantAccountAccessJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, Properties, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionBankAccountJson, TransactionRequestAttributeJsonV400, TransactionRequestAttributeResponseJson, TransactionRequestAttributesResponseJson, TransactionRequestBankAccountJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestRefundFrom, TransactionRequestRefundTo, TransactionRequestWithChargeJSON400, UpdateAccountJsonV400, UserLockStatusJson, When, XxxId}
+import code.api.v4_0_0.{APIInfoJson400, AccountBalanceJsonV400, AccountTagJSON, AccountTagsJSON, AccountsBalancesJsonV400, ApiCollectionEndpointJson400, ApiCollectionEndpointsJson400, ApiCollectionJson400, ApiCollectionsJson400, AttributeDefinitionJsonV400, AttributeDefinitionResponseJsonV400, AttributeDefinitionsResponseJsonV400, AttributeJsonV400, BalanceJsonV400, BankAccountRoutingJson, BankJson400, BanksJson400, CallLimitPostJsonV400, ChallengeAnswerJson400, ChallengeJsonV400, CounterpartiesJson400, CounterpartyJson400, CounterpartyWithMetadataJson400, CustomerAttributeJsonV400, CustomerAttributesResponseJson, DirectDebitJsonV400, DoubleEntryTransactionJson, EnergySource400, HostedAt400, HostedBy400, IbanCheckerJsonV400, IbanDetailsJsonV400, JsonSchemaV400, JsonValidationV400, LogoutLinkJson, ModeratedAccountJSON400, ModeratedAccountsJSON400, ModeratedCoreAccountJsonV400, ModeratedFirehoseAccountJsonV400, ModeratedFirehoseAccountsJsonV400, PostAccountAccessJsonV400, PostAccountTagJSON, PostApiCollectionEndpointJson400, PostApiCollectionJson400, PostCounterpartyJson400, PostCustomerPhoneNumberJsonV400, PostDirectDebitJsonV400, PostRevokeGrantAccountAccessJsonV400, PostStandingOrderJsonV400, PostViewJsonV400, Properties, RefundJson, RevokedJsonV400, SettlementAccountJson, SettlementAccountRequestJson, SettlementAccountResponseJson, SettlementAccountsJson, StandingOrderJsonV400, TransactionAttributeJsonV400, TransactionAttributeResponseJson, TransactionAttributesResponseJson, TransactionBankAccountJson, TransactionRequestAttributeJsonV400, TransactionRequestAttributeResponseJson, TransactionRequestAttributesResponseJson, TransactionRequestBankAccountJson, TransactionRequestBodyRefundJsonV400, TransactionRequestBodySEPAJsonV400, TransactionRequestReasonJsonV400, TransactionRequestRefundFrom, TransactionRequestRefundTo, TransactionRequestWithChargeJSON400, UpdateAccountJsonV400, UserLockStatusJson, When, XxxId}
 import code.api.v3_1_0.{AccountBalanceV310, AccountsBalancesV310Json, BadLoginStatusJson, ContactDetailsJson, InviteeJson, ObpApiLoopbackJson, PhysicalCardWithAttributesJsonV310, PutUpdateCustomerEmailJsonV310, _}
 import code.branches.Branches.{Branch, DriveUpString, LobbyString}
 import code.consent.ConsentStatus
@@ -3670,6 +3669,10 @@ object SwaggerDefinitionsJSON {
     account_routings = List(accountRoutingJsonV121),
     account_attributes = List(accountAttributeResponseJson),
     tags = List(accountTagJSON)
+  )
+
+  val moderatedAccountsJSON400 = ModeratedAccountsJSON400(
+    accounts = List(moderatedAccountJSON400)
   )
 
   val historicalTransactionAccountJsonV310 = HistoricalTransactionAccountJsonV310(

--- a/obp-api/src/main/scala/code/api/util/NewStyle.scala
+++ b/obp-api/src/main/scala/code/api/util/NewStyle.scala
@@ -290,6 +290,12 @@ object NewStyle {
       }
     }
 
+    def getAccountRoutingsByScheme(bankId: Option[BankId], scheme: String, callContext: Option[CallContext]) : OBPReturnType[List[BankAccountRouting]] = {
+      Connector.connector.vend.getAccountRoutingsByScheme(bankId: Option[BankId], scheme: String, callContext: Option[CallContext]) map { i =>
+        (unboxFullOrFail(i._1, callContext,s"$AccountRoutingNotFound Current scheme is $scheme, current bankId is $bankId", 404 ), i._2)
+      }
+    }
+
     def getBankAccountByAccountId(accountId : AccountId, callContext: Option[CallContext]) : OBPReturnType[BankAccount] = {
       Connector.connector.vend.getBankAccountByAccountId(accountId : AccountId, callContext: Option[CallContext]) map { i =>
         (unboxFullOrFail(i._1, callContext,s"$BankAccountNotFoundByAccountId Current account_id is $accountId", 404 ), i._2)

--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -2872,6 +2872,86 @@ trait APIMethods400 {
     }
 
     staticResourceDocs += ResourceDoc(
+      getAccountsByAccountRoutingRegex,
+      implementedInApiVersion,
+      nameOf(getAccountsByAccountRoutingRegex),
+      "POST",
+      "/management/accounts/account-routing-regex-query",
+      "Get Accounts by Account Routing Regex",
+      """This endpoint returns an array of accounts matching the provided routing scheme and the routing address regex.
+        |
+        |The `bank_id` field is optional.
+        |
+        |Example of account routing scheme: `IBAN`, `OBP`, `AccountNumber`, ...
+        |Example of account routing address regex: `DE175.*`, `55897106215-[A-Z]{3}`, ...
+        |
+        |This endpoint can be used to retrieve multiples accounts matching a same account routing address pattern.
+        |For example, if you want to link multiple accounts having different currencies, you can create an account
+        |with `123456789-EUR` as Account Number and an other account with `123456789-USD` as Account Number.
+        |So we can identify the Account Number as `123456789`, so to get all the accounts with the same account number
+        |and the different currencies, we can use this body in the request :
+        |
+        |```
+        |{
+        |   "bank_id": "BANK_ID",
+        |   "account_routing": {
+        |       "scheme": "AccountNumber",
+        |       "address": "123456789-[A-Z]{3}"
+        |   }
+        |}
+        |```
+        |
+        |This request will returns the accounts matching the routing address regex (`123456789-EUR` and `123456789-USD`).
+        |
+        |""".stripMargin,
+      bankAccountRoutingJson,
+      moderatedAccountsJSON400,
+      List(
+        $UserNotLoggedIn,
+        $BankNotFound,
+        $BankAccountNotFound,
+        $UserNoPermissionAccessView,
+        UnknownError),
+      List(apiTagAccount, apiTagNewStyle),
+    )
+    lazy val getAccountsByAccountRoutingRegex : OBPEndpoint = {
+      case "management" :: "accounts" :: "account-routing-regex-query" :: Nil JsonPost json -> _ => {
+        cc =>
+          val failMsg = s"$InvalidJsonFormat The Json body should be the $accountRoutingJsonV121"
+          for {
+            postJson <- NewStyle.function.tryons(failMsg, 400, cc.callContext) {
+              json.extract[BankAccountRoutingJson]
+            }
+
+            (accountRoutings, callContext) <- NewStyle.function.getAccountRoutingsByScheme(postJson.bank_id.map(BankId(_)),
+              postJson.account_routing.scheme, cc.callContext)
+
+            accountRoutingAddressRegex = postJson.account_routing.address.r
+            filteredAccountRoutings = accountRoutings.filter(accountRouting =>
+              accountRoutingAddressRegex.findFirstIn(accountRouting.accountRouting.address).isDefined)
+
+            user @Full(u) = cc.user
+
+            accountsJson <- Future.sequence(filteredAccountRoutings.map(accountRouting => for {
+              (account, callContext) <- NewStyle.function.getBankAccount(accountRouting.bankId, accountRouting.accountId, callContext)
+              view <- NewStyle.function.checkOwnerViewAccessAndReturnOwnerView(u, BankIdAccountId(account.bankId, account.accountId), callContext)
+              moderatedAccount <- NewStyle.function.moderatedBankAccountCore(account, view, user, callContext)
+              (accountAttributes, callContext) <- NewStyle.function.getAccountAttributesByAccount(
+                account.bankId,
+                account.accountId,
+                callContext: Option[CallContext])
+              availableViews = Views.views.vend.privateViewsUserCanAccessForAccount(cc.user.openOrThrowException("Exception user"), BankIdAccountId(account.bankId, account.accountId))
+              viewsAvailable = availableViews.map(JSONFactory.createViewJSON).sortBy(_.short_name)
+              tags = Tags.tags.vend.getTagsOnAccount(account.bankId, account.accountId)(view.viewId)
+            } yield createBankAccountJSON(moderatedAccount, viewsAvailable, accountAttributes, tags)
+            ))
+          } yield {
+            (ModeratedAccountsJSON400(accountsJson), HttpCode.`200`(callContext))
+          }
+      }
+    }
+
+    staticResourceDocs += ResourceDoc(
       getBankAccountsBalances,
       implementedInApiVersion,
       nameOf(getBankAccountsBalances),

--- a/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/JSONFactory4.0.0.scala
@@ -185,6 +185,10 @@ case class ModeratedAccountJSON400(
                                     tags: List[AccountTagJSON]
                                   )
 
+case class ModeratedAccountsJSON400(
+                                     accounts: List[ModeratedAccountJSON400]
+                                   )
+
 case class AccountTagJSON(
                            id : String,
                            value : String,

--- a/obp-api/src/main/scala/code/bankconnectors/Connector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/Connector.scala
@@ -486,6 +486,7 @@ trait Connector extends MdcLoggable {
   def getBankAccountByAccountId(accountId : AccountId, callContext: Option[CallContext]) : OBPReturnType[Box[BankAccount]]= Future{(Failure(setUnimplementedError),callContext)}
   def getBankAccountByIban(iban : String, callContext: Option[CallContext]) : OBPReturnType[Box[BankAccount]]= Future{(Failure(setUnimplementedError),callContext)}
   def getBankAccountByRouting(bankId: Option[BankId], scheme : String, address : String, callContext: Option[CallContext]) : Box[(BankAccount, Option[CallContext])]= Failure(setUnimplementedError)
+  def getAccountRoutingsByScheme(bankId: Option[BankId], scheme : String, callContext: Option[CallContext]): OBPReturnType[Box[List[BankAccountRouting]]] = Future{(Failure(setUnimplementedError),callContext)}
   def getAccountRouting(bankId: Option[BankId], scheme : String, address : String, callContext: Option[CallContext]) : Box[(BankAccountRouting, Option[CallContext])]= Failure(setUnimplementedError)
 
   def getBankAccounts(bankIdAccountIds: List[BankIdAccountId], callContext: Option[CallContext]) : OBPReturnType[Box[List[BankAccount]]]= Future{(Failure(setUnimplementedError), callContext)}

--- a/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -636,6 +636,15 @@ object LocalMappedConnector extends Connector with MdcLoggable {
     }
   }
 
+  override def getAccountRoutingsByScheme(bankId: Option[BankId], scheme: String, callContext: Option[CallContext]): OBPReturnType[Box[List[BankAccountRouting]]] = {
+    Future {
+      Full(bankId match {
+        case Some(bankId) => BankAccountRouting.findAll(By(BankAccountRouting.BankId, bankId.value), By(BankAccountRouting.AccountRoutingScheme, scheme))
+        case None => BankAccountRouting.findAll(By(BankAccountRouting.AccountRoutingScheme, scheme))
+      })
+    }.map((_, callContext))
+  }
+
   override def getAccountRouting(bankId: Option[BankId], scheme: String, address: String, callContext: Option[CallContext]): Box[(BankAccountRouting, Option[CallContext])] = {
     bankId match {
       case Some(bankId) =>


### PR DESCRIPTION
As discussed with you Simon, this endpoint allows to retrieve multiple accounts from an account routing address regex. With this implementation, we can keep the unique constraint on the account routing and propose a solution to link accounts having a same account number but different currencies.

Example of endpoint usage :
![image](https://user-images.githubusercontent.com/17991359/107245232-34656700-6a2f-11eb-92c3-1c1e66c1113b.png)


[Jenkins Tests](https://jenkins.tesobe.com/job/Build-OBP-API-guillaume-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/85/)