### PR TITLE
fix(resource-docs): restore dynamic-entity/endpoint specifiedUrl pref…

### DIFF
--- a/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
+++ b/obp-api/src/main/scala/code/api/ResourceDocs1_4_0/ResourceDocsAPIMethods.scala
@@ -289,11 +289,23 @@ trait ResourceDocsAPIMethods extends MdcLoggable with APIMethods220 with APIMeth
 
       // Always recompute specifiedUrl per-request. specifiedUrl is a var on a shared
       // ResourceDoc instance; if we kept the existing value (the prior `case Some(_) => it`
-      // shortcut), a request for /obp/v7.0.0/resource-docs would inherit a stale
-      // /obp/dynamic-endpoint/... value set by an earlier request and return the wrong URL.
+      // shortcut), a request for /obp/v7.0.0/resource-docs would inherit a stale value set
+      // by an earlier request and return the wrong URL.
+      //
+      // Dynamic-entity / dynamic-endpoint docs are served ONLY under their own prefix
+      // (/obp/dynamic-entity/... , /obp/dynamic-endpoint/...) by Http4sDynamicEntity /
+      // Http4sDynamicEndpoint — they are NOT reachable at the requested version, unlike
+      // normal versioned docs which the bridge cascade makes reachable at /obp/${version}/...
+      // So they must keep their dynamic-* prefix here, matching getResourceDocsObpDynamicCached.
+      // (Commit efb97531e over-corrected this branch to always use the requested version,
+      // which made API Explorer render dynamic-entity CRUD URLs as /obp/v7.0.0/<entity> — a 404.)
       val dynamicDocs = allDynamicResourceDocs
         .map { it =>
-          it.specifiedUrl = Some(s"/${it.implementedInApiVersion.urlPrefix}/${requestedApiVersion.vDottedApiVersion}${it.requestUrl}")
+          it.specifiedUrl =
+            if (it.partialFunctionName.startsWith("dynamicEntity"))
+              Some(s"/${it.implementedInApiVersion.urlPrefix}/${ApiVersion.`dynamic-entity`}${it.requestUrl}")
+            else
+              Some(s"/${it.implementedInApiVersion.urlPrefix}/${ApiVersion.`dynamic-endpoint`}${it.requestUrl}")
           it
         }
 

--- a/obp-api/src/test/scala/code/api/v7_0_0/V7ResourceDocsAggregationTest.scala
+++ b/obp-api/src/test/scala/code/api/v7_0_0/V7ResourceDocsAggregationTest.scala
@@ -699,16 +699,62 @@ class V7ResourceDocsAggregationTest extends ServerSetupWithTestData {
       info(s"Docs with non-empty specifiedUrl: ${docsWithSpecifiedUrl.size}")
       docsWithSpecifiedUrl.size shouldBe resourceDocs.size
 
-      // Check that all specifiedUrl values use v7.0.0 version
-      val docsWithV7SpecifiedUrl = resourceDocs.filter { doc =>
-        val fieldMap = toFieldMap(doc.obj)
-        fieldMap.get("specified_url") match {
-          case Some(JString(url)) => url.contains("/v7.0.0/")
-          case _ => false
+      // Dynamic-entity / dynamic-endpoint docs are a deliberate exception: their routes are
+      // served ONLY under /obp/dynamic-entity/... and /obp/dynamic-endpoint/... (by
+      // Http4sDynamicEntity / Http4sDynamicEndpoint), NOT at the requested version. Rendering
+      // them at /obp/v7.0.0/<x> produces a 404 in API Explorer. So they are legitimately NOT
+      // under /v7.0.0/ and must be excluded from the bulk version assertion below.
+      def specifiedUrlOf(doc: JObject): Option[String] = toFieldMap(doc.obj).get("specified_url").collect {
+        case JString(url) => url
+      }
+      // CRITICAL — classify by operation_id, NEVER by specified_url (the thing we validate).
+      // operation_id embeds the partial function name (buildOperationId = "${version}-${fnName}").
+      // The dynamic docs visible here are:
+      //   - real dynamic entities   → fnName starts with "dynamicEntity"   → /obp/dynamic-entity/...
+      //   - real dynamic endpoints  → fnName starts with "dynamicEndpoint" → /obp/dynamic-endpoint/...
+      //   - the always-present practise fixture (PractiseEndpointGroup, urlPrefix
+      //     "test-dynamic-resource-doc", from DynamicEndpoints.dynamicResourceDocs) → /obp/dynamic-endpoint/...
+      // Classifying by operation_id (URL-independent) is what makes the guard real: if the
+      // efb97531e prefix bug regresses, these docs get /obp/v7.0.0/<x> but are STILL recognised
+      // here as dynamic, so the guard FAILS. Classifying by the URL would be circular and would
+      // silently pass on a regression — exactly how the original bug slipped through.
+      val practiseFixtureOpId = "OBPv4.0.0-test-dynamic-resource-doc"
+      def isDynamicEntityDoc(doc: JObject): Boolean = getOperationId(doc).exists(_.contains("dynamicEntity"))
+      def isDynamicEndpointDoc(doc: JObject): Boolean =
+        getOperationId(doc).exists(id => id.contains("dynamicEndpoint") || id == practiseFixtureOpId)
+      def isDynamicDoc(doc: JObject): Boolean = isDynamicEntityDoc(doc) || isDynamicEndpointDoc(doc)
+
+      val (dynamicDocs, normalDocs) = resourceDocs.partition(isDynamicDoc)
+      info(s"Dynamic (entity/endpoint) docs: ${dynamicDocs.size}; normal versioned docs: ${normalDocs.size}")
+      // Sanity: the test env always registers the practise fixture, so at least one dynamic doc
+      // must be present — otherwise this scenario could not catch the prefix regression at all.
+      withClue("test env must expose at least one dynamic doc (practise fixture) to guard the prefix regression ") {
+        dynamicDocs.nonEmpty shouldBe true
+      }
+
+      // Check that all NORMAL (non-dynamic) specifiedUrl values use the v7.0.0 version
+      val docsWithV7SpecifiedUrl = normalDocs.filter { doc =>
+        specifiedUrlOf(doc).exists(_.contains("/v7.0.0/"))
+      }
+      info(s"Normal docs with v7.0.0 in specifiedUrl: ${docsWithV7SpecifiedUrl.size}")
+      docsWithV7SpecifiedUrl.size shouldBe normalDocs.size
+
+      // Regression guard for the dynamic prefix bug (efb97531e): every dynamic doc's specifiedUrl
+      // must keep its dynamic-* prefix and must NOT be rewritten to /v7.0.0/.
+      resourceDocs.filter(isDynamicEntityDoc).foreach { doc =>
+        val url = specifiedUrlOf(doc).getOrElse(fail(s"Expected specified_url on dynamicEntity doc ${getOperationId(doc)}"))
+        withClue(s"dynamicEntity doc ${getOperationId(doc)} specifiedUrl must keep /dynamic-entity/ prefix, got: $url ") {
+          url should include("/dynamic-entity/")
+          url should not include("/v7.0.0/")
         }
       }
-      info(s"Docs with v7.0.0 in specifiedUrl: ${docsWithV7SpecifiedUrl.size}")
-      docsWithV7SpecifiedUrl.size shouldBe resourceDocs.size
+      resourceDocs.filter(isDynamicEndpointDoc).foreach { doc =>
+        val url = specifiedUrlOf(doc).getOrElse(fail(s"Expected specified_url on dynamicEndpoint doc ${getOperationId(doc)}"))
+        withClue(s"dynamicEndpoint doc ${getOperationId(doc)} specifiedUrl must keep /dynamic-endpoint/ prefix, got: $url ") {
+          url should include("/dynamic-endpoint/")
+          url should not include("/v7.0.0/")
+        }
+      }
 
       // Verify a specific v6.0.0 endpoint has correct specifiedUrl
       val v6Endpoint = resourceDocs.find { doc =>
@@ -734,7 +780,7 @@ class V7ResourceDocsAggregationTest extends ServerSetupWithTestData {
       }
 
       info("**Expected Outcome**: This test PASSES after specifiedUrl fix")
-      info("**Validates**: specifiedUrl correctly uses v7.0.0 for all aggregated docs")
+      info("**Validates**: normal aggregated docs use v7.0.0; dynamic-entity/endpoint docs keep their dynamic-* prefix")
     }
   }
 }


### PR DESCRIPTION
…ix in aggregated docs

Commit efb97531e fixed a stale-cache bug in getAllResourceDocsObpCached but over-corrected the dynamic-docs branch: it replaced the dynamic-entity/endpoint prefix special-case with an unconditional /${requestedVersion}/... rewrite. This caused API Explorer to render dynamic-entity CRUD URLs as /obp/v7.0.0/<entity> instead of /obp/dynamic-entity/<entity>, producing 404s on every click.

The sibling getResourceDocsObpDynamicCached was fixed correctly in that commit (kept the special-case, removed only the stale shortcut), so the standalone dynamic endpoint remained correct while the aggregated view regressed.

Fix: restore the startsWith("dynamicEntity") branch in getAllResourceDocsObpCached (mirrors :337), keeping the always-recompute guarantee from efb97531e.

Also strengthen V7ResourceDocsAggregationTest Property 2.10. Its original assertion that ALL docs contain /v7.0.0/ encoded the wrong expectation for dynamic docs and let the regression pass undetected. The new guard:
  - classifies dynamic docs by operation_id (the partial function name), NEVER by specified_url — classifying by the URL would be circular and silently green on a regression (verified: reverting the fix makes the guard FAIL with "OBPv4.0.0-test-dynamic-resource-doc specifiedUrl must keep /dynamic-endpoint/ prefix, got /obp/v7.0.0/...");
  - asserts normal docs use /v7.0.0/ while dynamic-entity / dynamic-endpoint docs keep their /obp/dynamic-entity/ and /obp/dynamic-endpoint/ prefixes;
  - requires at least one dynamic doc present (the always-registered practise fixture) so the guard can never no-op.

Tested: ResourceDocsTest (63), SwaggerDocsTest (12), SwaggerFactoryUnitTest (11), ResourceDocsTechnologyTest (2), V7ResourceDocsAggregationTest (14) — all pass. Negative-tested: reverting the production fix turns Property 2.10 red.