### PR TITLE
bugfix/ErrorMessages reflective field scan runs before object is fully initialized

### DIFF
--- a/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
+++ b/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
@@ -982,7 +982,16 @@ object ErrorMessages {
   //For Swagger, used reflect to  list all the varible names and values.
   // eg : val InvalidUserId = "OBP-30107: Invalid User Id."
   //   -->(InvalidUserId, "OBP-30107: Invalid User Id.")
-  val allFields =
+  //
+  // This must be a lazy val: it reflectively scans this object's own declared fields,
+  // some of which (e.g. errorToCode, isValidName) are declared further down in this
+  // file and are only assigned once the object's constructor has run past them. As an
+  // eager val, this scan can run mid-construction and observe those fields as not yet
+  // set, with the exact outcome depending on JVM/reflection field-ordering, which is not
+  // guaranteed by the JVM spec and can differ between environments (e.g. local run vs.
+  // Docker). Making it lazy defers the scan until first use, by which point the object
+  // is fully constructed and every field is guaranteed to be initialized.
+  lazy val allFields =
   for (
     v <- this.getClass.getDeclaredFields
     //add guard, ignore the SwaggerJSONsV220.this and allFieldsAndValues fields


### PR DESCRIPTION
Related to #2624
allFields (used to build the Swagger error-code lookup table) reflectively scans this object's own declared fields, but as an eager val this scan can run while the ErrorMessages object is still being constructed. Fields declared later in the file (errorToCode, isValidName) are not yet assigned at that point, and the outcome depends on JVM/reflection field-ordering, which the JVM spec doesn't guarantee and which can differ between environments (e.g. a local run vs. a packaged Docker deployment).

Making allFields a lazy val defers the reflective scan until first actual use. Its only consumer (SwaggerJSONFactory.errorDefinitions) accesses it well after application boot during on-demand Swagger doc generation, so by then the object is guaranteed to be fully initialized regardless of field-declaration order.

I have read and agree to the Harmony Individual Contributor Assignment Agreement (Harmony_Individual_Contributor_Assignment_Agreement.txt).

Signed: Abhinav Reddy