### PR TITLE
upgrade maven git commit id plugin for git worktree support

### DIFF
--- a/obp-api/pom.xml
+++ b/obp-api/pom.xml
@@ -633,9 +633,9 @@
         </plugin>
 
         <plugin>
-          <groupId>pl.project13.maven</groupId>
-          <artifactId>git-commit-id-plugin</artifactId>
-          <version>4.9.10</version>
+          <groupId>io.github.git-commit-id</groupId>
+          <artifactId>git-commit-id-maven-plugin</artifactId>
+          <version>9.0.1</version>
           <executions>
             <execution>
               <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -226,9 +226,9 @@
 
 
         <plugin>
-          <groupId>pl.project13.maven</groupId>
-          <artifactId>git-commit-id-plugin</artifactId>
-          <version>4.9.10</version>
+          <groupId>io.github.git-commit-id</groupId>
+          <artifactId>git-commit-id-maven-plugin</artifactId>
+          <version>9.0.1</version>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
The old maven plugin did not support git worktrees, and would error if you tried to run the build and run script in a worktree.