### PR TITLE
fix(scripts): auto-switch dev.port when it's already in use

### DIFF
--- a/flushall_build_and_run.sh
+++ b/flushall_build_and_run.sh
@@ -129,6 +129,32 @@ echo "✓ Build log saved to: build.log"
 echo ""
 
 ################################################################################
+# PICK A FREE PORT (auto-switch if the configured one is already in use)
+################################################################################
+
+# dev.port -> OBP_DEV_PORT env var (APIUtil.getPropsValue checks env before
+# props, see Http4sServer.scala's getPropsAsIntValue("dev.port", 8080)), so
+# exporting this here is enough to actually move the server off a busy port.
+DEV_PORT="${OBP_DEV_PORT:-8080}"
+if lsof -nP -iTCP:"$DEV_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    ORIGINAL_PORT="$DEV_PORT"
+    FOUND_FREE_PORT=false
+    for candidate in $(seq $((DEV_PORT + 1)) $((DEV_PORT + 50))); do
+        if ! lsof -nP -iTCP:"$candidate" -sTCP:LISTEN >/dev/null 2>&1; then
+            DEV_PORT="$candidate"
+            FOUND_FREE_PORT=true
+            break
+        fi
+    done
+    if [ "$FOUND_FREE_PORT" = false ]; then
+        echo "❌ Port $ORIGINAL_PORT is already in use and no free port was found in $((ORIGINAL_PORT + 1))-$((ORIGINAL_PORT + 50))."
+        exit 1
+    fi
+    echo "⚠ Port $ORIGINAL_PORT is already in use — switching to port $DEV_PORT"
+fi
+export OBP_DEV_PORT="$DEV_PORT"
+
+################################################################################
 # RUN HTTP4S SERVER
 ################################################################################
 
@@ -138,6 +164,7 @@ if [ "$RUN_BACKGROUND" = true ]; then
 else
     echo "Starting HTTP4S server (foreground)..."
 fi
+echo "  PORT: $DEV_PORT"
 echo "=========================================="
 
 # Java options for runtime
@@ -155,15 +182,21 @@ JAVA_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED \
 RUNTIME_LOG=/tmp/obp-api.log
 
 if [ "$RUN_BACKGROUND" = true ]; then
-    # Run in background with output to log file (tee'd to /tmp as well)
-    nohup java $JAVA_OPTS -jar obp-api/target/obp-api.jar > >(tee "$RUNTIME_LOG") 2>&1 &
+    # Run in background with output to log file. Redirect straight to the file
+    # (not `> >(tee "$RUNTIME_LOG")`): that process-substitution form spawns a
+    # `tee` that inherits this script's own stdout fd, which — when this script
+    # is itself invoked from a caller capturing output via `$(... | tee ...)`
+    # (e.g. smoke_test.sh's start_and_test) — keeps that caller's pipe open for
+    # as long as the server runs, so `$(...)` never returns. A plain file
+    # redirect closes cleanly with this script's own exit.
+    nohup java $JAVA_OPTS -jar obp-api/target/obp-api.jar > "$RUNTIME_LOG" 2>&1 &
     SERVER_PID=$!
     echo "✓ HTTP4S server started in background"
     echo "  PID: $SERVER_PID"
-    echo "  Log: http4s-server.log (also $RUNTIME_LOG)"
+    echo "  Log: $RUNTIME_LOG"
     echo ""
     echo "To stop the server: kill $SERVER_PID"
-    echo "To view logs: tail -f http4s-server.log"
+    echo "To view logs: tail -f $RUNTIME_LOG"
 else
     # Run in foreground (Ctrl+C to stop). Also tee output to /tmp so it can be
     # tailed from another terminal without taking over this one.

--- a/flushall_fast_build_and_run.sh
+++ b/flushall_fast_build_and_run.sh
@@ -297,6 +297,32 @@ echo "✓ Build log saved to: fast_build.log"
 echo ""
 
 ################################################################################
+# PICK A FREE PORT (auto-switch if the configured one is already in use)
+################################################################################
+
+# dev.port -> OBP_DEV_PORT env var (APIUtil.getPropsValue checks env before
+# props, see Http4sServer.scala's getPropsAsIntValue("dev.port", 8080)), so
+# exporting this here is enough to actually move the server off a busy port.
+DEV_PORT="${OBP_DEV_PORT:-8080}"
+if lsof -nP -iTCP:"$DEV_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    ORIGINAL_PORT="$DEV_PORT"
+    FOUND_FREE_PORT=false
+    for candidate in $(seq $((DEV_PORT + 1)) $((DEV_PORT + 50))); do
+        if ! lsof -nP -iTCP:"$candidate" -sTCP:LISTEN >/dev/null 2>&1; then
+            DEV_PORT="$candidate"
+            FOUND_FREE_PORT=true
+            break
+        fi
+    done
+    if [ "$FOUND_FREE_PORT" = false ]; then
+        echo "❌ Port $ORIGINAL_PORT is already in use and no free port was found in $((ORIGINAL_PORT + 1))-$((ORIGINAL_PORT + 50))."
+        exit 1
+    fi
+    echo "⚠ Port $ORIGINAL_PORT is already in use — switching to port $DEV_PORT"
+fi
+export OBP_DEV_PORT="$DEV_PORT"
+
+################################################################################
 # RUN HTTP4S SERVER
 ################################################################################
 
@@ -306,6 +332,7 @@ if [ "$RUN_BACKGROUND" = true ]; then
 else
     echo "Starting HTTP4S server (foreground)..."
 fi
+echo "  PORT: $DEV_PORT"
 echo "=========================================="
 
 # Java options for runtime


### PR DESCRIPTION
## Summary
- `flushall_build_and_run.sh` and `flushall_fast_build_and_run.sh` now probe `dev.port` (default 8080) before starting the server; if it's already bound, they walk forward to the next free port in a 50-port range and export it via `OBP_DEV_PORT` (no props-file change needed, since `APIUtil.getPropsValue` checks env vars before props). Both scripts print `PORT: <n>` alongside the existing `PID: <n>` line.
- Fixes a hang in `flushall_build_and_run.sh`'s background mode: it launched the server with `> >(tee "$RUNTIME_LOG") 2>&1`, a process substitution whose inner `tee` inherits the script's own stdout fd. When a caller captures this script's output via `$(... | tee ...)` (the pattern the local `obp-api-test` smoke-test skill uses), that inherited fd keeps the caller's pipe open for as long as the server runs, so the command substitution never returns even though the meaningful output already printed. Switched to a plain file redirect, matching `flushall_fast_build_and_run.sh` (which never had this problem).

## Test plan
- [x] Verified both scripts auto-switch to a free port when 8080 is occupied by another local process, and the server boots and answers `/root` on the new port
- [x] Verified the previously-hanging `out=$(./flushall_build_and_run.sh --background 2>&1 | tee /dev/stderr)` pattern now returns promptly after printing PID/PORT
- [x] Ran the full local `obp-api-test` 6-step smoke test end-to-end (test suite → build+run → get root → kill → fast-rebuild+run → get root) with port 8080 occupied — all 6 steps passed