### PR TITLE
feature/dynamic_resourceDoc: add validation rule 

### DIFF
--- a/obp-api/src/main/scala/code/api/util/ExampleValue.scala
+++ b/obp-api/src/main/scala/code/api/util/ExampleValue.scala
@@ -413,7 +413,7 @@ object ExampleValue {
   lazy val partialFunctionNameExample = ConnectorField("getBanks", "partial function name")
   glossaryItems += makeGlossaryItem("DynamicResourceDoc.partialFunctionName", partialFunctionNameExample)
   
-  lazy val requestVerbExample = ConnectorField("GET", "This is the HTTP methods, eg: GET, POST, PUT, DELETE ")
+  lazy val requestVerbExample = ConnectorField("POST", "This is the HTTP methods, eg: GET, POST, PUT, DELETE ")
   glossaryItems += makeGlossaryItem("DynamicResourceDoc.requestVerb", requestVerbExample)
   
   lazy val requestUrlExample = ConnectorField("/my_user/MY_USER_ID", "The URL of the endpoint.")

--- a/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
+++ b/obp-api/src/main/scala/code/api/v4_0_0/APIMethods400.scala
@@ -7123,11 +7123,15 @@ trait APIMethods400 {
             jsonDynamicResourceDoc <- NewStyle.function.tryons(s"$InvalidJsonFormat The Json body should be the $JsonDynamicResourceDoc", 400, cc.callContext) {
               json.extract[JsonDynamicResourceDoc]
             }
-
             _ <- Helper.booleanToFuture(failMsg = s"""$InvalidJsonFormat The request_verb must be one of ["POST", "PUT", "GET", "DELETE"]""") {
               Set("POST", "PUT", "GET", "DELETE").contains(jsonDynamicResourceDoc.requestVerb)
             }
-
+            _ <- Helper.booleanToFuture(failMsg = s"""$InvalidJsonFormat When request_verb is "GET" or "DELETE", the example_request_body must be a blank String""") {
+              (jsonDynamicResourceDoc.requestVerb, jsonDynamicResourceDoc.exampleRequestBody) match {
+                case ("GET" | "DELETE", Some(requestBody)) => requestBody == JNothing
+                case _ => true
+              }
+            }
             _ = try {
               CompiledObjects(jsonDynamicResourceDoc.exampleRequestBody, jsonDynamicResourceDoc.successResponseBody, jsonDynamicResourceDoc.methodBody)
             } catch {
@@ -7180,6 +7184,13 @@ trait APIMethods400 {
 
             _ <- Helper.booleanToFuture(failMsg = s"""$InvalidJsonFormat The request_verb must be one of ["POST", "PUT", "GET", "DELETE"]""") {
               Set("POST", "PUT", "GET", "DELETE").contains(dynamicResourceDocBody.requestVerb)
+            }
+
+            _ <- Helper.booleanToFuture(failMsg = s"""$InvalidJsonFormat When request_verb is "GET" or "DELETE", the example_request_body must be a blank String""") {
+              (dynamicResourceDocBody.requestVerb, dynamicResourceDocBody.exampleRequestBody) match {
+                case ("GET" | "DELETE", Some(requestBody)) => requestBody == JNothing
+                case _ => true
+              }
             }
 
             _ = try {
@@ -7325,6 +7336,13 @@ trait APIMethods400 {
             }
             _ <- Helper.booleanToFuture(failMsg = s"""$InvalidJsonFormat The request_verb must be one of ["POST", "PUT", "GET", "DELETE"]""") {
                Set("POST", "PUT", "GET", "DELETE").contains(resourceDocFragment.requestVerb)
+            }
+
+            _ <- Helper.booleanToFuture(failMsg = s"""$InvalidJsonFormat When request_verb is "GET" or "DELETE", the example_request_body must be a blank String""") {
+              (resourceDocFragment.requestVerb, resourceDocFragment.exampleRequestBody) match {
+                case ("GET" | "DELETE", Some(requestBody)) => requestBody == JNothing
+                case _ => true
+              }
             }
 
             code = DynamicEndpointCodeGenerator.buildTemplate(resourceDocFragment)


### PR DESCRIPTION
If request_verb is "GET" or "DELETE", the example_request_body must be a blank string

### Jenkins job is passed, please merge this pull request. 

----------------------
Jenkins jobs passed:
[JDK 8](https://jenkins.tesobe.com/job/Build-obp-api-shuang/405)
[JDK 11](https://jenkins.tesobe.com/view/-Build/job/Build-OBP-API-shuang-jdk11/166/)
[JDK 13](https://jenkins.tesobe.com/job/Build-OBP-API-shuang-jdk13_UNLICENSED-JDK-NOT-FOR-DEPLOYMENT/278/)