### PR TITLE
refactor/(bankconnectors): Reorganize connector method classification…

### DIFF
--- a/obp-api/src/main/scala/code/bankconnectors/generator/ConnectorBuilderUtil.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/generator/ConnectorBuilderUtil.scala
@@ -440,6 +440,9 @@ object ConnectorBuilderUtil {
       "getBankAccountBalanceById",
       "createOrUpdateBankAccountBalance",
       "deleteBankAccountBalance",
+      "checkExternalUserCredentials",// this is not a standard connector method.
+      "checkExternalUserExists", // this is not a standard connector method. 
+      "getCurrentFxRate", // this is speical method
     ).distinct
 
   /**
@@ -452,7 +455,7 @@ object ConnectorBuilderUtil {
     "createOrUpdateAtm",
     "createOrUpdateProduct",
     "createOrUpdateFXRate",
-    "getCurrentFxRate",
+//    "getCurrentFxRate",
     "getCounterpartyFromTransaction",
     "getCounterpartiesFromTransaction",
   ).distinct
@@ -468,8 +471,6 @@ object ConnectorBuilderUtil {
     "createDynamicEndpoint",
     "getDynamicEndpoint",
     "getDynamicEndpoints",
-    "checkExternalUserCredentials",// this is not a standard connector method.
-    "checkExternalUserExists", // this is not a standard connector method. 
     "getBankAccountByRoutingLegacy",
     "getAccountRoutingsByScheme",
     "getAccountRouting",

--- a/obp-api/src/main/scala/code/bankconnectors/storedprocedure/MSsqlStoredProcedure.sql
+++ b/obp-api/src/main/scala/code/bankconnectors/storedprocedure/MSsqlStoredProcedure.sql
@@ -1,4 +1,4 @@
--- auto generated MS sql server procedures script, create on 2024-10-30T12:20:39Z
+-- auto generated MS sql server procedures script, create on 2026-02-10T14:42:15Z
 
 -- drop procedure obp_get_adapter_info
 DROP PROCEDURE IF EXISTS obp_get_adapter_info;
@@ -170,7 +170,7 @@ this is example of parameter @outbound_json
          "name":"NAME",
          "version":"version string",
          "git_commit":"git_commit",
-         "date":"date String"
+         "date":"1100-01-01T01:01:01.000Z"
        }
      }'
 	);
@@ -1407,7 +1407,7 @@ this is example of parameter @outbound_json
        "transactionRequestId":"8138a7e4-6d02-40e3-a129-0b2bf89de9f1",
        "scaMethod":"SMS",
        "scaStatus":"received",
-       "consentId":"",
+       "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
        "authenticationMethodId":"string"
      }'
 */
@@ -1447,12 +1447,15 @@ this is example of parameter @outbound_json
            "salt":"string",
            "successful":true,
            "challengeType":"",
-           "consentId":"",
+           "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
            "basketId":"",
            "scaMethod":"SMS",
            "scaStatus":"received",
            "authenticationMethodId":"string",
-           "attemptCounter":123
+           "attemptCounter":123,
+           "challengePurpose":"string",
+           "challengeContextHash":"string",
+           "challengeContextStructure":"string"
          }
        ]
      }'
@@ -1597,7 +1600,7 @@ this is example of parameter @outbound_json
        "transactionRequestId":"8138a7e4-6d02-40e3-a129-0b2bf89de9f1",
        "scaMethod":"SMS",
        "scaStatus":"received",
-       "consentId":"",
+       "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
        "basketId":"",
        "authenticationMethodId":"string"
      }'
@@ -1638,12 +1641,15 @@ this is example of parameter @outbound_json
            "salt":"string",
            "successful":true,
            "challengeType":"",
-           "consentId":"",
+           "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
            "basketId":"",
            "scaMethod":"SMS",
            "scaStatus":"received",
            "authenticationMethodId":"string",
-           "attemptCounter":123
+           "attemptCounter":123,
+           "challengePurpose":"string",
+           "challengeContextHash":"string",
+           "challengeContextStructure":"string"
          }
        ]
      }'
@@ -2117,7 +2123,7 @@ this is example of parameter @outbound_json
          }
        },
        "transactionRequestId":"8138a7e4-6d02-40e3-a129-0b2bf89de9f1",
-       "consentId":"",
+       "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
        "challengeId":"123chaneid13-6d02-40e3-a129-0b2bf89de9f0",
        "hashOfSuppliedAnswer":"a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"
      }'
@@ -2157,12 +2163,15 @@ this is example of parameter @outbound_json
          "salt":"string",
          "successful":true,
          "challengeType":"",
-         "consentId":"",
+         "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
          "basketId":"",
          "scaMethod":"SMS",
          "scaStatus":"received",
          "authenticationMethodId":"string",
-         "attemptCounter":123
+         "attemptCounter":123,
+         "challengePurpose":"string",
+         "challengeContextHash":"string",
+         "challengeContextStructure":"string"
        }
      }'
 	);
@@ -2300,7 +2309,7 @@ this is example of parameter @outbound_json
          }
        },
        "transactionRequestId":"8138a7e4-6d02-40e3-a129-0b2bf89de9f1",
-       "consentId":"",
+       "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
        "basketId":"",
        "challengeId":"123chaneid13-6d02-40e3-a129-0b2bf89de9f0",
        "hashOfSuppliedAnswer":"a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"
@@ -2341,12 +2350,15 @@ this is example of parameter @outbound_json
          "salt":"string",
          "successful":true,
          "challengeType":"",
-         "consentId":"",
+         "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
          "basketId":"",
          "scaMethod":"SMS",
          "scaStatus":"received",
          "authenticationMethodId":"string",
-         "attemptCounter":123
+         "attemptCounter":123,
+         "challengePurpose":"string",
+         "challengeContextHash":"string",
+         "challengeContextStructure":"string"
        }
      }'
 	);
@@ -2484,7 +2496,7 @@ this is example of parameter @outbound_json
          }
        },
        "transactionRequestId":"8138a7e4-6d02-40e3-a129-0b2bf89de9f1",
-       "consentId":"",
+       "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
        "challengeId":"123chaneid13-6d02-40e3-a129-0b2bf89de9f0",
        "suppliedAnswer":"123456",
        "suppliedAnswerType":"PLAIN_TEXT_VALUE"
@@ -2525,12 +2537,15 @@ this is example of parameter @outbound_json
          "salt":"string",
          "successful":true,
          "challengeType":"",
-         "consentId":"",
+         "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
          "basketId":"",
          "scaMethod":"SMS",
          "scaStatus":"received",
          "authenticationMethodId":"string",
-         "attemptCounter":123
+         "attemptCounter":123,
+         "challengePurpose":"string",
+         "challengeContextHash":"string",
+         "challengeContextStructure":"string"
        }
      }'
 	);
@@ -2668,7 +2683,7 @@ this is example of parameter @outbound_json
          }
        },
        "transactionRequestId":"8138a7e4-6d02-40e3-a129-0b2bf89de9f1",
-       "consentId":"",
+       "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
        "basketId":"",
        "challengeId":"123chaneid13-6d02-40e3-a129-0b2bf89de9f0",
        "suppliedAnswer":"123456",
@@ -2710,12 +2725,15 @@ this is example of parameter @outbound_json
          "salt":"string",
          "successful":true,
          "challengeType":"",
-         "consentId":"",
+         "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
          "basketId":"",
          "scaMethod":"SMS",
          "scaStatus":"received",
          "authenticationMethodId":"string",
-         "attemptCounter":123
+         "attemptCounter":123,
+         "challengePurpose":"string",
+         "challengeContextHash":"string",
+         "challengeContextStructure":"string"
        }
      }'
 	);
@@ -2891,12 +2909,15 @@ this is example of parameter @outbound_json
            "salt":"string",
            "successful":true,
            "challengeType":"",
-           "consentId":"",
+           "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
            "basketId":"",
            "scaMethod":"SMS",
            "scaStatus":"received",
            "authenticationMethodId":"string",
-           "attemptCounter":123
+           "attemptCounter":123,
+           "challengePurpose":"string",
+           "challengeContextHash":"string",
+           "challengeContextStructure":"string"
          }
        ]
      }'
@@ -3034,7 +3055,7 @@ this is example of parameter @outbound_json
            ]
          }
        },
-       "consentId":""
+       "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947"
      }'
 */
 
@@ -3073,12 +3094,15 @@ this is example of parameter @outbound_json
            "salt":"string",
            "successful":true,
            "challengeType":"",
-           "consentId":"",
+           "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
            "basketId":"",
            "scaMethod":"SMS",
            "scaStatus":"received",
            "authenticationMethodId":"string",
-           "attemptCounter":123
+           "attemptCounter":123,
+           "challengePurpose":"string",
+           "challengeContextHash":"string",
+           "challengeContextStructure":"string"
          }
        ]
      }'
@@ -3255,12 +3279,15 @@ this is example of parameter @outbound_json
            "salt":"string",
            "successful":true,
            "challengeType":"",
-           "consentId":"",
+           "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
            "basketId":"",
            "scaMethod":"SMS",
            "scaStatus":"received",
            "authenticationMethodId":"string",
-           "attemptCounter":123
+           "attemptCounter":123,
+           "challengePurpose":"string",
+           "challengeContextHash":"string",
+           "challengeContextStructure":"string"
          }
        ]
      }'
@@ -3436,12 +3463,15 @@ this is example of parameter @outbound_json
          "salt":"string",
          "successful":true,
          "challengeType":"",
-         "consentId":"",
+         "consentId":"9d429899-24f5-42c8-8565-943ffa6a7947",
          "basketId":"",
          "scaMethod":"SMS",
          "scaStatus":"received",
          "authenticationMethodId":"string",
-         "attemptCounter":123
+         "attemptCounter":123,
+         "challengePurpose":"string",
+         "challengeContextHash":"string",
+         "challengeContextStructure":"string"
        }
      }'
 	);
@@ -3981,6 +4011,371 @@ GO
  
 
 
+-- drop procedure obp_check_external_user_credentials
+DROP PROCEDURE IF EXISTS obp_check_external_user_credentials;
+GO
+-- create procedure obp_check_external_user_credentials
+CREATE PROCEDURE obp_check_external_user_credentials
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "username":"felixsmith",
+       "password":"password"
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":{
+         "aud":"String",
+         "exp":"60",
+         "iat":"60",
+         "iss":"String",
+         "sub":"felixsmith",
+         "azp":"string",
+         "email":"felixsmith@example.com",
+         "emailVerified":"String",
+         "name":"felixsmith",
+         "userAuthContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       }
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_check_external_user_exists
+DROP PROCEDURE IF EXISTS obp_check_external_user_exists;
+GO
+-- create procedure obp_check_external_user_exists
+CREATE PROCEDURE obp_check_external_user_exists
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "username":"felixsmith"
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":{
+         "aud":"String",
+         "exp":"60",
+         "iat":"60",
+         "iss":"String",
+         "sub":"felixsmith",
+         "azp":"string",
+         "email":"felixsmith@example.com",
+         "emailVerified":"String",
+         "name":"felixsmith",
+         "userAuthContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       }
+     }'
+	);
+GO
+
+ 
+ 
+
+
 -- drop procedure obp_get_bank_account_by_iban
 DROP PROCEDURE IF EXISTS obp_get_bank_account_by_iban;
 GO
@@ -4304,7 +4699,7 @@ this is example of parameter @outbound_json
        "bankId":{
          "value":"gh.29.uk"
        },
-       "scheme":"scheme value",
+       "scheme":"OBP",
        "address":""
      }'
 */
@@ -4953,7 +5348,7 @@ this is example of parameter @outbound_json
                "currency":"EUR",
                "amount":"50.89"
              },
-             "balanceType":"string"
+             "balanceType":"openingBooked"
            }
          ],
          "overallBalance":{
@@ -5346,6 +5741,385 @@ GO
  
 
 
+-- drop procedure obp_get_accounts_held
+DROP PROCEDURE IF EXISTS obp_get_accounts_held;
+GO
+-- create procedure obp_get_accounts_held
+CREATE PROCEDURE obp_get_accounts_held
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "bankId":{
+         "value":"gh.29.uk"
+       },
+       "user":{
+         "userPrimaryKey":{
+           "value":123
+         },
+         "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+         "idGivenByProvider":"string",
+         "provider":"ETHEREUM",
+         "emailAddress":"",
+         "name":"felixsmith",
+         "createdByConsentId":"string",
+         "createdByUserInvitationId":"string",
+         "isDeleted":true,
+         "lastMarketingAgreementSignedDate":"2020-01-27T00:00:00Z"
+       }
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":[
+         {
+           "bankId":{
+             "value":"gh.29.uk"
+           },
+           "accountId":{
+             "value":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0"
+           }
+         }
+       ]
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_get_accounts_held_by_user
+DROP PROCEDURE IF EXISTS obp_get_accounts_held_by_user;
+GO
+-- create procedure obp_get_accounts_held_by_user
+CREATE PROCEDURE obp_get_accounts_held_by_user
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "user":{
+         "userPrimaryKey":{
+           "value":123
+         },
+         "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+         "idGivenByProvider":"string",
+         "provider":"ETHEREUM",
+         "emailAddress":"",
+         "name":"felixsmith",
+         "createdByConsentId":"string",
+         "createdByUserInvitationId":"string",
+         "isDeleted":true,
+         "lastMarketingAgreementSignedDate":"2020-01-27T00:00:00Z"
+       }
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":[
+         {
+           "bankId":{
+             "value":"gh.29.uk"
+           },
+           "accountId":{
+             "value":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0"
+           }
+         }
+       ]
+     }'
+	);
+GO
+
+ 
+ 
+
+
 -- drop procedure obp_check_bank_account_exists
 DROP PROCEDURE IF EXISTS obp_check_bank_account_exists;
 GO
@@ -5710,14 +6484,14 @@ this is example of parameter @outbound_json
        "data":{
          "createdByUserId":"",
          "name":"ACCOUNT_MANAGEMENT_FEE",
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
          "currency":"EUR",
          "thisBankId":"",
          "thisAccountId":"",
          "thisViewId":"",
          "counterpartyId":"9fg8a7e4-6d02-40e3-a129-0b2bf89de8uh",
-         "otherAccountRoutingScheme":"",
-         "otherAccountRoutingAddress":"",
+         "otherAccountRoutingScheme":"IBAN",
+         "otherAccountRoutingAddress":"DE89370400440532013000",
          "otherAccountSecondaryRoutingScheme":"",
          "otherAccountSecondaryRoutingAddress":"",
          "otherBankRoutingScheme":"",
@@ -5902,14 +6676,14 @@ this is example of parameter @outbound_json
        "data":{
          "createdByUserId":"",
          "name":"ACCOUNT_MANAGEMENT_FEE",
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
          "currency":"EUR",
          "thisBankId":"",
          "thisAccountId":"",
          "thisViewId":"",
          "counterpartyId":"9fg8a7e4-6d02-40e3-a129-0b2bf89de8uh",
-         "otherAccountRoutingScheme":"",
-         "otherAccountRoutingAddress":"",
+         "otherAccountRoutingScheme":"IBAN",
+         "otherAccountRoutingAddress":"DE89370400440532013000",
          "otherAccountSecondaryRoutingScheme":"",
          "otherAccountSecondaryRoutingAddress":"",
          "otherBankRoutingScheme":"",
@@ -6092,14 +6866,14 @@ this is example of parameter @outbound_json
        "data":{
          "createdByUserId":"",
          "name":"ACCOUNT_MANAGEMENT_FEE",
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
          "currency":"EUR",
          "thisBankId":"",
          "thisAccountId":"",
          "thisViewId":"",
          "counterpartyId":"9fg8a7e4-6d02-40e3-a129-0b2bf89de8uh",
-         "otherAccountRoutingScheme":"",
-         "otherAccountRoutingAddress":"",
+         "otherAccountRoutingScheme":"IBAN",
+         "otherAccountRoutingAddress":"DE89370400440532013000",
          "otherAccountSecondaryRoutingScheme":"",
          "otherAccountSecondaryRoutingAddress":"",
          "otherBankRoutingScheme":"",
@@ -6288,14 +7062,14 @@ this is example of parameter @outbound_json
        "data":{
          "createdByUserId":"",
          "name":"ACCOUNT_MANAGEMENT_FEE",
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
          "currency":"EUR",
          "thisBankId":"",
          "thisAccountId":"",
          "thisViewId":"",
          "counterpartyId":"9fg8a7e4-6d02-40e3-a129-0b2bf89de8uh",
-         "otherAccountRoutingScheme":"",
-         "otherAccountRoutingAddress":"",
+         "otherAccountRoutingScheme":"IBAN",
+         "otherAccountRoutingAddress":"DE89370400440532013000",
          "otherAccountSecondaryRoutingScheme":"",
          "otherAccountSecondaryRoutingAddress":"",
          "otherBankRoutingScheme":"",
@@ -6487,14 +7261,14 @@ this is example of parameter @outbound_json
          {
            "createdByUserId":"",
            "name":"ACCOUNT_MANAGEMENT_FEE",
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
            "currency":"EUR",
            "thisBankId":"",
            "thisAccountId":"",
            "thisViewId":"",
            "counterpartyId":"9fg8a7e4-6d02-40e3-a129-0b2bf89de8uh",
-           "otherAccountRoutingScheme":"",
-           "otherAccountRoutingAddress":"",
+           "otherAccountRoutingScheme":"IBAN",
+           "otherAccountRoutingAddress":"DE89370400440532013000",
            "otherAccountSecondaryRoutingScheme":"",
            "otherAccountSecondaryRoutingAddress":"",
            "otherBankRoutingScheme":"",
@@ -6735,6 +7509,8 @@ this is example of parameter @outbound_json
              "thisAccountId":{
                "value":""
              },
+             "otherAccountRoutingScheme":"IBAN",
+             "otherAccountRoutingAddress":"DE89370400440532013000",
              "isBeneficiary":false
            },
            "transactionType":"DEBIT",
@@ -6743,7 +7519,8 @@ this is example of parameter @outbound_json
            "description":"The piano lession-Invoice No:68",
            "startDate":"2019-09-07T00:00:00Z",
            "finishDate":"2019-09-08T00:00:00Z",
-           "balance":"10"
+           "balance":"10",
+           "status":" COMPLETED"
          }
        ]
      }'
@@ -6889,8 +7666,8 @@ this is example of parameter @outbound_json
        },
        "limit":100,
        "offset":100,
-       "fromDate":"",
-       "toDate":""
+       "fromDate":"1100-01-01T01:01:01.000Z",
+       "toDate":"1100-01-01T01:01:01.000Z"
      }'
 */
 
@@ -6973,15 +7750,15 @@ this is example of parameter @outbound_json
              },
              "otherBankRoutingScheme":"",
              "otherBankRoutingAddress":"",
-             "otherAccountRoutingScheme":"",
-             "otherAccountRoutingAddress":"",
+             "otherAccountRoutingScheme":"IBAN",
+             "otherAccountRoutingAddress":"DE89370400440532013000",
              "otherAccountProvider":"",
              "isBeneficiary":false
            },
            "transactionType":"DEBIT",
            "amount":"10.12",
            "currency":"EUR",
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
            "startDate":"2020-01-27T00:00:00Z",
            "finishDate":"2020-01-27T00:00:00Z",
            "balance":"10"
@@ -7210,6 +7987,8 @@ this is example of parameter @outbound_json
            "thisAccountId":{
              "value":""
            },
+           "otherAccountRoutingScheme":"IBAN",
+           "otherAccountRoutingAddress":"DE89370400440532013000",
            "isBeneficiary":false
          },
          "transactionType":"DEBIT",
@@ -7218,7 +7997,8 @@ this is example of parameter @outbound_json
          "description":"The piano lession-Invoice No:68",
          "startDate":"2019-09-07T00:00:00Z",
          "finishDate":"2019-09-08T00:00:00Z",
-         "balance":"10"
+         "balance":"10",
+         "status":" COMPLETED"
        }
      }'
 	);
@@ -8053,8 +8833,8 @@ this is example of parameter @outbound_json
        },
        "limit":100,
        "offset":100,
-       "fromDate":"",
-       "toDate":""
+       "fromDate":"1100-01-01T01:01:01.000Z",
+       "toDate":"1100-01-01T01:01:01.000Z"
      }'
 */
 
@@ -8936,10 +9716,10 @@ this is example of parameter @outbound_json
            "currency":"EUR",
            "amount":"10.12"
          },
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here."
        },
        "amount":"10.12",
-       "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+       "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
        "transactionRequestType":{
          "value":"SEPA"
        },
@@ -9375,7 +10155,7 @@ this is example of parameter @outbound_json
            "currency":"EUR",
            "amount":"10.12"
          },
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here."
        },
        "detailsPlain":"string",
        "chargePolicy":"SHARED",
@@ -9424,7 +10204,7 @@ this is example of parameter @outbound_json
              "currency":"EUR",
              "amount":"10.12"
            },
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here."
          },
          "transaction_ids":"string",
          "status":"",
@@ -9675,7 +10455,7 @@ this is example of parameter @outbound_json
            "currency":"EUR",
            "amount":"10.12"
          },
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here."
        },
        "detailsPlain":"string",
        "chargePolicy":"SHARED",
@@ -9687,7 +10467,7 @@ this is example of parameter @outbound_json
            "documentNumber":"",
            "amount":"10.12",
            "currency":"EUR",
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here."
          }
        ]
      }'
@@ -9733,7 +10513,7 @@ this is example of parameter @outbound_json
              "currency":"EUR",
              "amount":"10.12"
            },
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here."
          },
          "transaction_ids":"string",
          "status":"",
@@ -10941,7 +11721,7 @@ this is example of parameter @outbound_json
                "currency":"EUR",
                "amount":"10.12"
              },
-             "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+             "description":"Description of the object. Maximum length is 2000. It can be any characters here."
            },
            "transaction_ids":"string",
            "status":"",
@@ -11142,7 +11922,7 @@ this is example of parameter @outbound_json
              "currency":"EUR",
              "amount":"10.12"
            },
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here."
          },
          "transaction_ids":"string",
          "status":"",
@@ -11565,7 +12345,7 @@ this is example of parameter @outbound_json
              "currency":"EUR",
              "amount":"10.12"
            },
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here."
          },
          "transaction_ids":"string",
          "status":"",
@@ -11627,7 +12407,7 @@ this is example of parameter @outbound_json
              "currency":"EUR",
              "amount":"10.12"
            },
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here."
          },
          "transaction_ids":"string",
          "status":"",
@@ -12428,7 +13208,7 @@ this is example of parameter @outbound_json
            "moreInfoUrl":"www.example.com/abc",
            "termsAndConditionsUrl":"www.example.com/xyz",
            "details":"",
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
            "meta":{
              "license":{
                "id":"ODbL-1.0",
@@ -12624,7 +13404,7 @@ this is example of parameter @outbound_json
          "moreInfoUrl":"www.example.com/abc",
          "termsAndConditionsUrl":"www.example.com/xyz",
          "details":"",
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
          "meta":{
            "license":{
              "id":"ODbL-1.0",
@@ -13067,8 +13847,8 @@ this is example of parameter @outbound_json
        },
        "limit":100,
        "offset":100,
-       "fromDate":"",
-       "toDate":""
+       "fromDate":"1100-01-01T01:01:01.000Z",
+       "toDate":"1100-01-01T01:01:01.000Z"
      }'
 */
 
@@ -13453,7 +14233,10 @@ this is example of parameter @outbound_json
            "\"de\""
          ],
          "services":[
-           ""
+           "{\"CY\":\"PS_010\"",
+           "\"PS_020\"",
+           "\"PS_03C\"",
+           "\"PS_04C\"}"
          ],
          "accessibilityFeatures":[
            "\"ATAC\"",
@@ -13620,8 +14403,8 @@ this is example of parameter @outbound_json
        },
        "limit":100,
        "offset":100,
-       "fromDate":"",
-       "toDate":""
+       "fromDate":"1100-01-01T01:01:01.000Z",
+       "toDate":"1100-01-01T01:01:01.000Z"
      }'
 */
 
@@ -13710,7 +14493,10 @@ this is example of parameter @outbound_json
              "\"de\""
            ],
            "services":[
-             ""
+             "{\"CY\":\"PS_010\"",
+             "\"PS_020\"",
+             "\"PS_03C\"",
+             "\"PS_04C\"}"
            ],
            "accessibilityFeatures":[
              "\"ATAC\"",
@@ -13738,6 +14524,185 @@ this is example of parameter @outbound_json
            "phone":""
          }
        ]
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_get_current_fx_rate
+DROP PROCEDURE IF EXISTS obp_get_current_fx_rate;
+GO
+-- create procedure obp_get_current_fx_rate
+CREATE PROCEDURE obp_get_current_fx_rate
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "bankId":{
+         "value":"gh.29.uk"
+       },
+       "fromCurrencyCode":"",
+       "toCurrencyCode":"EUR"
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":{
+         "bankId":{
+           "value":"gh.29.uk"
+         },
+         "fromCurrencyCode":"",
+         "toCurrencyCode":"EUR",
+         "conversionValue":100.0,
+         "inverseConversionValue":50.0,
+         "effectiveDate":"2020-01-27T00:00:00Z"
+       }
      }'
 	);
 GO
@@ -13972,7 +14937,7 @@ this is example of parameter @outbound_json
              "currency":"EUR",
              "amount":"10.12"
            },
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here."
          },
          "transaction_ids":"string",
          "status":"",
@@ -14215,14 +15180,14 @@ this is example of parameter @outbound_json
        "toCounterparty":{
          "createdByUserId":"",
          "name":"John Smith Ltd.",
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
          "currency":"EUR",
          "thisBankId":"",
          "thisAccountId":"",
          "thisViewId":"",
          "counterpartyId":"9fg8a7e4-6d02-40e3-a129-0b2bf89de8uh",
-         "otherAccountRoutingScheme":"OBP",
-         "otherAccountRoutingAddress":"36f8a9e6-c2b1-407a-8bd0-421b7119307e",
+         "otherAccountRoutingScheme":"IBAN",
+         "otherAccountRoutingAddress":"DE89370400440532013000",
          "otherAccountSecondaryRoutingScheme":"IBAN",
          "otherAccountSecondaryRoutingAddress":"DE89370400440532013000",
          "otherBankRoutingScheme":"OBP",
@@ -14242,7 +15207,7 @@ this is example of parameter @outbound_json
            "currency":"EUR",
            "amount":"10.12"
          },
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here."
        },
        "transactionRequestType":{
          "value":"SEPA"
@@ -14507,14 +15472,14 @@ this is example of parameter @outbound_json
        "toCounterparty":{
          "createdByUserId":"",
          "name":"John Smith Ltd.",
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
          "currency":"EUR",
          "thisBankId":"",
          "thisAccountId":"",
          "thisViewId":"",
          "counterpartyId":"9fg8a7e4-6d02-40e3-a129-0b2bf89de8uh",
-         "otherAccountRoutingScheme":"OBP",
-         "otherAccountRoutingAddress":"36f8a9e6-c2b1-407a-8bd0-421b7119307e",
+         "otherAccountRoutingScheme":"IBAN",
+         "otherAccountRoutingAddress":"DE89370400440532013000",
          "otherAccountSecondaryRoutingScheme":"IBAN",
          "otherAccountSecondaryRoutingAddress":"DE89370400440532013000",
          "otherBankRoutingScheme":"OBP",
@@ -14537,7 +15502,7 @@ this is example of parameter @outbound_json
            "currency":"EUR",
            "amount":"10.12"
          },
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here."
        },
        "detailsPlain":"string",
        "chargePolicy":"SHARED"
@@ -14584,7 +15549,7 @@ this is example of parameter @outbound_json
              "currency":"EUR",
              "amount":"10.12"
            },
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here."
          },
          "transaction_ids":"string",
          "status":"",
@@ -14752,7 +15717,7 @@ this is example of parameter @outbound_json
              "currency":"EUR",
              "amount":"10.12"
            },
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here."
          },
          "transaction_ids":"string",
          "status":"",
@@ -14777,7 +15742,7 @@ this is example of parameter @outbound_json
            "documentNumber":"",
            "amount":"10.12",
            "currency":"EUR",
-           "description":"This an optional field. Maximum length is 2000. It can be any characters here."
+           "description":"Description of the object. Maximum length is 2000. It can be any characters here."
          }
        ]
      }'
@@ -15306,14 +16271,14 @@ this is example of parameter @outbound_json
          }
        },
        "name":"ACCOUNT_MANAGEMENT_FEE",
-       "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+       "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
        "currency":"EUR",
        "createdByUserId":"",
        "thisBankId":"",
        "thisAccountId":"",
        "thisViewId":"",
-       "otherAccountRoutingScheme":"",
-       "otherAccountRoutingAddress":"",
+       "otherAccountRoutingScheme":"IBAN",
+       "otherAccountRoutingAddress":"DE89370400440532013000",
        "otherAccountSecondaryRoutingScheme":"",
        "otherAccountSecondaryRoutingAddress":"",
        "otherBankRoutingScheme":"",
@@ -15359,14 +16324,14 @@ this is example of parameter @outbound_json
        "data":{
          "createdByUserId":"",
          "name":"ACCOUNT_MANAGEMENT_FEE",
-         "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+         "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
          "currency":"EUR",
          "thisBankId":"",
          "thisAccountId":"",
          "thisViewId":"",
          "counterpartyId":"9fg8a7e4-6d02-40e3-a129-0b2bf89de8uh",
-         "otherAccountRoutingScheme":"",
-         "otherAccountRoutingAddress":"",
+         "otherAccountRoutingScheme":"IBAN",
+         "otherAccountRoutingAddress":"DE89370400440532013000",
          "otherAccountSecondaryRoutingScheme":"",
          "otherAccountSecondaryRoutingAddress":"",
          "otherBankRoutingScheme":"",
@@ -18381,8 +19346,8 @@ this is example of parameter @outbound_json
        },
        "limit":100,
        "offset":100,
-       "fromDate":"",
-       "toDate":""
+       "fromDate":"1100-01-01T01:01:01.000Z",
+       "toDate":"1100-01-01T01:01:01.000Z"
      }'
 */
 
@@ -18825,13 +19790,13 @@ this is example of parameter @outbound_json
            "account_type":"string",
            "account_routings":[
              {
-               "scheme":"scheme value",
+               "scheme":"OBP",
                "address":""
              }
            ],
            "branch_routings":[
              {
-               "scheme":"scheme value",
+               "scheme":"OBP",
                "address":""
              }
            ]
@@ -20069,6 +21034,185 @@ this is example of parameter @outbound_json
          "value":"5987953",
          "isActive":false
        }
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_get_bank_attributes_by_bank
+DROP PROCEDURE IF EXISTS obp_get_bank_attributes_by_bank;
+GO
+-- create procedure obp_get_bank_attributes_by_bank
+CREATE PROCEDURE obp_get_bank_attributes_by_bank
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "bankId":{
+         "value":"gh.29.uk"
+       }
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":[
+         {
+           "bankId":{
+             "value":"gh.29.uk"
+           },
+           "bankAttributeId":"string",
+           "attributeType":"STRING",
+           "name":"ACCOUNT_MANAGEMENT_FEE",
+           "value":"5987953",
+           "isActive":false
+         }
+       ]
      }'
 	);
 GO
@@ -25184,7 +26328,7 @@ this is example of parameter @outbound_json
              "moreInfoUrl":"www.example.com/abc",
              "termsAndConditionsUrl":"www.example.com/xyz",
              "details":"",
-             "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+             "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
              "meta":{
                "license":{
                  "id":"ODbL-1.0",
@@ -27725,7 +28869,7 @@ this is example of parameter @outbound_json
        "completed":"2020-01-27T00:00:00Z",
        "amount":"10.12",
        "currency":"EUR",
-       "description":"This an optional field. Maximum length is 2000. It can be any characters here.",
+       "description":"Description of the object. Maximum length is 2000. It can be any characters here.",
        "transactionRequestType":"SEPA",
        "chargePolicy":"SHARED"
      }'
@@ -28081,6 +29225,1289 @@ this is example of parameter @outbound_json
          }
        },
        "customerAttributeId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh"
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":true
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_get_regulated_entities
+DROP PROCEDURE IF EXISTS obp_get_regulated_entities;
+GO
+-- create procedure obp_get_regulated_entities
+CREATE PROCEDURE obp_get_regulated_entities
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       }
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":[
+         {
+           "entityId":"0af807d7-3c39-43ef-9712-82bcfde1b9ca",
+           "certificateAuthorityCaOwnerId":"CY_CBC",
+           "entityName":"EXAMPLE COMPANY LTD",
+           "entityCode":"PSD_PICY_CBC!12345",
+           "entityCertificatePublicKey":"MIICsjCCAZqgAwIBAgIGAYwQ62R0MA0GCSqGSIb3DQEBCwUAMBoxGDAWBgNVBAMMD2FwcC5leGFtcGxlLmNvbTAeFw0yMzExMjcxMzE1MTFaFw0yNTExMjYxMzE1MTFaMBoxGDAWBgNVBAMMD2FwcC5leGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK9WIodZHWzKyCcf9YfWEhPURbfO6zKuMqzHN27GdqHsVVEGxP4F/J4mso+0ENcRr6ur4u81iREaVdCc40rHDHVJNEtniD8Icbz7tcsqAewIVhc/q6WXGqImJpCq7hA0m247dDsaZT0lb/MVBiMoJxDEmAE/GYYnWTEn84R35WhJsMvuQ7QmLvNg6RkChY6POCT/YKe9NKwa1NqI1U+oA5RFzAaFtytvZCE3jtp+aR0brL7qaGfgxm6B7dEpGyhg0NcVCV7xMQNq2JxZTVdAr6lcsRGaAFulakmW3aNnmK+L35Wu8uW+OxNxwUuC6f3b4FVBa276FMuUTRfu7gc+k6kCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAAU5CjEyAoyTn7PgFpQD48ZNPuUsEQ19gzYgJvHMzFIoZ7jKBodjO5mCzWBcR7A4mpeAsdyiNBl2sTiZscSnNqxk61jVzP5Ba1D7XtOjjr7+3iqowrThj6BY40QqhYh/6BSY9fDzVZQiHnvlo6ZUM5kUK6OavZOovKlp5DIl5sGqoP0qAJnpQ4nhB2WVVsKfPlOXc+2KSsbJ23g9l8zaTMr+X0umlvfEKqyEl1Fa2L1dO0y/KFQ+ILmxcZLpRdq1hRAjd0quq9qGC8ucXhRWDg4hslVpau0da68g0aItWNez3mc5lB82b3dcZpFMzO41bgw7gvw10AvvTfQDqEYIuQ==",
+           "entityType":"PSD_PI",
+           "entityAddress":"EXAMPLE COMPANY LTD, 5 SOME STREET",
+           "entityTownCity":"SOME CITY",
+           "entityPostCode":"1060",
+           "entityCountry":"CY",
+           "entityWebSite":"www.example.com",
+           "services":"[{\"CY\":[\"PS_010\",\"PS_020\",\"PS_03C\",\"PS_04C\"]}]",
+           "attributes":[
+             {
+               "attributeType":"STRING",
+               "name":"ACCOUNT_MANAGEMENT_FEE",
+               "value":"5987953"
+             }
+           ]
+         }
+       ]
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_get_regulated_entity_by_entity_id
+DROP PROCEDURE IF EXISTS obp_get_regulated_entity_by_entity_id;
+GO
+-- create procedure obp_get_regulated_entity_by_entity_id
+CREATE PROCEDURE obp_get_regulated_entity_by_entity_id
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "regulatedEntityId":"string"
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":{
+         "entityId":"0af807d7-3c39-43ef-9712-82bcfde1b9ca",
+         "certificateAuthorityCaOwnerId":"CY_CBC",
+         "entityName":"EXAMPLE COMPANY LTD",
+         "entityCode":"PSD_PICY_CBC!12345",
+         "entityCertificatePublicKey":"MIICsjCCAZqgAwIBAgIGAYwQ62R0MA0GCSqGSIb3DQEBCwUAMBoxGDAWBgNVBAMMD2FwcC5leGFtcGxlLmNvbTAeFw0yMzExMjcxMzE1MTFaFw0yNTExMjYxMzE1MTFaMBoxGDAWBgNVBAMMD2FwcC5leGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK9WIodZHWzKyCcf9YfWEhPURbfO6zKuMqzHN27GdqHsVVEGxP4F/J4mso+0ENcRr6ur4u81iREaVdCc40rHDHVJNEtniD8Icbz7tcsqAewIVhc/q6WXGqImJpCq7hA0m247dDsaZT0lb/MVBiMoJxDEmAE/GYYnWTEn84R35WhJsMvuQ7QmLvNg6RkChY6POCT/YKe9NKwa1NqI1U+oA5RFzAaFtytvZCE3jtp+aR0brL7qaGfgxm6B7dEpGyhg0NcVCV7xMQNq2JxZTVdAr6lcsRGaAFulakmW3aNnmK+L35Wu8uW+OxNxwUuC6f3b4FVBa276FMuUTRfu7gc+k6kCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAAU5CjEyAoyTn7PgFpQD48ZNPuUsEQ19gzYgJvHMzFIoZ7jKBodjO5mCzWBcR7A4mpeAsdyiNBl2sTiZscSnNqxk61jVzP5Ba1D7XtOjjr7+3iqowrThj6BY40QqhYh/6BSY9fDzVZQiHnvlo6ZUM5kUK6OavZOovKlp5DIl5sGqoP0qAJnpQ4nhB2WVVsKfPlOXc+2KSsbJ23g9l8zaTMr+X0umlvfEKqyEl1Fa2L1dO0y/KFQ+ILmxcZLpRdq1hRAjd0quq9qGC8ucXhRWDg4hslVpau0da68g0aItWNez3mc5lB82b3dcZpFMzO41bgw7gvw10AvvTfQDqEYIuQ==",
+         "entityType":"PSD_PI",
+         "entityAddress":"EXAMPLE COMPANY LTD, 5 SOME STREET",
+         "entityTownCity":"SOME CITY",
+         "entityPostCode":"1060",
+         "entityCountry":"CY",
+         "entityWebSite":"www.example.com",
+         "services":"[{\"CY\":[\"PS_010\",\"PS_020\",\"PS_03C\",\"PS_04C\"]}]",
+         "attributes":[
+           {
+             "attributeType":"STRING",
+             "name":"ACCOUNT_MANAGEMENT_FEE",
+             "value":"5987953"
+           }
+         ]
+       }
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_get_bank_account_balances_by_account_id
+DROP PROCEDURE IF EXISTS obp_get_bank_account_balances_by_account_id;
+GO
+-- create procedure obp_get_bank_account_balances_by_account_id
+CREATE PROCEDURE obp_get_bank_account_balances_by_account_id
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "accountId":{
+         "value":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0"
+       }
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":[
+         {
+           "bankId":{
+             "value":"gh.29.uk"
+           },
+           "accountId":{
+             "value":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0"
+           },
+           "balanceId":{
+             "value":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh"
+           },
+           "balanceType":"openingBooked",
+           "balanceAmount":"50.89",
+           "lastChangeDateTime":"2020-01-27T00:00:00Z",
+           "referenceDate":"2020-01-27"
+         }
+       ]
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_get_bank_accounts_balances_by_account_ids
+DROP PROCEDURE IF EXISTS obp_get_bank_accounts_balances_by_account_ids;
+GO
+-- create procedure obp_get_bank_accounts_balances_by_account_ids
+CREATE PROCEDURE obp_get_bank_accounts_balances_by_account_ids
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "accountIds":[
+         {
+           "value":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0"
+         }
+       ]
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":[
+         {
+           "bankId":{
+             "value":"gh.29.uk"
+           },
+           "accountId":{
+             "value":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0"
+           },
+           "balanceId":{
+             "value":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh"
+           },
+           "balanceType":"openingBooked",
+           "balanceAmount":"50.89",
+           "lastChangeDateTime":"2020-01-27T00:00:00Z",
+           "referenceDate":"2020-01-27"
+         }
+       ]
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_get_bank_account_balance_by_id
+DROP PROCEDURE IF EXISTS obp_get_bank_account_balance_by_id;
+GO
+-- create procedure obp_get_bank_account_balance_by_id
+CREATE PROCEDURE obp_get_bank_account_balance_by_id
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "balanceId":{
+         "value":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh"
+       }
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":{
+         "bankId":{
+           "value":"gh.29.uk"
+         },
+         "accountId":{
+           "value":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0"
+         },
+         "balanceId":{
+           "value":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh"
+         },
+         "balanceType":"openingBooked",
+         "balanceAmount":"50.89",
+         "lastChangeDateTime":"2020-01-27T00:00:00Z",
+         "referenceDate":"2020-01-27"
+       }
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_create_or_update_bank_account_balance
+DROP PROCEDURE IF EXISTS obp_create_or_update_bank_account_balance;
+GO
+-- create procedure obp_create_or_update_bank_account_balance
+CREATE PROCEDURE obp_create_or_update_bank_account_balance
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "bankId":{
+         "value":"gh.29.uk"
+       },
+       "accountId":{
+         "value":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0"
+       },
+       "balanceId":{
+         "value":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh"
+       },
+       "balanceType":"openingBooked",
+       "balanceAmount":"50.89"
+     }'
+*/
+
+-- return example value
+	SELECT @inbound_json = (
+		SELECT
+     N'{
+       "inboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ]
+       },
+       "status":{
+         "errorCode":"",
+         "backendMessages":[
+           {
+             "source":"",
+             "status":"",
+             "errorCode":"",
+             "text":"",
+             "duration":"5.123"
+           }
+         ]
+       },
+       "data":{
+         "bankId":{
+           "value":"gh.29.uk"
+         },
+         "accountId":{
+           "value":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0"
+         },
+         "balanceId":{
+           "value":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh"
+         },
+         "balanceType":"openingBooked",
+         "balanceAmount":"50.89",
+         "lastChangeDateTime":"2020-01-27T00:00:00Z",
+         "referenceDate":"2020-01-27"
+       }
+     }'
+	);
+GO
+
+ 
+ 
+
+
+-- drop procedure obp_delete_bank_account_balance
+DROP PROCEDURE IF EXISTS obp_delete_bank_account_balance;
+GO
+-- create procedure obp_delete_bank_account_balance
+CREATE PROCEDURE obp_delete_bank_account_balance
+   @outbound_json NVARCHAR(MAX),
+   @inbound_json NVARCHAR(MAX) OUT
+   AS
+	  SET nocount on
+
+-- replace the follow example to real logic
+/*
+this is example of parameter @outbound_json
+     N'{
+       "outboundAdapterCallContext":{
+         "correlationId":"1flssoftxq0cr1nssr68u0mioj",
+         "sessionId":"b4e0352a-9a0f-4bfa-b30b-9003aa467f50",
+         "consumerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+         "generalContext":[
+           {
+             "key":"CustomerNumber",
+             "value":"5987953"
+           }
+         ],
+         "outboundAdapterAuthInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         },
+         "outboundAdapterConsenterInfo":{
+           "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+           "username":"felixsmith",
+           "linkedCustomers":[
+             {
+               "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+               "customerNumber":"5987953",
+               "legalName":"Eveline Tripman"
+             }
+           ],
+           "userAuthContext":[
+             {
+               "key":"CustomerNumber",
+               "value":"5987953"
+             }
+           ],
+           "authViews":[
+             {
+               "view":{
+                 "id":"owner",
+                 "name":"owner",
+                 "description":"This view is for the owner for the account."
+               },
+               "account":{
+                 "id":"8ca8a7e4-6d02-40e3-a129-0b2bf89de9f0",
+                 "accountRoutings":[
+                   {
+                     "scheme":"IBAN",
+                     "address":"DE91 1000 0000 0123 4567 89"
+                   }
+                 ],
+                 "customerOwners":[
+                   {
+                     "bankId":"gh.29.uk",
+                     "customerId":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh",
+                     "customerNumber":"5987953",
+                     "legalName":"Eveline Tripman",
+                     "dateOfBirth":"2018-03-09T00:00:00Z"
+                   }
+                 ],
+                 "userOwners":[
+                   {
+                     "userId":"9ca9a7e4-6d02-40e3-a129-0b2bf89de9b1",
+                     "emailAddress":"felixsmith@example.com",
+                     "name":"felixsmith"
+                   }
+                 ]
+               }
+             }
+           ]
+         }
+       },
+       "balanceId":{
+         "value":"7uy8a7e4-6d02-40e3-a129-0b2bf89de8uh"
+       }
      }'
 */
 

--- a/obp-api/src/main/scala/code/bankconnectors/storedprocedure/StoredProcedureConnector_vDec2019.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/storedprocedure/StoredProcedureConnector_vDec2019.scala
@@ -69,7 +69,7 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
   val connectorName = "stored_procedure_vDec2019"
 
 //---------------- dynamic start -------------------please don't modify this line
-// ---------- created on 2024-10-30T11:51:31Z
+// ---------- created on 2026-02-10T15:25:46Z
 
   messageDocs += getAdapterInfoDoc
   def getAdapterInfoDoc = MessageDoc(
@@ -344,7 +344,10 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       scaMethod=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SMS),
       scaStatus=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.example),
       authenticationMethodId=Some("string"),
-      attemptCounter=123)))
+      attemptCounter=123,
+      challengePurpose=Some("string"),
+      challengeContextHash=Some("string"),
+      challengeContextStructure=Some("string"))))
     ),
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
@@ -389,7 +392,10 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       scaMethod=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SMS),
       scaStatus=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.example),
       authenticationMethodId=Some("string"),
-      attemptCounter=123)))
+      attemptCounter=123,
+      challengePurpose=Some("string"),
+      challengeContextHash=Some("string"),
+      challengeContextStructure=Some("string"))))
     ),
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
@@ -485,7 +491,10 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       scaMethod=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SMS),
       scaStatus=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.example),
       authenticationMethodId=Some("string"),
-      attemptCounter=123))
+      attemptCounter=123,
+      challengePurpose=Some("string"),
+      challengeContextHash=Some("string"),
+      challengeContextStructure=Some("string")))
     ),
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
@@ -527,7 +536,10 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       scaMethod=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SMS),
       scaStatus=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.example),
       authenticationMethodId=Some("string"),
-      attemptCounter=123))
+      attemptCounter=123,
+      challengePurpose=Some("string"),
+      challengeContextHash=Some("string"),
+      challengeContextStructure=Some("string")))
     ),
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
@@ -569,7 +581,10 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       scaMethod=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SMS),
       scaStatus=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.example),
       authenticationMethodId=Some("string"),
-      attemptCounter=123))
+      attemptCounter=123,
+      challengePurpose=Some("string"),
+      challengeContextHash=Some("string"),
+      challengeContextStructure=Some("string")))
     ),
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
@@ -612,7 +627,10 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       scaMethod=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SMS),
       scaStatus=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.example),
       authenticationMethodId=Some("string"),
-      attemptCounter=123))
+      attemptCounter=123,
+      challengePurpose=Some("string"),
+      challengeContextHash=Some("string"),
+      challengeContextStructure=Some("string")))
     ),
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
@@ -650,7 +668,10 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       scaMethod=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SMS),
       scaStatus=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.example),
       authenticationMethodId=Some("string"),
-      attemptCounter=123)))
+      attemptCounter=123,
+      challengePurpose=Some("string"),
+      challengeContextHash=Some("string"),
+      challengeContextStructure=Some("string"))))
     ),
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
@@ -688,7 +709,10 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       scaMethod=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SMS),
       scaStatus=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.example),
       authenticationMethodId=Some("string"),
-      attemptCounter=123)))
+      attemptCounter=123,
+      challengePurpose=Some("string"),
+      challengeContextHash=Some("string"),
+      challengeContextStructure=Some("string"))))
     ),
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
@@ -726,7 +750,10 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       scaMethod=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SMS),
       scaStatus=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.example),
       authenticationMethodId=Some("string"),
-      attemptCounter=123)))
+      attemptCounter=123,
+      challengePurpose=Some("string"),
+      challengeContextHash=Some("string"),
+      challengeContextStructure=Some("string"))))
     ),
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
@@ -764,7 +791,10 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       scaMethod=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthentication.SMS),
       scaStatus=Some(com.openbankproject.commons.model.enums.StrongCustomerAuthenticationStatus.example),
       authenticationMethodId=Some("string"),
-      attemptCounter=123))
+      attemptCounter=123,
+      challengePurpose=Some("string"),
+      challengeContextHash=Some("string"),
+      challengeContextStructure=Some("string")))
     ),
     adapterImplementation = Some(AdapterImplementation("- Core", 1))
   )
@@ -883,7 +913,6 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
         val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_bank_accounts_for_user", req, callContext)
         response.map(convertToTuple[List[InboundAccountCommons]](callContext))        
   }
-  
   
   messageDocs += checkExternalUserCredentialsDoc
   def checkExternalUserCredentialsDoc = MessageDoc(
@@ -1148,7 +1177,7 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       address=accountRoutingAddressExample.value)),
       balances=List( BankAccountBalance(balance= AmountOfMoney(currency=balanceCurrencyExample.value,
       amount=balanceAmountExample.value),
-      balanceType="string")),
+      balanceType=balanceTypeExample.value)),
       overallBalance= AmountOfMoney(currency=currencyExample.value,
       amount=amountExample.value),
       overallBalanceDate=toDate(overallBalanceDateExample)))
@@ -1225,6 +1254,79 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
         val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, bankIdAccountIds)
         val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_bank_accounts_held", req, callContext)
         response.map(convertToTuple[List[AccountHeld]](callContext))        
+  }
+          
+  messageDocs += getAccountsHeldDoc
+  def getAccountsHeldDoc = MessageDoc(
+    process = "obp.getAccountsHeld",
+    messageFormat = messageFormat,
+    description = "Get Accounts Held",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+     OutBoundGetAccountsHeld(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      bankId=BankId(bankIdExample.value),
+      user= UserCommons(userPrimaryKey=UserPrimaryKey(123),
+      userId=userIdExample.value,
+      idGivenByProvider="string",
+      provider=providerExample.value,
+      emailAddress=emailAddressExample.value,
+      name=userNameExample.value,
+      createdByConsentId=Some("string"),
+      createdByUserInvitationId=Some("string"),
+      isDeleted=Some(true),
+      lastMarketingAgreementSignedDate=Some(toDate(dateExample))))
+    ),
+    exampleInboundMessage = (
+     InBoundGetAccountsHeld(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
+      data=List( BankIdAccountId(bankId=BankId(bankIdExample.value),
+      accountId=AccountId(accountIdExample.value))))
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def getAccountsHeld(bankId: BankId, user: User, callContext: Option[CallContext]): OBPReturnType[Box[List[BankIdAccountId]]] = {
+        import com.openbankproject.commons.dto.{InBoundGetAccountsHeld => InBound, OutBoundGetAccountsHeld => OutBound}  
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, bankId, user)
+        val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_accounts_held", req, callContext)
+        response.map(convertToTuple[List[BankIdAccountId]](callContext))        
+  }
+          
+  messageDocs += getAccountsHeldByUserDoc
+  def getAccountsHeldByUserDoc = MessageDoc(
+    process = "obp.getAccountsHeldByUser",
+    messageFormat = messageFormat,
+    description = "Get Accounts Held By User",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+     OutBoundGetAccountsHeldByUser(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      user= UserCommons(userPrimaryKey=UserPrimaryKey(123),
+      userId=userIdExample.value,
+      idGivenByProvider="string",
+      provider=providerExample.value,
+      emailAddress=emailAddressExample.value,
+      name=userNameExample.value,
+      createdByConsentId=Some("string"),
+      createdByUserInvitationId=Some("string"),
+      isDeleted=Some(true),
+      lastMarketingAgreementSignedDate=Some(toDate(dateExample))))
+    ),
+    exampleInboundMessage = (
+     InBoundGetAccountsHeldByUser(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
+      data=List( BankIdAccountId(bankId=BankId(bankIdExample.value),
+      accountId=AccountId(accountIdExample.value))))
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def getAccountsHeldByUser(user: User, callContext: Option[CallContext]): OBPReturnType[Box[List[BankIdAccountId]]] = {
+        import com.openbankproject.commons.dto.{InBoundGetAccountsHeldByUser => InBound, OutBoundGetAccountsHeldByUser => OutBound}  
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, user)
+        val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_accounts_held_by_user", req, callContext)
+        response.map(convertToTuple[List[BankIdAccountId]](callContext))        
   }
           
   messageDocs += checkBankAccountExistsDoc
@@ -2353,6 +2455,8 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       amount=amountExample.value),
       creditorAccount=PaymentAccount("string"),
       creditorName="string")),
+      to_agent=Some( TransactionRequestAgentCashWithdrawal(bank_id=bank_idExample.value,
+      agent_number="string")),
       value= AmountOfMoney(currency=currencyExample.value,
       amount=amountExample.value),
       description=descriptionExample.value),
@@ -2516,6 +2620,8 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       amount=amountExample.value),
       creditorAccount=PaymentAccount("string"),
       creditorName="string")),
+      to_agent=Some( TransactionRequestAgentCashWithdrawal(bank_id=bank_idExample.value,
+      agent_number="string")),
       value= AmountOfMoney(currency=currencyExample.value,
       amount=amountExample.value),
       description=descriptionExample.value),
@@ -2566,7 +2672,7 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
     inboundTopic = None,
     exampleOutboundMessage = (
      OutBoundCreateTransactionRequestSepaCreditTransfersBGV1(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
-      initiator= Some(UserCommons(userPrimaryKey=UserPrimaryKey(123),
+      initiator=Some( UserCommons(userPrimaryKey=UserPrimaryKey(123),
       userId=userIdExample.value,
       idGivenByProvider="string",
       provider=providerExample.value,
@@ -2631,7 +2737,7 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
     inboundTopic = None,
     exampleOutboundMessage = (
      OutBoundCreateTransactionRequestPeriodicSepaCreditTransfersBGV1(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
-      initiator= Some(UserCommons(userPrimaryKey=UserPrimaryKey(123),
+      initiator=Some( UserCommons(userPrimaryKey=UserPrimaryKey(123),
       userId=userIdExample.value,
       idGivenByProvider="string",
       provider=providerExample.value,
@@ -2865,6 +2971,8 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       amount=amountExample.value),
       creditorAccount=PaymentAccount("string"),
       creditorName="string")),
+      to_agent=Some( TransactionRequestAgentCashWithdrawal(bank_id=bank_idExample.value,
+      agent_number="string")),
       value= AmountOfMoney(currency=currencyExample.value,
       amount=amountExample.value),
       description=descriptionExample.value),
@@ -2969,6 +3077,8 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       amount=amountExample.value),
       creditorAccount=PaymentAccount("string"),
       creditorName="string")),
+      to_agent=Some( TransactionRequestAgentCashWithdrawal(bank_id=bank_idExample.value,
+      agent_number="string")),
       value= AmountOfMoney(currency=currencyExample.value,
       amount=amountExample.value),
       description=descriptionExample.value),
@@ -3139,6 +3249,8 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       amount=amountExample.value),
       creditorAccount=PaymentAccount("string"),
       creditorName="string")),
+      to_agent=Some( TransactionRequestAgentCashWithdrawal(bank_id=bank_idExample.value,
+      agent_number="string")),
       value= AmountOfMoney(currency=currencyExample.value,
       amount=amountExample.value),
       description=descriptionExample.value),
@@ -3222,6 +3334,8 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       amount=amountExample.value),
       creditorAccount=PaymentAccount("string"),
       creditorName="string")),
+      to_agent=Some( TransactionRequestAgentCashWithdrawal(bank_id=bank_idExample.value,
+      agent_number="string")),
       value= AmountOfMoney(currency=currencyExample.value,
       amount=amountExample.value),
       description=descriptionExample.value),
@@ -3408,8 +3522,7 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
     exampleInboundMessage = (
      InBoundGetProducts(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
       status=MessageDocsSwaggerDefinitions.inboundStatus,
-      data=List( ProductCommons(
-      bankId=BankId(bankIdExample.value),
+      data=List( ProductCommons(bankId=BankId(bankIdExample.value),
       code=ProductCode(productCodeExample.value),
       parentProductCode=ProductCode(parentProductCodeExample.value),
       name=productNameExample.value,
@@ -3448,8 +3561,7 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
     exampleInboundMessage = (
      InBoundGetProduct(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
       status=MessageDocsSwaggerDefinitions.inboundStatus,
-      data= ProductCommons(
-      bankId=BankId(bankIdExample.value),
+      data= ProductCommons(bankId=BankId(bankIdExample.value),
       code=ProductCode(productCodeExample.value),
       parentProductCode=ProductCode(parentProductCodeExample.value),
       name=productNameExample.value,
@@ -3695,7 +3807,7 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       moreInfo=Some(moreInfoExample.value),
       hasDepositCapability=Some(hasDepositCapabilityExample.value.toBoolean),
       supportedLanguages=Some(supportedLanguagesExample.value.replace("[","").replace("]","").split(",").toList),
-      services=Some(listExample.value.replace("[","").replace("]","").split(",").toList),
+      services=Some(servicesExample.value.replace("[","").replace("]","").split(",").toList),
       accessibilityFeatures=Some(accessibilityFeaturesExample.value.replace("[","").replace("]","").split(",").toList),
       supportedCurrencies=Some(supportedCurrenciesExample.value.replace("[","").replace("]","").split(",").toList),
       notes=Some(listExample.value.replace("[","").replace("]","").split(",").toList),
@@ -3776,7 +3888,7 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       moreInfo=Some(moreInfoExample.value),
       hasDepositCapability=Some(hasDepositCapabilityExample.value.toBoolean),
       supportedLanguages=Some(supportedLanguagesExample.value.replace("[","").replace("]","").split(",").toList),
-      services=Some(listExample.value.replace("[","").replace("]","").split(",").toList),
+      services=Some(servicesExample.value.replace("[","").replace("]","").split(",").toList),
       accessibilityFeatures=Some(accessibilityFeaturesExample.value.replace("[","").replace("]","").split(",").toList),
       supportedCurrencies=Some(supportedCurrenciesExample.value.replace("[","").replace("]","").split(",").toList),
       notes=Some(listExample.value.replace("[","").replace("]","").split(",").toList),
@@ -3809,12 +3921,14 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
     outboundTopic = None,
     inboundTopic = None,
     exampleOutboundMessage = (
-     OutBoundGetCurrentFxRate(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,bankId=BankId(bankIdExample.value),
+     OutBoundGetCurrentFxRate(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      bankId=BankId(bankIdExample.value),
       fromCurrencyCode=fromCurrencyCodeExample.value,
       toCurrencyCode=toCurrencyCodeExample.value)
     ),
     exampleInboundMessage = (
-     InBoundGetCurrentFxRate(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,status=MessageDocsSwaggerDefinitions.inboundStatus,
+     InBoundGetCurrentFxRate(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
       data= FXRateCommons(bankId=BankId(bankIdExample.value),
       fromCurrencyCode=fromCurrencyCodeExample.value,
       toCurrencyCode=toCurrencyCodeExample.value,
@@ -3827,7 +3941,7 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
 
   override def getCurrentFxRate(bankId: BankId, fromCurrencyCode: String, toCurrencyCode: String, callContext: Option[CallContext]): Box[FXRate] = {
         import com.openbankproject.commons.dto.{InBoundGetCurrentFxRate => InBound, OutBoundGetCurrentFxRate => OutBound}  
-        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull,bankId, fromCurrencyCode, toCurrencyCode)
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, bankId, fromCurrencyCode, toCurrencyCode)
         val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_current_fx_rate", req, callContext)
         response.map(convertToTuple[FXRateCommons](callContext))        
   }
@@ -3924,6 +4038,8 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       amount=amountExample.value),
       creditorAccount=PaymentAccount("string"),
       creditorName="string")),
+      to_agent=Some( TransactionRequestAgentCashWithdrawal(bank_id=bank_idExample.value,
+      agent_number="string")),
       value= AmountOfMoney(currency=currencyExample.value,
       amount=amountExample.value),
       description=descriptionExample.value),
@@ -4194,6 +4310,8 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       amount=amountExample.value),
       creditorAccount=PaymentAccount("string"),
       creditorName="string")),
+      to_agent=Some( TransactionRequestAgentCashWithdrawal(bank_id=bank_idExample.value,
+      agent_number="string")),
       value= AmountOfMoney(currency=currencyExample.value,
       amount=amountExample.value),
       description=descriptionExample.value),
@@ -4293,6 +4411,8 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       amount=amountExample.value),
       creditorAccount=PaymentAccount("string"),
       creditorName="string")),
+      to_agent=Some( TransactionRequestAgentCashWithdrawal(bank_id=bank_idExample.value,
+      agent_number="string")),
       value= AmountOfMoney(currency=currencyExample.value,
       amount=amountExample.value),
       description=descriptionExample.value),
@@ -5471,6 +5591,37 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
         response.map(convertToTuple[ProductAttributeCommons](callContext))        
   }
           
+  messageDocs += getBankAttributesByBankDoc
+  def getBankAttributesByBankDoc = MessageDoc(
+    process = "obp.getBankAttributesByBank",
+    messageFormat = messageFormat,
+    description = "Get Bank Attributes By Bank",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+     OutBoundGetBankAttributesByBank(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      bankId=BankId(bankIdExample.value))
+    ),
+    exampleInboundMessage = (
+     InBoundGetBankAttributesByBank(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
+      data=List( BankAttributeTraitCommons(bankId=BankId(bankIdExample.value),
+      bankAttributeId="string",
+      attributeType=com.openbankproject.commons.model.enums.BankAttributeType.example,
+      name=nameExample.value,
+      value=valueExample.value,
+      isActive=Some(isActiveExample.value.toBoolean))))
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def getBankAttributesByBank(bankId: BankId, callContext: Option[CallContext]): OBPReturnType[Box[List[BankAttributeTrait]]] = {
+        import com.openbankproject.commons.dto.{InBoundGetBankAttributesByBank => InBound, OutBoundGetBankAttributesByBank => OutBound}  
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, bankId)
+        val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_bank_attributes_by_bank", req, callContext)
+        response.map(convertToTuple[List[BankAttributeTraitCommons]](callContext))        
+  }
+          
   messageDocs += getProductAttributeByIdDoc
   def getProductAttributeByIdDoc = MessageDoc(
     process = "obp.getProductAttributeById",
@@ -6369,8 +6520,7 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
       status=MessageDocsSwaggerDefinitions.inboundStatus,
       data=List( ProductCollectionItemsTree(productCollectionItem= ProductCollectionItemCommons(collectionCode=collectionCodeExample.value,
       memberProductCode=memberProductCodeExample.value),
-      product= ProductCommons(
-      bankId=BankId(bankIdExample.value),
+      product= ProductCommons(bankId=BankId(bankIdExample.value),
       code=ProductCode(productCodeExample.value),
       parentProductCode=ProductCode(parentProductCodeExample.value),
       name=productNameExample.value,
@@ -7057,8 +7207,245 @@ trait StoredProcedureConnector_vDec2019 extends Connector with MdcLoggable {
         response.map(convertToTuple[Boolean](callContext))        
   }
           
-// ---------- created on 2024-10-30T11:51:31Z
-//---------------- dynamic end ---------------------please don't modify this line                                            
+  messageDocs += getRegulatedEntitiesDoc
+  def getRegulatedEntitiesDoc = MessageDoc(
+    process = "obp.getRegulatedEntities",
+    messageFormat = messageFormat,
+    description = "Get Regulated Entities",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+          OutBoundGetRegulatedEntities(MessageDocsSwaggerDefinitions.outboundAdapterCallContext)
+    ),
+    exampleInboundMessage = (
+     InBoundGetRegulatedEntities(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
+      data=List( RegulatedEntityTraitCommons(entityId=entityIdExample.value,
+      certificateAuthorityCaOwnerId=certificateAuthorityCaOwnerIdExample.value,
+      entityName=entityNameExample.value,
+      entityCode=entityCodeExample.value,
+      entityCertificatePublicKey=entityCertificatePublicKeyExample.value,
+      entityType=entityTypeExample.value,
+      entityAddress=entityAddressExample.value,
+      entityTownCity=entityTownCityExample.value,
+      entityPostCode=entityPostCodeExample.value,
+      entityCountry=entityCountryExample.value,
+      entityWebSite=entityWebSiteExample.value,
+      services=servicesExample.value,
+      attributes=Some(List( RegulatedEntityAttributeSimple(attributeType=attributeTypeExample.value,
+      name=nameExample.value,
+      value=valueExample.value))))))
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def getRegulatedEntities(callContext: Option[CallContext]): OBPReturnType[Box[List[RegulatedEntityTrait]]] = {
+        import com.openbankproject.commons.dto.{InBoundGetRegulatedEntities => InBound, OutBoundGetRegulatedEntities => OutBound}  
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull)
+        val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_regulated_entities", req, callContext)
+        response.map(convertToTuple[List[RegulatedEntityTraitCommons]](callContext))        
+  }
+          
+  messageDocs += getRegulatedEntityByEntityIdDoc
+  def getRegulatedEntityByEntityIdDoc = MessageDoc(
+    process = "obp.getRegulatedEntityByEntityId",
+    messageFormat = messageFormat,
+    description = "Get Regulated Entity By Entity Id",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+     OutBoundGetRegulatedEntityByEntityId(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      regulatedEntityId="string")
+    ),
+    exampleInboundMessage = (
+     InBoundGetRegulatedEntityByEntityId(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
+      data= RegulatedEntityTraitCommons(entityId=entityIdExample.value,
+      certificateAuthorityCaOwnerId=certificateAuthorityCaOwnerIdExample.value,
+      entityName=entityNameExample.value,
+      entityCode=entityCodeExample.value,
+      entityCertificatePublicKey=entityCertificatePublicKeyExample.value,
+      entityType=entityTypeExample.value,
+      entityAddress=entityAddressExample.value,
+      entityTownCity=entityTownCityExample.value,
+      entityPostCode=entityPostCodeExample.value,
+      entityCountry=entityCountryExample.value,
+      entityWebSite=entityWebSiteExample.value,
+      services=servicesExample.value,
+      attributes=Some(List( RegulatedEntityAttributeSimple(attributeType=attributeTypeExample.value,
+      name=nameExample.value,
+      value=valueExample.value)))))
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def getRegulatedEntityByEntityId(regulatedEntityId: String, callContext: Option[CallContext]): OBPReturnType[Box[RegulatedEntityTrait]] = {
+        import com.openbankproject.commons.dto.{InBoundGetRegulatedEntityByEntityId => InBound, OutBoundGetRegulatedEntityByEntityId => OutBound}  
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, regulatedEntityId)
+        val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_regulated_entity_by_entity_id", req, callContext)
+        response.map(convertToTuple[RegulatedEntityTraitCommons](callContext))        
+  }
+          
+  messageDocs += getBankAccountBalancesByAccountIdDoc
+  def getBankAccountBalancesByAccountIdDoc = MessageDoc(
+    process = "obp.getBankAccountBalancesByAccountId",
+    messageFormat = messageFormat,
+    description = "Get Bank Account Balances By Account Id",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+     OutBoundGetBankAccountBalancesByAccountId(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      accountId=AccountId(accountIdExample.value))
+    ),
+    exampleInboundMessage = (
+     InBoundGetBankAccountBalancesByAccountId(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
+      data=List( BankAccountBalanceTraitCommons(bankId=BankId(bankIdExample.value),
+      accountId=AccountId(accountIdExample.value),
+      balanceId=BalanceId(balanceIdExample.value),
+      balanceType=balanceTypeExample.value,
+      balanceAmount=BigDecimal(balanceAmountExample.value),
+      lastChangeDateTime=Some(toDate(dateExample)),
+      referenceDate=Some(referenceDateExample.value))))
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def getBankAccountBalancesByAccountId(accountId: AccountId, callContext: Option[CallContext]): OBPReturnType[Box[List[BankAccountBalanceTrait]]] = {
+        import com.openbankproject.commons.dto.{InBoundGetBankAccountBalancesByAccountId => InBound, OutBoundGetBankAccountBalancesByAccountId => OutBound}  
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, accountId)
+        val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_bank_account_balances_by_account_id", req, callContext)
+        response.map(convertToTuple[List[BankAccountBalanceTraitCommons]](callContext))        
+  }
+          
+  messageDocs += getBankAccountsBalancesByAccountIdsDoc
+  def getBankAccountsBalancesByAccountIdsDoc = MessageDoc(
+    process = "obp.getBankAccountsBalancesByAccountIds",
+    messageFormat = messageFormat,
+    description = "Get Bank Accounts Balances By Account Ids",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+     OutBoundGetBankAccountsBalancesByAccountIds(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      accountIds=List(AccountId(accountIdExample.value)))
+    ),
+    exampleInboundMessage = (
+     InBoundGetBankAccountsBalancesByAccountIds(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
+      data=List( BankAccountBalanceTraitCommons(bankId=BankId(bankIdExample.value),
+      accountId=AccountId(accountIdExample.value),
+      balanceId=BalanceId(balanceIdExample.value),
+      balanceType=balanceTypeExample.value,
+      balanceAmount=BigDecimal(balanceAmountExample.value),
+      lastChangeDateTime=Some(toDate(dateExample)),
+      referenceDate=Some(referenceDateExample.value))))
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def getBankAccountsBalancesByAccountIds(accountIds: List[AccountId], callContext: Option[CallContext]): OBPReturnType[Box[List[BankAccountBalanceTrait]]] = {
+        import com.openbankproject.commons.dto.{InBoundGetBankAccountsBalancesByAccountIds => InBound, OutBoundGetBankAccountsBalancesByAccountIds => OutBound}  
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, accountIds)
+        val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_bank_accounts_balances_by_account_ids", req, callContext)
+        response.map(convertToTuple[List[BankAccountBalanceTraitCommons]](callContext))        
+  }
+          
+  messageDocs += getBankAccountBalanceByIdDoc
+  def getBankAccountBalanceByIdDoc = MessageDoc(
+    process = "obp.getBankAccountBalanceById",
+    messageFormat = messageFormat,
+    description = "Get Bank Account Balance By Id",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+     OutBoundGetBankAccountBalanceById(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      balanceId=BalanceId(balanceIdExample.value))
+    ),
+    exampleInboundMessage = (
+     InBoundGetBankAccountBalanceById(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
+      data= BankAccountBalanceTraitCommons(bankId=BankId(bankIdExample.value),
+      accountId=AccountId(accountIdExample.value),
+      balanceId=BalanceId(balanceIdExample.value),
+      balanceType=balanceTypeExample.value,
+      balanceAmount=BigDecimal(balanceAmountExample.value),
+      lastChangeDateTime=Some(toDate(dateExample)),
+      referenceDate=Some(referenceDateExample.value)))
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def getBankAccountBalanceById(balanceId: BalanceId, callContext: Option[CallContext]): OBPReturnType[Box[BankAccountBalanceTrait]] = {
+        import com.openbankproject.commons.dto.{InBoundGetBankAccountBalanceById => InBound, OutBoundGetBankAccountBalanceById => OutBound}  
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, balanceId)
+        val response: Future[Box[InBound]] = sendRequest[InBound]("obp_get_bank_account_balance_by_id", req, callContext)
+        response.map(convertToTuple[BankAccountBalanceTraitCommons](callContext))        
+  }
+          
+  messageDocs += createOrUpdateBankAccountBalanceDoc
+  def createOrUpdateBankAccountBalanceDoc = MessageDoc(
+    process = "obp.createOrUpdateBankAccountBalance",
+    messageFormat = messageFormat,
+    description = "Create Or Update Bank Account Balance",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+     OutBoundCreateOrUpdateBankAccountBalance(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      bankId=BankId(bankIdExample.value),
+      accountId=AccountId(accountIdExample.value),
+      balanceId=Some(BalanceId(balanceIdExample.value)),
+      balanceType=balanceTypeExample.value,
+      balanceAmount=BigDecimal(balanceAmountExample.value))
+    ),
+    exampleInboundMessage = (
+     InBoundCreateOrUpdateBankAccountBalance(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
+      data= BankAccountBalanceTraitCommons(bankId=BankId(bankIdExample.value),
+      accountId=AccountId(accountIdExample.value),
+      balanceId=BalanceId(balanceIdExample.value),
+      balanceType=balanceTypeExample.value,
+      balanceAmount=BigDecimal(balanceAmountExample.value),
+      lastChangeDateTime=Some(toDate(dateExample)),
+      referenceDate=Some(referenceDateExample.value)))
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def createOrUpdateBankAccountBalance(bankId: BankId, accountId: AccountId, balanceId: Option[BalanceId], balanceType: String, balanceAmount: BigDecimal, callContext: Option[CallContext]): OBPReturnType[Box[BankAccountBalanceTrait]] = {
+        import com.openbankproject.commons.dto.{InBoundCreateOrUpdateBankAccountBalance => InBound, OutBoundCreateOrUpdateBankAccountBalance => OutBound}  
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, bankId, accountId, balanceId, balanceType, balanceAmount)
+        val response: Future[Box[InBound]] = sendRequest[InBound]("obp_create_or_update_bank_account_balance", req, callContext)
+        response.map(convertToTuple[BankAccountBalanceTraitCommons](callContext))        
+  }
+          
+  messageDocs += deleteBankAccountBalanceDoc
+  def deleteBankAccountBalanceDoc = MessageDoc(
+    process = "obp.deleteBankAccountBalance",
+    messageFormat = messageFormat,
+    description = "Delete Bank Account Balance",
+    outboundTopic = None,
+    inboundTopic = None,
+    exampleOutboundMessage = (
+     OutBoundDeleteBankAccountBalance(outboundAdapterCallContext=MessageDocsSwaggerDefinitions.outboundAdapterCallContext,
+      balanceId=BalanceId(balanceIdExample.value))
+    ),
+    exampleInboundMessage = (
+     InBoundDeleteBankAccountBalance(inboundAdapterCallContext=MessageDocsSwaggerDefinitions.inboundAdapterCallContext,
+      status=MessageDocsSwaggerDefinitions.inboundStatus,
+      data=true)
+    ),
+    adapterImplementation = Some(AdapterImplementation("- Core", 1))
+  )
+
+  override def deleteBankAccountBalance(balanceId: BalanceId, callContext: Option[CallContext]): OBPReturnType[Box[Boolean]] = {
+        import com.openbankproject.commons.dto.{InBoundDeleteBankAccountBalance => InBound, OutBoundDeleteBankAccountBalance => OutBound}  
+        val req = OutBound(callContext.map(_.toOutboundAdapterCallContext).orNull, balanceId)
+        val response: Future[Box[InBound]] = sendRequest[InBound]("obp_delete_bank_account_balance", req, callContext)
+        response.map(convertToTuple[Boolean](callContext))        
+  }
+          
+// ---------- created on 2026-02-10T15:25:46Z
+//---------------- dynamic end ---------------------please don't modify this line                                              
 
   private val availableOperation = DynamicEntityOperation.values.map(it => s""""$it"""").mkString("[", ", ", "]")
 


### PR DESCRIPTION
…s and update SCA challenge fields

- Move checkExternalUserCredentials, checkExternalUserExists, and getCurrentFxRate to standard connector methods list
- Comment out getCurrentFxRate from optional methods list to avoid duplication
- Remove checkExternalUserCredentials and checkExternalUserExists from non-standard methods list
- Update MS SQL stored procedure generation timestamp to 2026-02-10T14:42:15Z
- Replace empty consentId values with valid UUID 9d429899-24f5-42c8-8565-943ffa6a7947 across multiple procedures
- Update adapter info date example from "date String" to ISO 8601 format "1100-01-01T01:01:01.000Z"
- Add three new SCA challenge fields to response examples: challengePurpose, challengeContextHash, and challengeContextStructure
- Consolidate method categorization to improve connector builder clarity and reduce maintenance overhead