### PR TITLE
reafactor/ ci: expand branch pattern to include all branches

### DIFF
--- a/.github/workflows/build_container_non_develop_branch.yml
+++ b/.github/workflows/build_container_non_develop_branch.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "*"
+      - '**'
       - "!develop"
 
 env:


### PR DESCRIPTION
The previous branch pattern excluded some branches unintentionally. Adding '**' ensures all branches are matched except 'develop'.