### PR TITLE
fix(cache): apply cache.redis.password and redis.use.ssl on every Redis connection

### DIFF
--- a/obp-api/src/main/resources/props/sample.props.template
+++ b/obp-api/src/main/resources/props/sample.props.template
@@ -1085,10 +1085,14 @@ featured_apis=elasticSearchWarehouseV300
 ## Note: You do NOT need to include anything here for this to work.
 
 # -- Redis cache -------------------------------------
+# The 127.0.0.1 default is a deliberate security default: Redis must not be bound to a
+# public interface. If you enable authentication (requirepass) or TLS on Redis, set the
+# properties below - they are honoured by both the direct and the memoize-backed cache paths.
 # cache.redis.url=127.0.0.1
 # cache.redis.port=6379
 # Default value is empty or omitted props
 # cache.redis.password =
+# redis.use.ssl=false
 # ---------------------------------------------------------
 
 # -- New Style Endpoints -----------------------

--- a/obp-api/src/main/scala/code/api/cache/Redis.scala
+++ b/obp-api/src/main/scala/code/api/cache/Redis.scala
@@ -46,15 +46,34 @@ object Redis extends MdcLoggable {
   poolConfig.setNumTestsPerEvictionRun(3)
   poolConfig.setBlockWhenExhausted(true)
 
+  // Lazy so the keystore/truststore files are only read when redis.use.ssl is on, and only once
+  // even though both jedisPool and every subscriber connection need the socket factory.
+  private lazy val sslContext: SSLContext = configureSslContext()
+
   val jedisPool =
     if (useSsl) {
       // SSL connection: Use SSLContext with JedisPool
-      val sslContext = configureSslContext()
       new JedisPool(poolConfig, url, port, timeout, password, true, sslContext.getSocketFactory, null, null)
     } else {
       // Non-SSL connection
       new JedisPool(poolConfig, url, port, timeout, password)
     }
+
+  /**
+   * Build a dedicated, non-pooled connection for a pub/sub subscriber.
+   *
+   * `subscribe`/`psubscribe` occupy their connection for the whole life of the subscription,
+   * so subscribers cannot lease from jedisPool. They must still apply the same password and
+   * TLS settings the pool uses: the plain `Jedis(url, port, timeout)` constructor is
+   * unencrypted, so building one directly silently ignores redis.use.ssl.
+   */
+  def newSubscriberConnection(): Jedis = {
+    val jedis =
+      if (useSsl) new Jedis(url, port, timeout, true, sslContext.getSocketFactory, null, null)
+      else new Jedis(url, port, timeout)
+    if (password != null) jedis.auth(password)
+    jedis
+  }
 
   // Redis startup health check
   private def performStartupHealthCheck(): Unit = {

--- a/obp-api/src/main/scala/code/api/cache/Redis.scala
+++ b/obp-api/src/main/scala/code/api/cache/Redis.scala
@@ -290,7 +290,11 @@ object Redis extends MdcLoggable {
     }
   }
 
-  implicit val scalaCache = ScalaCache(RedisCache(url, port))
+  // Reuse the pool built above so the memoize-backed cache shares the same authenticated,
+  // optionally SSL-configured connection. The RedisCache(url, port) overload builds its own
+  // JedisPool internally with no password and no SSL, so with `requirepass` enabled it fails
+  // with NOAUTH while the jedisPool-based paths keep working.
+  implicit val scalaCache = ScalaCache(RedisCache(jedisPool))
   implicit val flags = Flags(readsEnabled = true, writesEnabled = true)
 
   implicit def anyToByte[T](implicit m: Manifest[T]) = new Codec[T, Array[Byte]] {

--- a/obp-api/src/main/scala/code/chat/ChatEventBus.scala
+++ b/obp-api/src/main/scala/code/chat/ChatEventBus.scala
@@ -123,8 +123,7 @@ object ChatEventBus extends MdcLoggable {
     subscriberThread = new Thread(() => {
       try {
         // Dedicated connection for the subscriber (not from the pool)
-        subscriberJedis = new Jedis(Redis.url, Redis.port, Redis.timeout)
-        if (Redis.password != null) subscriberJedis.auth(Redis.password)
+        subscriberJedis = Redis.newSubscriberConnection()
         logger.info(s"ChatEventBus says: Redis subscriber started, pattern-subscribing to ${CHANNEL_PREFIX}*")
         subscriberJedis.psubscribe(pubSub, s"${CHANNEL_PREFIX}*")
       } catch {

--- a/obp-api/src/main/scala/code/logcache/LogCacheEventBus.scala
+++ b/obp-api/src/main/scala/code/logcache/LogCacheEventBus.scala
@@ -107,8 +107,7 @@ object LogCacheEventBus extends MdcLoggable {
 
     subscriberThread = new Thread(() => {
       try {
-        subscriberJedis = new Jedis(Redis.url, Redis.port, Redis.timeout)
-        if (Redis.password != null) subscriberJedis.auth(Redis.password)
+        subscriberJedis = Redis.newSubscriberConnection()
         logger.info(s"LogCacheEventBus says: Redis subscriber started, pattern-subscribing to ${CHANNEL_PREFIX}*")
         subscriberJedis.psubscribe(pubSub, s"${CHANNEL_PREFIX}*")
       } catch {

--- a/obp-api/src/main/scala/code/metricsstream/MetricsEventBus.scala
+++ b/obp-api/src/main/scala/code/metricsstream/MetricsEventBus.scala
@@ -102,8 +102,7 @@ object MetricsEventBus extends MdcLoggable {
 
     subscriberThread = new Thread(() => {
       try {
-        subscriberJedis = new Jedis(Redis.url, Redis.port, Redis.timeout)
-        if (Redis.password != null) subscriberJedis.auth(Redis.password)
+        subscriberJedis = Redis.newSubscriberConnection()
         logger.info(s"MetricsEventBus says: Redis subscriber started, subscribing to $ALL_CHANNEL")
         subscriberJedis.subscribe(pubSub, ALL_CHANNEL)
       } catch {


### PR DESCRIPTION
## Problem

`code/api/cache/Redis.scala` reads `cache.redis.password` and `redis.use.ssl`, but not every connection path applied them. Two gaps, both of which only surface once an operator actually hardens Redis:

**1. The memoize cache ignored the password (and TLS).**

`jedisPool` passes both settings, and is what rate limiting, idempotency, the health check and `Redis.use` lease from. But the memoize store was built separately:

```scala
implicit val scalaCache = ScalaCache(RedisCache(url, port))
```

`scalacache-redis` 0.9.3's `RedisCache.apply(String, int)` constructs its **own** internal `JedisPool` with no password and no SSL. That store backs `memoizeWithRedis` / `memoizeSyncWithRedis`, which serve `Caching.memoizeWithProvider` / `memoizeSyncWithProvider` — the main API caching layer, including connector result caching (31 call sites across 22 files).

With `requirepass` enabled, that path fails with `NOAUTH` while `performStartupHealthCheck()` — which leases from `jedisPool` — still logs `Redis health check PASSED`. The failure surfaces only as cache misses and a performance collapse, with clean-looking logs.

**2. The pub/sub subscribers ignored TLS.**

`ChatEventBus`, `LogCacheEventBus` and `MetricsEventBus` each built their subscriber connection with the plaintext `Jedis(url, port, timeout)` constructor. They authenticated explicitly, so the password was applied, but `redis.use.ssl` was silently dropped: with TLS on, the pool and the memoize cache spoke TLS while these three streaming buses tried to connect in plaintext.

## Fix

**Memoize store** — reuse the pool that already has both settings:

```scala
implicit val scalaCache = ScalaCache(RedisCache(jedisPool))
```

The `RedisCache(JedisPool, Option[ClassLoader])` overload resolves with its default second argument.

**Subscribers** — they genuinely cannot lease from `jedisPool`, since `subscribe`/`psubscribe` occupy their connection for the life of the subscription. Rather than have each call site reassemble the connection settings, add `Redis.newSubscriberConnection()`, which applies the same password and TLS configuration the pool uses, and have the three buses call it. `sslContext` becomes a `lazy val` so the keystore and truststore are read once, and only when `redis.use.ssl` is on.

**Docs** — `sample.props.template` now lists `redis.use.ssl` alongside `cache.redis.password` in the Redis block, and notes that the `127.0.0.1` default is a deliberate security default: Redis should not be bound to a public interface.

## Verification

Against a local `requirepass`-protected Redis:

| Scenario | Before | After |
|---|---|---|
| memoize round trip | never caches — every call recomputes, 0 keys written (silent `NOAUTH`) | caches; second call served from Redis |

Against a local TLS-only, `requirepass`-protected Redis (self-signed CA; the port rejects plaintext):

| Scenario | Before | After |
|---|---|---|
| subscriber connect + pub/sub round trip | `JedisConnectionException: Connection reset` | authenticates and delivers the message |

No-password and no-SSL defaults are unchanged: a null password still yields an unauthenticated connection, and `MethodRoutingCacheInvalidationTest` + `RedisDeserializeMissTest` (5 tests, exercising the memoize path against a passwordless Redis) pass.

All connection construction sites were audited (`new JedisPool`, `new Jedis`, `RedisCache(`, `JedisPubSub`): the pool, the memoize store, the three subscribers, and `RedisMessaging` / `RedisLogger` / `ConnectorMetricsRedis` (all of which already go through the pool). The cache-config endpoint exposes only `url`, `port` and `use_ssl` — never the password.

CI is green on both commits (9 test shards + compile + docker).