### PR TITLE
change example ID in accountsHeld swagger definition to valid UUID

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/SwaggerDefinitionsJSON.scala
@@ -3639,7 +3639,7 @@ object SwaggerDefinitionsJSON {
   
   
   val accountHeldJson  = AccountHeldJson(
-    id = "12314",
+    id = "7b97bd26-583b-4c3b-8282-55ea9d934aad",
     label = "My Account",
     bank_id=  "123",
     number = "123",


### PR DESCRIPTION
The example ID was not a valid UUID, which was causing problems trying to integrate with Weaviate (GraphQL) database