### PR TITLE
fix: nine consent-access defects raised in review of #2881

### DIFF
--- a/obp-api/src/main/resources/props/sample.props.template
+++ b/obp-api/src/main/resources/props/sample.props.template
@@ -1896,6 +1896,20 @@ securelogging_mask_email=true
 # already configured for Berlin Group Redirect SCA needs no edit.
 # sca_front_end_consumer_ids=
 
+# Let a consent that records no lodging TPP be addressed by any authenticated caller.
+#
+# A consent belongs to the Consumer that lodged it -- Berlin Group states it for the whole API
+# ("all methods submitted by a TPP ... may only apply to resources which have been created by the
+# same TPP before", Implementation Guidelines 4.11) and UK scopes GET and DELETE of an
+# account-access-consent to one "that they have created". A row recording no Consumer therefore
+# matches no caller, and is refused.
+#
+# Rows like that exist: they predate the Consumer being recorded on a consent at all. Turning this
+# on restores the old behaviour for them -- and the old behaviour is that ANY authenticated caller
+# can read and revoke them, which is why it is off by default and warns on every use. It is a
+# migration window, not a setting: re-lodge the affected consents and turn it back off.
+# consent_allow_legacy_unrecorded_tpp=false
+
 # Berlin Group: the Consumers that are this ASPSP's own Strong Customer Authentication front end,
 # comma separated consumer ids. Under the Redirect approach the PSU authenticates at the ASPSP, so
 # the authorisation calls on /berlin-group/v1.3/consents/{id}/authorisations arrive from that front

--- a/obp-api/src/main/scala/code/api/UKOpenBanking/UKTransactionsQuery.scala
+++ b/obp-api/src/main/scala/code/api/UKOpenBanking/UKTransactionsQuery.scala
@@ -101,7 +101,7 @@ object UKTransactionsQuery extends MdcLoggable {
    * that lost rows to the filter is the exact signature, and it tells an operator which connector
    * still needs to honour the param.
    */
-  private def warnIfPageWasTrimmed(
+  def warnIfPageWasTrimmed(
     fetched: List[ModeratedTransaction],
     kept: List[ModeratedTransaction],
     params: List[OBPQueryParam],

--- a/obp-api/src/main/scala/code/api/UKOpenBanking/v3_1_0/Http4sUKOBv310AccountAccess.scala
+++ b/obp-api/src/main/scala/code/api/UKOpenBanking/v3_1_0/Http4sUKOBv310AccountAccess.scala
@@ -188,7 +188,7 @@ object Http4sUKOBv310AccountAccess extends MdcLoggable {
         for {
           _ <- passesPsd2Aisp(Some(cc))
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
-            unboxFullOrFail(_, Some(cc), ConsentNotFound)
+            unboxFullOrFail(_, Some(cc), ConsentNotFound, 403)
           }
           _ <- Consent.assertUKConsentAccess(consent.userId, consent.consumerId, cc)
           _ <- Future(Consents.consentProvider.vend.revoke(consentId)) map {
@@ -222,7 +222,7 @@ object Http4sUKOBv310AccountAccess extends MdcLoggable {
       EndpointHelpers.executeAndRespond(req) { cc =>
         for {
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
-            unboxFullOrFail(_, Some(cc), s"$ConsentNotFound ($consentId)")
+            unboxFullOrFail(_, Some(cc), ConsentNotFound, 403)
           }
           _ <- Consent.assertUKConsentAccess(consent.userId, consent.consumerId, cc)
           consentViews <- Future(JwtUtil.getSignedPayloadAsJson(consent.jsonWebToken).map(

--- a/obp-api/src/main/scala/code/api/UKOpenBanking/v4_0_1/Http4sUKOBv401AccountInfo.scala
+++ b/obp-api/src/main/scala/code/api/UKOpenBanking/v4_0_1/Http4sUKOBv401AccountInfo.scala
@@ -11,7 +11,7 @@ import code.api.util.APIUtil.{EmptyBody, ResourceDoc, HTTPParam, UserOrApplicati
 import code.api.util.ApiTag
 import code.api.util.CallContext
 import code.api.util.CustomJsonFormats
-import code.api.util.ErrorMessages.{AuthenticatedUserIsRequired, ConsentNotFound, ConsentViewNotFund, InvalidJsonFormat, InvalidUKConsentPermissions, UnknownError}
+import code.api.util.ErrorMessages.{AuthenticatedUserIsRequired, BankNotFound, ConsentNotFound, ConsentViewNotFund, InvalidJsonFormat, InvalidUKConsentPermissions, UnknownError}
 import code.api.util.http4s.Http4sRequestAttributes.{EndpointHelpers, RequestOps}
 import code.api.util.newstyle.ViewNewStyle
 import code.api.util.{APIUtil, Consent, ConsentJWT, JwtUtil, NewStyle}
@@ -24,7 +24,7 @@ import com.github.dwickern.macros.NameOf.nameOf
 import com.openbankproject.commons.model.{AccountId, BankId, BankIdAccountId, TransactionAttribute, View, ViewId}
 import com.openbankproject.commons.util.{ApiVersion, ScannedApiVersion}
 import com.openbankproject.commons.util.JsonAliases
-import net.liftweb.common.Full
+import net.liftweb.common.{Box, Full}
 import org.json4s.{Formats, JObject}
 import org.http4s._
 import org.http4s.dsl.io._
@@ -229,7 +229,7 @@ object Http4sUKOBv401AccountInfo extends MdcLoggable {
       EndpointHelpers.executeAndRespond(req) { cc =>
         for {
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
-            unboxFullOrFail(_, Some(cc), s"$ConsentNotFound ($consentId)")
+            unboxFullOrFail(_, Some(cc), ConsentNotFound, 403)
           }
           _ <- Consent.assertUKConsentAccess(consent.userId, consent.consumerId, cc)
           consentViews <- Future(JwtUtil.getSignedPayloadAsJson(consent.jsonWebToken).map(
@@ -275,7 +275,7 @@ object Http4sUKOBv401AccountInfo extends MdcLoggable {
         for {
           _ <- passesPsd2Aisp(Some(cc))
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
-            unboxFullOrFail(_, Some(cc), ConsentNotFound)
+            unboxFullOrFail(_, Some(cc), ConsentNotFound, 403)
           }
           _ <- Consent.assertUKConsentAccess(consent.userId, consent.consumerId, cc)
           _ <- Future(Consents.consentProvider.vend.revoke(consentId)) map {
@@ -3503,6 +3503,11 @@ object Http4sUKOBv401AccountInfo extends MdcLoggable {
           (bank, _) <- NewStyle.function.getBank(BankId(defaultBankId), Some(cc))
           availablePrivateAccounts <- Views.views.vend.getPrivateBankAccountsFuture(u)
           (accounts, _) <- NewStyle.function.getBankAccounts(availablePrivateAccounts, Some(cc))
+          // One lookup per distinct bank rather than one per account: a consent may name accounts at
+          // several banks, and moderation needs each account's own.
+          banksById <- Future.sequence(accounts.map(_.bankId).distinct.map { bankId =>
+            NewStyle.function.getBank(bankId, Some(cc)).map { case (b, _) => bankId -> b }
+          }).map(_.toMap)
           allTxns <- Future {
             val detailViewId = ViewId(Constant.SYSTEM_READ_TRANSACTIONS_DETAIL_VIEW_ID)
             val basicViewId = ViewId(Constant.SYSTEM_READ_TRANSACTIONS_BASIC_VIEW_ID)
@@ -3515,9 +3520,25 @@ object Http4sUKOBv401AccountInfo extends MdcLoggable {
                 // per-account endpoint does.
                 view <- APIUtil.checkViewAccessAndReturnView(detailViewId, BankIdAccountId(bankAccount.bankId, bankAccount.accountId), Full(u), Some(cc))
                   .or(APIUtil.checkViewAccessAndReturnView(basicViewId, BankIdAccountId(bankAccount.bankId, bankAccount.accountId), Full(u), Some(cc)))
+                // The account's own bank, not the instance's default one. moderateTransactionsWithSameAccount
+                // builds the moderated account from whatever Bank it is handed and then refuses every
+                // transaction that does not belong to it -- so passing the default bank returned an empty
+                // list for every account not held there, logging "Attempted to moderate a transaction using
+                // the incorrect moderated account" once per row. The `.getOrElse(Nil)` below is what made
+                // that look like "this account has no transactions" rather than like a failure.
+                accountBank <- Box(banksById.get(bankAccount.bankId)) ?~! s"$BankNotFound ${bankAccount.bankId.value}"
                 params = createQueriesByHttpParams(req.headers.headers.toList.map(h => HTTPParam(h.name.toString, List(h.value)))).getOrElse(Nil)
-                (transactions, _) <- BankAccountExtended(bankAccount).getModeratedTransactions(bank, Full(u), view, BankIdAccountId(bankAccount.bankId, bankAccount.accountId), Some(cc), params)
-              } yield transactions).getOrElse(Nil)
+                // Resolved per account, because a consent can grant different directions on different
+                // accounts. Same three calls the per-account endpoint makes through UKTransactionsQuery:
+                // the query param so the database applies the restriction with the page limit, and the
+                // filter so the restriction still holds when the connector ignores the param.
+                grantsCredits = UKAmounts.grantsView(Constant.SYSTEM_READ_TRANSACTIONS_CREDITS_VIEW_ID, bankAccount.bankId, bankAccount.accountId, u, cc)
+                grantsDebits = UKAmounts.grantsView(Constant.SYSTEM_READ_TRANSACTIONS_DEBITS_VIEW_ID, bankAccount.bankId, bankAccount.accountId, u, cc)
+                directedParams = params ++ UKAmounts.directionQueryParam(grantsCredits, grantsDebits)
+                (transactions, _) <- BankAccountExtended(bankAccount).getModeratedTransactions(accountBank, Full(u), view, BankIdAccountId(bankAccount.bankId, bankAccount.accountId), Some(cc), directedParams)
+                directed = UKAmounts.filterByGrantedDirections(transactions, grantsCredits, grantsDebits)
+                _ = UKTransactionsQuery.warnIfPageWasTrimmed(transactions, directed, directedParams, cc)
+              } yield directed).getOrElse(Nil)
             }
           }
         } yield JSONFactory_UKOpenBanking_401.createTransactionsJson(bank.bankId, allTxns)

--- a/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13AIS.scala
+++ b/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13AIS.scala
@@ -163,11 +163,7 @@ object Http4sBGv13AIS extends MdcLoggable {
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
             unboxFullOrFail(_, callContext, ConsentNotFound, 403)
           }
-          consumerIdFromConsent = consent.mConsumerId.get
-          consumerIdFromCurrentCall = callContext.map(_.consumer.map(_.consumerId.get).getOrElse("None")).getOrElse("None")
-          _ <- booleanToFuture(failMsg = ConsentNotFound, failCode = 403, cc = callContext) {
-            consumerIdFromConsent == consumerIdFromCurrentCall
-          }
+          _ <- Consent.assertBerlinGroupConsentReadAccess(consent.userId, consent.consumerId, cc)
           _ <- Future(Consents.consentProvider.vend.revokeBerlinGroupConsent(consentId)) map {
             i => connectorEmptyResponse(i, callContext)
           }
@@ -324,9 +320,7 @@ object Http4sBGv13AIS extends MdcLoggable {
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
             unboxFullOrFail(_, callContext, s"$ConsentNotFound ($consentId)")
           }
-          _ <- booleanToFuture(failMsg = ConsentNotFound, failCode = 403, cc = callContext) {
-            consent.mConsumerId.get == cc.consumer.map(_.consumerId.get).getOrElse("None")
-          }
+          _ <- Consent.assertBerlinGroupConsentReadAccess(consent.userId, consent.consumerId, cc)
           (challenges, callContext) <- NewStyle.function.getChallengesByConsentId(consentId, callContext)
         } yield {
           JSONFactory_BERLIN_GROUP_1_3.AuthorisationJsonV13(challenges.map(_.challengeId))
@@ -344,11 +338,7 @@ object Http4sBGv13AIS extends MdcLoggable {
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
             unboxFullOrFail(_, callContext, s"$ConsentNotFound ($consentId)")
           }
-          consumerIdFromConsent = consent.mConsumerId.get
-          consumerIdFromCurrentCall = callContext.map(_.consumer.map(_.consumerId.get).getOrElse("None")).getOrElse("None")
-          _ <- booleanToFuture(failMsg = ConsentNotFound, failCode = 403, cc = callContext) {
-            consumerIdFromConsent == consumerIdFromCurrentCall
-          }
+          _ <- Consent.assertBerlinGroupConsentReadAccess(consent.userId, consent.consumerId, cc)
         } yield {
           createGetConsentResponseJson(consent)
         }
@@ -368,9 +358,7 @@ object Http4sBGv13AIS extends MdcLoggable {
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
             unboxFullOrFail(_, callContext, s"$ConsentNotFound ($consentId)", 403)
           }
-          _ <- booleanToFuture(failMsg = ConsentNotFound, failCode = 403, cc = callContext) {
-            consent.mConsumerId.get == cc.consumer.map(_.consumerId.get).getOrElse("None")
-          }
+          _ <- Consent.assertBerlinGroupConsentReadAccess(consent.userId, consent.consumerId, cc)
           (challenges, callContext) <- NewStyle.function.getChallengesByConsentId(consentId, callContext)
         } yield {
           val challengeStatus = challenges.filter(_.challengeId == authorisationId)
@@ -393,9 +381,7 @@ object Http4sBGv13AIS extends MdcLoggable {
           // Same ownership test as the three sibling reads of this consent. Without it the status of
           // any consent was readable by any AISP holding its id -- which is enough to confirm the
           // consent exists and to watch it move through authorisation.
-          _ <- booleanToFuture(failMsg = ConsentNotFound, failCode = 403, cc = callContext) {
-            consent.mConsumerId.get == cc.consumer.map(_.consumerId.get).getOrElse("None")
-          }
+          _ <- Consent.assertBerlinGroupConsentReadAccess(consent.userId, consent.consumerId, cc)
         } yield {
           JSONFactory_BERLIN_GROUP_1_3.ConsentStatusJsonV13(consent.status)
         }

--- a/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13AIS.scala
+++ b/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13AIS.scala
@@ -318,7 +318,7 @@ object Http4sBGv13AIS extends MdcLoggable {
           // than access, but the asymmetry between two neighbouring reads of the same consent was an
           // oversight, not a decision.
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
-            unboxFullOrFail(_, callContext, s"$ConsentNotFound ($consentId)")
+            unboxFullOrFail(_, callContext, ConsentNotFound, 403)
           }
           _ <- Consent.assertBerlinGroupConsentReadAccess(consent.userId, consent.consumerId, cc)
           (challenges, callContext) <- NewStyle.function.getChallengesByConsentId(consentId, callContext)
@@ -336,7 +336,7 @@ object Http4sBGv13AIS extends MdcLoggable {
         for {
           _ <- passesPsd2Aisp(callContext)
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
-            unboxFullOrFail(_, callContext, s"$ConsentNotFound ($consentId)")
+            unboxFullOrFail(_, callContext, ConsentNotFound, 403)
           }
           _ <- Consent.assertBerlinGroupConsentReadAccess(consent.userId, consent.consumerId, cc)
         } yield {

--- a/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13PIS.scala
+++ b/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13PIS.scala
@@ -106,7 +106,7 @@ object Http4sBGv13PIS extends MdcLoggable {
       // the wire, and that model's shape is a frozen contract.
       lodgedByConsumer = TransactionRequests.transactionRequestProvider.vend
         .getMappedTransactionRequest(TransactionRequestId(paymentId))
-        .map(_.mConsumerId.get).toOption.filter(_.nonEmpty)
+        .toOption.flatMap(tr => Consent.present(tr.mConsumerId.get))
       sameTpp = lodgedByConsumer.forall(lodgedBy => callingConsumer.contains(lodgedBy))
       _ <- Helper.booleanToFuture(s"$PaymentNotInitiatedByCaller Payment id: $paymentId.", 403, callContext) {
         sameTpp && initiators.exists(callers)

--- a/obp-api/src/main/scala/code/api/util/ConsentUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/ConsentUtil.scala
@@ -137,6 +137,24 @@ object Consent extends MdcLoggable {
   final lazy val challengeAnswerAtTestEnvironment = "123"
 
   /**
+   * An identifier a row does not carry, read safely: None for absent, blank, or whitespace.
+   *
+   * Every id the ownership rules below compare arrives out of a MappedString, and a MappedString
+   * that was never written holds a Java null rather than "" -- MappedConsent and
+   * MappedTransactionRequestProvider both write the absent case as a literal null. So `.nonEmpty`
+   * on the raw value is not a blankness test, it is a NullPointerException waiting for the first
+   * row that predates the column, and on any long-lived instance nearly every row does.
+   *
+   * Trimming as well, because "the consent names no TPP" and "the consent names a TPP whose id is
+   * three spaces" have to reach the same decision -- a rule that refuses one and admits the other
+   * is not a rule.
+   *
+   * Public rather than local to each caller: it was written four times inside this object before a
+   * fifth caller in Http4sBGv13PIS omitted it and returned 500 on 1757 of 1800 stored payments.
+   */
+  def present(s: String): Option[String] = Option(s).map(_.trim).filter(_.nonEmpty)
+
+  /**
     * Purpose of this helper function is to get the Consumer-Key value from a Request Headers.
     * @return the Consumer-Key value from a Request Header as a String
     */
@@ -1721,8 +1739,6 @@ object Consent extends MdcLoggable {
     callerConsumerId: Option[String],
     callerIsScaFrontEnd: Boolean
   ): Option[String] = {
-    def present(s: String): Option[String] = Option(s).map(_.trim).filter(_.nonEmpty)
-
     (present(consentUserId), callerUserId.flatMap(present)) match {
       case (Some(psu), Some(caller)) if psu != caller => Some(ErrorMessages.ConsentDoesNotMatchUser)
       case (Some(_), Some(_)) => None
@@ -1761,8 +1777,6 @@ object Consent extends MdcLoggable {
     callerUserId: Option[String],
     callerConsumerId: Option[String]
   ): Option[String] = {
-    def present(s: String): Option[String] = Option(s).map(_.trim).filter(_.nonEmpty)
-
     (present(consentUserId), callerUserId.flatMap(present)) match {
       case (Some(psu), Some(caller)) =>
         // The consent belongs to a PSU and the caller is acting as one: they must be the same PSU.
@@ -1836,8 +1850,6 @@ object Consent extends MdcLoggable {
     ukConsentUnresolved.filterNot(_ => requestUrl.contains(UK_CONSENT_MANAGEMENT_URL_SEGMENT))
 
   def checkObpConsentUserAccess(consentUserId: String, callerHumanUserId: Option[String]): Option[String] = {
-    def present(s: String): Option[String] = Option(s).map(_.trim).filter(_.nonEmpty)
-
     present(consentUserId) match {
       case Some(psu) if !callerHumanUserId.flatMap(present).contains(psu) =>
         Some(ErrorMessages.ConsentNotFound)
@@ -2001,8 +2013,6 @@ object Consent extends MdcLoggable {
     sessionPsuId: Option[String],
     headerPsuId: Option[String]
   ): Either[String, String] = {
-    def present(s: String): Option[String] = Option(s).map(_.trim).filter(_.nonEmpty)
-
     val alreadyKnown = present(consentUserId).orElse(sessionPsuId.flatMap(present))
 
     (alreadyKnown, headerPsuId.flatMap(present)) match {

--- a/obp-api/src/main/scala/code/api/util/ConsentUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/ConsentUtil.scala
@@ -1078,6 +1078,33 @@ object Consent extends MdcLoggable {
    * checkUKConsent still applies everything it did before as well: wrong standard, revoked, expired,
    * bound to a different PSU, held by a different consumer.
    */
+  /**
+   * Which PSU a UK consent named on an access token runs for, or the reason to refuse.
+   *
+   * The PSU comes off the consent row, as it does on the header path in applyUKRules -- the consent
+   * is the record of whose data this is, and the token is a claim about it. The token's subject then
+   * has to BE that PSU, which is the substance of the profile binding a token to one consent and one
+   * person: the intent id is carried into the request object so that "the access token that is
+   * eventually generated [is] bound to a specific consent".
+   *
+   * Both halves matter and one of them is easy to lose. Deriving the PSU from the consent and
+   * dropping the comparison would make checkUKConsent's own check -- mUserId against consenter --
+   * compare the consent's user with itself and pass for anybody's token. So the comparison moves
+   * here rather than going away, and moving it is the gain: this runs on every request and its
+   * refusal is enforced by ResourceDocMiddleware, whereas checkUKConsent runs only on the UK read
+   * endpoints.
+   *
+   * A consent naming no PSU is refused rather than falling back to the token's user. Such a consent
+   * was never authorised, so there is nobody it is on behalf of, and "we cannot tell whose this is"
+   * is a reason to serve nothing.
+   */
+  def ukTokenPathPsuId(consentUserId: String, tokenUserId: String): Either[String, String] =
+    present(consentUserId) match {
+      case None => Left(ErrorMessages.ConsentNotFound)
+      case Some(psuId) if psuId != tokenUserId => Left(ErrorMessages.ConsentDoesNotMatchUser)
+      case Some(psuId) => Right(psuId)
+    }
+
   def applyUKConsentPrincipalFromToken(user: Box[User],
                                        callContext: Option[CallContext]): (Box[User], Option[CallContext]) = {
     // Whether this request is exercising a UK consent at all. None at any step means it is not --
@@ -1100,23 +1127,29 @@ object Consent extends MdcLoggable {
     // "carry on as the PSU": that serves everything the PSU can see, which is the whole of what the
     // consent exists to narrow. ConsentNotFound for an unreadable JWT matches what applyUKRules
     // answers on the header path for the same row.
-    def resolve(psu: User, storedConsent: MappedConsent): Box[User] = for {
+    // Returns the principal to run as and the PSU it is running on behalf of, in that order.
+    def resolve(tokenUser: User, storedConsent: MappedConsent): Box[(User, User)] = for {
       consentJwt <- {
         implicit val dateFormats = CustomJsonFormats.formats
         JwtUtil.getSignedPayloadAsJson(storedConsent.jsonWebToken).map(parse(_).extract[ConsentJWT])
       } ?~! ErrorMessages.ConsentNotFound
+      psuId <- ukTokenPathPsuId(storedConsent.userId, tokenUser.userId) match {
+        case Right(id) => Full(id)
+        case Left(reason) => Failure(reason)
+      }
+      psu <- Users.users.vend.getUserByUserId(psuId) ?~! ErrorMessages.ConsentNotFound
       principal <- resolveUKConsentPrincipal(storedConsent, consentJwt, psu)
-    } yield principal
+    } yield (principal, psu)
 
     namedConsent match {
       case None => (user, callContext)
-      case Some((cc, psu, storedConsent)) =>
+      case Some((cc, tokenUser, storedConsent)) =>
         // A throw is as unresolved as a Failure, and for the same reason it must not fall through:
         // the fallback is the PSU. Box.map does not catch, so an unextractable ConsentJWT arrives
         // here as a MappingException rather than as a Failure.
-        val outcome = Try(resolve(psu, storedConsent))
+        val outcome = Try(resolve(tokenUser, storedConsent))
         outcome match {
-          case Success(Full(principal)) =>
+          case Success(Full((principal, psu))) =>
             (Full(principal), Some(cc.copy(
               user = Full(principal),
               consenter = Full(psu),
@@ -2018,9 +2051,18 @@ object Consent extends MdcLoggable {
       consentUserId, consentConsumerId,
       actingPsu(callContext).map(_.userId), callContext.consumer.map(_.consumerId.get),
       isScaFrontEnd(callContext.consumer.map(_.consumerId.get)))
-    // booleanToFuture only reads failMsg when the statement is false, so the empty default is never
-    // the message anyone sees.
-    Helper.booleanToFuture(refusal.getOrElse(""), 403, Some(callContext))(refusal.isEmpty)
+    // ConsentNotFound whatever the reason, and the same answer these endpoints give for a consent id
+    // that matches nothing at all. A caller who is not entitled to a consent must not be able to
+    // tell "there is no such consent" from "that one is not yours", or the endpoint is a way to
+    // confirm which ids exist. The rule's own ConsentDoesNotMatchUser / ConsentDoesNotMatchConsumer
+    // say which, so the reason is logged rather than returned -- same shape as the Berlin Group
+    // read wrapper above, which is the answer this one was brought into line with.
+    refusal.foreach { reason =>
+      logger.info(
+        s"A UK consent read was refused: $reason. Reported as ${ErrorMessages.ConsentNotFound} so " +
+        s"the caller cannot tell a consent that is not theirs from one that does not exist.")
+    }
+    Helper.booleanToFuture(ErrorMessages.ConsentNotFound, 403, Some(callContext))(refusal.isEmpty)
   }
 
   /**

--- a/obp-api/src/main/scala/code/api/util/ConsentUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/ConsentUtil.scala
@@ -1741,13 +1741,49 @@ object Consent extends MdcLoggable {
   ): Option[String] = {
     (present(consentUserId), callerUserId.flatMap(present)) match {
       case (Some(psu), Some(caller)) if psu != caller => Some(ErrorMessages.ConsentDoesNotMatchUser)
-      case (Some(_), Some(_)) => None
+      // The PSU matches, which is necessary but not sufficient: the Consumer still has to, and that
+      // comparison is below. The exception is the ASPSP's own front end, which under Redirect is by
+      // definition not the Consumer that lodged the consent -- that is the whole reason it has to be
+      // declared. Without this case a declared front end could not complete an SCA it is allowed to
+      // start, because psuOrLodgingTppRefusal would refuse it on the Consumer.
+      case (Some(_), Some(_)) if callerIsScaFrontEnd => None
       // Only while the consent is still unclaimed. A caller with no PSU used to reach this too, so a
       // declared front end presenting client credentials could drive the authorisation of a consent
       // already bound to somebody else -- the opposite of what the paragraph above promises.
       case (None, _) if callerIsScaFrontEnd => None
       case _ => psuOrLodgingTppRefusal(consentUserId, consentConsumerId, callerUserId, callerConsumerId)
     }
+  }
+
+  /**
+   * checkBerlinGroupConsentAccess for the five endpoints that read or delete a consent resource,
+   * refusing with the answer those endpoints have always given.
+   *
+   * They answer `ConsentNotFound` at 403 whatever the reason, which is deliberate: a caller who is
+   * not entitled to a consent should not be able to tell "it is not yours" from "there is no such
+   * consent", or the endpoint becomes a way to confirm that an id exists. The rule's own
+   * ConsentDoesNotMatchUser / ConsentDoesNotMatchConsumer say which, so the reason is logged rather
+   * than returned. The authorisation pair does return it -- there the caller is mid-ceremony on a
+   * consent it has already been handed, and needs to know why it was stopped.
+   *
+   * Not a general-purpose wrapper: assertUKConsentAccess next to it passes the reason through, and
+   * that difference is the point rather than an inconsistency to iron out.
+   */
+  def assertBerlinGroupConsentReadAccess(
+    consentUserId: String,
+    consentConsumerId: String,
+    callContext: CallContext
+  ): Future[Box[Unit]] = {
+    val refusal = checkBerlinGroupConsentAccess(
+      consentUserId, consentConsumerId,
+      genuinePsu(callContext).map(_.userId), callContext.consumer.map(_.consumerId.get),
+      isScaFrontEnd(callContext.consumer.map(_.consumerId.get)))
+    refusal.foreach { reason =>
+      logger.info(
+        s"A consent read was refused: $reason. Reported as ${ErrorMessages.ConsentNotFound} so the " +
+        s"caller cannot tell a consent that is not theirs from one that does not exist.")
+    }
+    Helper.booleanToFuture(ErrorMessages.ConsentNotFound, 403, Some(callContext))(refusal.isEmpty)
   }
 
   /**
@@ -1777,16 +1813,39 @@ object Consent extends MdcLoggable {
     callerUserId: Option[String],
     callerConsumerId: Option[String]
   ): Option[String] = {
+    // The Consumer that lodged the consent is what identifies a legitimate caller, and a consent
+    // recording none belongs to nobody. This used to read `owner.forall(...)`, which is vacuously
+    // true when there is no owner -- so a consent with no lodging TPP was addressable by every
+    // authenticated caller. "Absent" was being read as "matches everything" where it means "there is
+    // nobody this belongs to", and neither standard supports the first reading: Berlin Group scopes
+    // a resource to "the same TPP" that created it (IG 4.11), and UK scopes GET and DELETE to "an
+    // account-access-consent resource that they have created".
+    //
+    // It is a live population -- 10 of 566 Berlin Group, 50 of 463 OBP-native and 4 of 753 UK
+    // consents record no consumer on a long-lived instance -- so the prop is there for an operator
+    // who needs a migration window and accepts what it means. Default false, and it says so every
+    // time it is used.
+    def lodgingTppRefusal: Option[String] = present(consentConsumerId) match {
+      case Some(owner) if callerConsumerId.flatMap(present).contains(owner) => None
+      case Some(_) => Some(ErrorMessages.ConsentDoesNotMatchConsumer)
+      case None if APIUtil.getPropsAsBoolValue("consent_allow_legacy_unrecorded_tpp", defaultValue = false) =>
+        logger.warn(
+          "A consent recording no lodging TPP was addressed and allowed through because " +
+          "consent_allow_legacy_unrecorded_tpp is set. Any authenticated caller can read and revoke " +
+          "such a consent while that stays on. Re-lodge the affected consents and turn it off.")
+        None
+      case None => Some(ErrorMessages.ConsentDoesNotMatchConsumer)
+    }
+
     (present(consentUserId), callerUserId.flatMap(present)) match {
-      case (Some(psu), Some(caller)) =>
-        // The consent belongs to a PSU and the caller is acting as one: they must be the same PSU.
-        if (psu == caller) None else Some(ErrorMessages.ConsentDoesNotMatchUser)
-      case _ =>
-        // Either the consent has no PSU yet, or the caller is not acting as one. Either way the
-        // Consumer that lodged it is what identifies a legitimate caller.
-        val owner = present(consentConsumerId)
-        if (owner.forall(id => callerConsumerId.flatMap(present).contains(id))) None
-        else Some(ErrorMessages.ConsentDoesNotMatchConsumer)
+      // The consent belongs to a PSU and the caller is acting as one: they must be the same PSU.
+      case (Some(psu), Some(caller)) if psu != caller => Some(ErrorMessages.ConsentDoesNotMatchUser)
+      // Matching the PSU is necessary, not sufficient. This used to return None here, so agreeing on
+      // the person ended the enquiry and the Consumer was never looked at -- a second TPP holding a
+      // session for the same PSU could read and revoke the consent a first TPP lodged. One TPP's
+      // mandate over a consent is not another's, and IG 4.11's same-TPP rule admits no PSU
+      // exception. So a PSU match falls through to the Consumer comparison rather than skipping it.
+      case _ => lodgingTppRefusal
     }
   }
 

--- a/obp-api/src/main/scala/code/api/v5_1_0/Http4s510.scala
+++ b/obp-api/src/main/scala/code/api/v5_1_0/Http4s510.scala
@@ -4396,7 +4396,22 @@ object Http4s510 {
             _ <- Helper.booleanToFuture(s"$InvalidJsonFormat The Json body should be the $PostUKConsentAuthoriseJsonV510 (account_ids must not be empty) ", 400, Some(cc)) {
               authJson.account_ids.nonEmpty
             }
-            (_, _) <- NewStyle.function.getChallenge(authJson.challenge_id, Some(cc))
+            (startedChallenge, _) <- NewStyle.function.getChallenge(authJson.challenge_id, Some(cc))
+            // The consent this challenge was minted for is the consent it may authorise, and nothing
+            // below establishes that: validateChallengeAnswerC4 is handed the consentId but the
+            // connector ignores it and matches on challengeId, answer and expected user alone. So a
+            // PSU holding an OTP raised for one consent could answer it against another of their own
+            // -- and since the two need not carry the same Permissions, an OTP the PSU was given for
+            // a narrow consent authorised a wider one, which is precisely the dynamic linking the
+            // profile is asking for ("all authentication journeys take place in the context of a
+            // consent"; the ConsentId is the intent identifier).
+            //
+            // Same guard, message and code as the Berlin Group twin in Http4sBGv13AIS, which gets
+            // the binding structurally by nesting authorisations under the consent's own path. It
+            // also refuses a transaction-request challenge here for free: that carries no consentId.
+            _ <- Helper.booleanToFuture(s"$InvalidChallengeChallengeId Current challengeId(${authJson.challenge_id}) does not belong to CONSENTID($consentId) ", 400, Some(cc)) {
+              startedChallenge.consentId.contains(consentId)
+            }
             (challenge, _) <- NewStyle.function.validateChallengeAnswerC4(
               ChallengeType.OBP_CONSENT_CHALLENGE,
               None,

--- a/obp-api/src/main/scala/code/consent/MappedConsent.scala
+++ b/obp-api/src/main/scala/code/consent/MappedConsent.scala
@@ -377,7 +377,25 @@ object MappedConsentProvider extends ConsentProvider with code.util.Helper.MdcLo
           // Every revoke endpoint funnels through here, so this is the one place that has to give
           // the granted access back. The status flip alone leaves the AccountAccess rows live in
           // the table for anything that reads them without asking the consent first.
-          code.api.util.Consent.revokeConsentAccountAccess(consent)
+          //
+          // Guarded because conditionalRevoke above has already committed, so a throw here cannot
+          // undo the revoke -- it can only hide that it happened. The caller got a 500 and the
+          // retry got ConsentAlreadyRevoked, which leaves an AISP unable to complete the DELETE the
+          // standards require of it and with no correct next step. It does not take much to get
+          // there: revokeConsentAccountAccess extracts the stored JWT through Box.map, which does
+          // not catch, so a payload that no longer matches ConsentJWT arrives as a MappingException.
+          //
+          // Logged at error, not swallowed. The consent IS revoked and the API is right to say so,
+          // but rows that should have been dropped are still live, and that is the one thing about
+          // a revoked consent nobody comes back for. Same shape as the sibling below.
+          tryo(code.api.util.Consent.revokeConsentAccountAccess(consent)) match {
+            case Failure(msg, ex, _) =>
+              logger.error(
+                s"revoke: consent $consentId is revoked, but its account access could not be given " +
+                s"back and those rows are still live: $msg" +
+                ex.map(e => s" (${e.getClass.getSimpleName}: ${e.getMessage})").getOrElse(""))
+            case _ =>
+          }
           MappedConsent.find(By(MappedConsent.mConsentId, consentId))
         }
         else Failure(ErrorMessages.ConsentAlreadyRevoked)

--- a/obp-api/src/main/scala/code/views/MapperViews.scala
+++ b/obp-api/src/main/scala/code/views/MapperViews.scala
@@ -196,32 +196,6 @@ object MapperViews extends Views with MdcLoggable {
     }
   }
 
-  // The consumer-scoped counterparts of the two grants above, mirroring the revoke...ForConsumer
-  // pair further down. Access granted through one application's consent belongs to that application
-  // alone: keeping it on its own row is what stops a second TPP's consent from rewriting it, and
-  // what makes narrowing a consent narrow only that consent.
-  def grantAccessToSystemViewForConsumer(bankId: BankId, accountId: AccountId, view: View, user: User, consumerId: String): Box[View] = {
-    { view.isPublic && !allowPublicViews } match {
-      case true => Failure(PublicViewsNotAllowedOnThisInstance)
-      case false => getOrGrantAccessToViewCommon(user, view, bankId.value, accountId.value, consumerId)
-    }
-  }
-
-  def grantAccessToCustomViewForConsumer(bankIdAccountIdViewId: BankIdAccountIdViewId, user: User, consumerId: String): Box[View] = {
-    val viewDefinition = ViewDefinition.findCustomView(
-      bankIdAccountIdViewId.bankId.value,
-      bankIdAccountIdViewId.accountId.value,
-      bankIdAccountIdViewId.viewId.value)
-
-    viewDefinition match {
-      case Full(v) =>
-        if (v.isPublic && !allowPublicViews) Failure(PublicViewsNotAllowedOnThisInstance)
-        else getOrGrantAccessToViewCommon(user, v, bankIdAccountIdViewId.bankId.value, bankIdAccountIdViewId.accountId.value, consumerId)
-      case _ =>
-        Empty ~> APIFailure(s"View ${bankIdAccountIdViewId.viewId} not found", 404)
-    }
-  }
-
   def grantAccessToMultipleViews(views: List[BankIdAccountIdViewId], user: User, callContext: Option[CallContext]): Box[List[View]] = {
     val viewDefinitions: List[(ViewDefinition, BankIdAccountIdViewId)] = views.map {
       uid => ViewDefinition.findCustomView(uid.bankId.value,uid.accountId.value, uid.viewId.value).map((_, uid))

--- a/obp-api/src/main/scala/code/views/Views.scala
+++ b/obp-api/src/main/scala/code/views/Views.scala
@@ -36,11 +36,15 @@ trait Views {
   def revokeAccessToSystemViewForConsumer(bankId: BankId, accountId: AccountId, view : View, consumerId : String) : Box[Boolean]
   def revokeAccessToCustomViewForConsumer(view : View, consumerId : String) : Box[Boolean]
 
-  // Grant/revoke a single application's access, rather than access shared by every application.
-  // Used by the consent flows: what one TPP's consent grants is that TPP's alone, so narrowing or
-  // re-authorising it must not touch another TPP's grants on the same account.
-  def grantAccessToSystemViewForConsumer(bankId: BankId, accountId: AccountId, view : View, user : User, consumerId : String) : Box[View]
-  def grantAccessToCustomViewForConsumer(bankIdAccountIdViewId : BankIdAccountIdViewId, user : User, consumerId : String) : Box[View]
+  // Revoke and enumerate one application's access, rather than access shared by every application.
+  // The consent flows use these against Constant.ALL_CONSUMERS, which is the literal every consent
+  // grant is written under -- not a wildcard, and every lookup matches it by equality.
+  //
+  // There is deliberately no grant...ForConsumer counterpart. Two existed and had no callers, and
+  // could not have gained one safely: a row written under a real consumer id is invisible to
+  // revokeConsentAccountAccess, which sweeps by asking for exactly ALL_CONSUMERS, so the access
+  // would outlive the consent that granted it. Grants go through grantAccessToSystemView /
+  // grantAccessToCustomView, which write ALL_CONSUMERS and are therefore revocable.
   def revokeAccessToViewForUserAndConsumer(bankIdAccountIdViewId : BankIdAccountIdViewId, user : User, consumerId : String) : Box[Boolean]
   // Everything a user currently holds under one application's scope. The consent flows reconcile
   // against this: a consent's granted views are whatever its JWT says, so the rows that back it are

--- a/obp-api/src/test/scala/code/api/UKOpenBanking/v3_1_0/UKOpenBankingV310AisTests.scala
+++ b/obp-api/src/test/scala/code/api/UKOpenBanking/v3_1_0/UKOpenBankingV310AisTests.scala
@@ -1,7 +1,7 @@
 package code.api.UKOpenBanking.v3_1_0
 
 import code.api.util.APIUtil.{DateWithDayFormat, ResourceDoc, UserOrApplication, buildOperationId}
-import code.api.util.ErrorMessages.ConsentDoesNotMatchConsumer
+import code.api.util.ErrorMessages.ConsentNotFound
 import code.consent.Consents
 import com.openbankproject.commons.model.ErrorMessage
 import com.openbankproject.commons.util.ApiVersion
@@ -75,13 +75,19 @@ class UKOpenBankingV310AisTests extends UKOpenBankingV310ServerSetup {
     // Http4sUKOBv310AccountAccess.deleteAccountAccessConsentsConsentId only guards against a
     // *different bound user*, not a *different consumer*. deleteAuthedAsUser2 authenticates as
     // consumer2 (see DefaultUsers), a different OAuth1 consumer than the one that created this
-    // pending consent (testConsumer/consumer). Once fixed, this must be 403
-    // ConsentDoesNotMatchConsumer, and the consent must be left untouched.
+    // pending consent (testConsumer/consumer). It is refused with 403, and the consent must be
+    // left untouched. The refusal says ConsentNotFound rather than naming the consumer: these
+    // endpoints answer the same thing for a consent that is not yours and one that does not exist,
+    // so that a caller cannot use them to find out which ids are real.
     scenario("authenticated as a different consumer than the creator, pending consent -> 403, and consent is left untouched", UKOpenBankingV310) {
       val consentId = createPendingConsentForConsumer1()
       val response = deleteAuthedAsUser2("account-access-consents", consentId)
       response.code should equal(403)
-      response.body.extract[ErrorMessage].message should startWith(ConsentDoesNotMatchConsumer)
+      // The refusal is still a 403 and still has no side effect, which is what this scenario
+      // guards. Only the wording moved: these endpoints now answer ConsentNotFound whatever the
+      // reason, so a caller cannot tell "that one is not yours" from "there is no such consent".
+      // The specific reason is logged instead.
+      response.body.extract[ErrorMessage].message should startWith(ConsentNotFound)
 
       Consents.consentProvider.vend.getConsentByConsentId(consentId).isDefined should equal(true)
     }
@@ -97,12 +103,17 @@ class UKOpenBankingV310AisTests extends UKOpenBankingV310ServerSetup {
     // Cross-consumer regression (currently RED): same root cause as the DELETE gap above --
     // a pending consent is currently readable by ANY authenticated party. getAuthedAsUser2
     // authenticates as consumer2, a different OAuth1 consumer than the one that created this
-    // pending consent. Once fixed, this must be 403 ConsentDoesNotMatchConsumer.
+    // pending consent. It is refused with 403 ConsentNotFound -- the same answer an id that
+    // matches nothing gets, deliberately.
     scenario("authenticated as a different consumer than the creator, pending consent -> 403, not 200", UKOpenBankingV310) {
       val consentId = createPendingConsentForConsumer1()
       val response = getAuthedAsUser2("account-access-consents", consentId)
       response.code should equal(403)
-      response.body.extract[ErrorMessage].message should startWith(ConsentDoesNotMatchConsumer)
+      // The refusal is still a 403 and still has no side effect, which is what this scenario
+      // guards. Only the wording moved: these endpoints now answer ConsentNotFound whatever the
+      // reason, so a caller cannot tell "that one is not yours" from "there is no such consent".
+      // The specific reason is logged instead.
+      response.body.extract[ErrorMessage].message should startWith(ConsentNotFound)
     }
   }
 

--- a/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401AccountInfoTests.scala
+++ b/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401AccountInfoTests.scala
@@ -54,12 +54,18 @@ class UKOpenBankingV401AccountInfoTests extends UKOpenBankingV401ServerSetup {
       |  "Risk": {}
       |}""".stripMargin
 
+  // consumerId is the consumer these consents are then read with (getAuthed signs as testConsumer),
+  // because that is what the endpoint itself records -- createAccountAccessConsents passes the
+  // calling consumer straight into saveUKConsent. It used to pass None here, which produced a row
+  // no production path creates: one naming no lodging TPP. That was invisible while such a row was
+  // readable by anyone, and became a 403 the moment "records no TPP" stopped meaning "matches every
+  // caller". The fixture was the thing that was wrong.
   private def createRealConsent(): String = {
     val consent = Consents.consentProvider.vend.saveUKConsent(
       user = Some(resourceUser1),
       bankId = None,
       accountIds = None,
-      consumerId = None,
+      consumerId = Some(testConsumer.consumerId.get),
       permissions = consentPermissions,
       expirationDateTime = Some(DateWithDayFormat.parse("2030-01-01")),
       transactionFromDateTime = Some(DateWithDayFormat.parse("2020-01-01")),
@@ -747,6 +753,47 @@ class UKOpenBankingV401AccountInfoTests extends UKOpenBankingV401ServerSetup {
   // assertion is "nobody", and both spellings mean that.
   private def boundPsuOf(consentId: String): String =
     Option(storedConsent(consentId).userId).map(_.trim).getOrElse("")
+
+  // The profile defines the authentication journey as taking place in the context of one consent:
+  // the ConsentId is the intent identifier, and the intent id is carried into the request object so
+  // that "the access token that is eventually generated [is] bound to a specific consent". OBP mints
+  // its own OTP challenge instead of using that mechanism, so the binding the profile gets
+  // structurally has to be asserted here -- and the connector will not do it: LocalMappedConnector's
+  // validateChallengeAnswerC4 ignores the consentId it is handed and matches on challengeId, answer
+  // and userId alone. The Berlin Group twin of this endpoint already asserts it
+  // (Http4sBGv13AIS: startedChallenge.consentId.contains(consentId)).
+  feature("UKOB v4.0.1 a challenge only authorises the consent it was minted for") {
+    scenario("a challenge minted on one consent cannot authorise another -> 400, and the other consent is untouched", UKOpenBankingV401AccountInfo) {
+      setPropsValues("suggested_default_sca_method" -> "DUMMY")
+      val expiry = Some(new java.util.Date(System.currentTimeMillis() + 3600000L))
+      // Two consents the same PSU may authorise. The PSU guard at the top of the authorise endpoint
+      // passes for both, so nothing but the binding stands between them.
+      val challenged = createUKConsent(None, expiry)
+      val other = createUKConsent(None, expiry)
+
+      val challenge = makePostRequest(scaChallengeRequest(challenged) <@ (user1), "")
+      challenge.code should equal(200)
+      val challengeId = (challenge.body \ "challenge_id").extract[String]
+
+      When("the challenge minted on one consent is answered against the other")
+      val refused = makePostRequest(authoriseRequest(other) <@ (user1),
+        s"""{"account_ids":["$acc"],"challenge_id":"$challengeId","answer":"123"}""")
+
+      Then("it is refused with the same answer the Berlin Group twin gives")
+      refused.code should equal(400)
+      refused.body.extract[ErrorMessage].message should include("OBP-40022")
+
+      // The refusal is the point, but so is what it did not do: an authorisation that got this far
+      // used to bind the PSU and flip the status on a consent nobody authenticated for.
+      And("the consent it was aimed at is left exactly as it was")
+      boundPsuOf(other) should equal("")
+      storedConsent(other).status should equal(ConsentStatus.AWAITINGAUTHORISATION.toString)
+
+      And("so is the consent the challenge actually belonged to")
+      boundPsuOf(challenged) should equal("")
+      storedConsent(challenged).status should equal(ConsentStatus.AWAITINGAUTHORISATION.toString)
+    }
+  }
 
   feature("UKOB v4.0.1 a refused authorisation does not claim the consent") {
     scenario("account_ids naming an account the PSU does not hold -> refused, consent left unbound", UKOpenBankingV401AccountInfo) {

--- a/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401AccountInfoTests.scala
+++ b/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401AccountInfoTests.scala
@@ -2,7 +2,7 @@ package code.api.UKOpenBanking.v4_0_1
 
 import code.api.Constant
 import code.api.util.APIUtil.{DateWithDayFormat, ResourceDoc, UserOrApplication, buildOperationId}
-import code.api.util.ErrorMessages.{ConsentDoesNotMatchConsumer, ConsentDoesNotMatchUser, ConsentExpiredIssue, ConsentIdClaimMissing}
+import code.api.util.ErrorMessages.{ConsentDoesNotMatchConsumer, ConsentDoesNotMatchUser, ConsentExpiredIssue, ConsentIdClaimMissing, ConsentNotFound}
 import code.api.util.{CallContext, CertificateUtil, Consent}
 import code.consent.{ConsentStatus, Consents}
 import code.model.UserExtended
@@ -34,6 +34,13 @@ import scala.concurrent.duration._
 // the consent check entirely and returned real data straight from a DirectLogin
 // token, which let a token with no bound consent reach 500 instead of the 403
 // OBP-35035 every other AISP data endpoint gives it.
+//
+// That 401/not-401 limit is also why the two aggregate endpoints' substance is covered out of
+// repo. What getTransactions does per account -- resolve that account's own bank for moderation,
+// and resolve and apply the consent's granted transaction directions -- only happens once a real
+// consent is in play, which needs a Bearer token this suite cannot mint. uk_direction.py drives it
+// against a running instance with a real consent, on the bulk path as well as the per-account one;
+// it was the bulk path being absent from that probe that let the gap stand.
 //
 // The remaining 80 endpoints are still static spec-faithful stubs; their tests
 // are unchanged (two scenarios: authenticated -> fixed code, unauthenticated -> 401).
@@ -221,8 +228,30 @@ class UKOpenBankingV401AccountInfoTests extends UKOpenBankingV401ServerSetup {
       // freshly-created consent is AWAITINGAUTHORISATION → wire code AWAU
       (response.body \ "Data" \ "Status").extract[String] should equal("AWAU")
     }
-    scenario("authenticated with unknown consent -> 400", UKOpenBankingV401AccountInfo) {
-      getAuthed("aisp", "account-access-consents", "fake-consentid").code should equal(400)
+    scenario("authenticated with unknown consent -> 403", UKOpenBankingV401AccountInfo) {
+      getAuthed("aisp", "account-access-consents", "fake-consentid").code should equal(403)
+    }
+    // A caller who is not entitled to a consent must not be able to tell "there is no such consent"
+    // from "that one is not yours". The two used to answer differently -- 400 with the id spelled
+    // back, against 403 -- which turns the endpoint into a way of confirming that an id exists.
+    // Berlin Group's equivalents already answer the same thing both ways.
+    scenario("a consent that does not exist and one that is not yours answer identically", UKOpenBankingV401AccountInfo) {
+      val someoneElses = createRealConsent() // resourceUser1's, lodged under testConsumer
+
+      val missing = getAuthedAsUser2("aisp", "account-access-consents", "no-such-consent-at-all")
+      val foreign = getAuthedAsUser2("aisp", "account-access-consents", someoneElses)
+
+      withClue("the two answers differ, so the endpoint confirms which ids exist: ") {
+        missing.code should equal(foreign.code)
+        missing.body should equal(foreign.body)
+      }
+      missing.code should equal(403)
+
+      And("neither answer names a consent")
+      val message = missing.body.extract[ErrorMessage].message
+      message should startWith(ConsentNotFound)
+      message should not include someoneElses
+      message should not include "no-such-consent-at-all"
     }
     scenario("unauthenticated -> 401", UKOpenBankingV401AccountInfo) {
       getUnauthed("aisp", "account-access-consents", "fake-consentid").code should equal(401)
@@ -237,7 +266,11 @@ class UKOpenBankingV401AccountInfoTests extends UKOpenBankingV401ServerSetup {
       val consentId = createRealConsent() // owned by resourceUser1
       val response = getAuthedAsUser2("aisp", "account-access-consents", consentId)
       response.code should equal(403)
-      response.body.extract[ErrorMessage].message should startWith(ConsentDoesNotMatchUser)
+      // The refusal is still a 403 and still has no side effect, which is what this scenario
+      // guards. Only the wording moved: these endpoints now answer ConsentNotFound whatever the
+      // reason, so a caller cannot tell "that one is not yours" from "there is no such consent".
+      // The specific reason is logged instead.
+      response.body.extract[ErrorMessage].message should startWith(ConsentNotFound)
     }
     // Cross-consumer regression (currently RED): a pending consent (no bound PSU yet) is
     // currently readable by ANY authenticated party, because the ownership check
@@ -250,7 +283,11 @@ class UKOpenBankingV401AccountInfoTests extends UKOpenBankingV401ServerSetup {
       val consentId = createPendingConsentForConsumer1()
       val response = getAuthedAsUser2("aisp", "account-access-consents", consentId)
       response.code should equal(403)
-      response.body.extract[ErrorMessage].message should startWith(ConsentDoesNotMatchConsumer)
+      // The refusal is still a 403 and still has no side effect, which is what this scenario
+      // guards. Only the wording moved: these endpoints now answer ConsentNotFound whatever the
+      // reason, so a caller cannot tell "that one is not yours" from "there is no such consent".
+      // The specific reason is logged instead.
+      response.body.extract[ErrorMessage].message should startWith(ConsentNotFound)
     }
   }
   feature("UKOB v4.0.1 DELETE /aisp/account-access-consents/CONSENT_ID") {
@@ -266,8 +303,9 @@ class UKOpenBankingV401AccountInfoTests extends UKOpenBankingV401ServerSetup {
       // stored status is REVOKED, but the v4.0.1 wire format reports the spec's CANC code
       (afterDelete.body \ "Data" \ "Status").extract[String] should equal("CANC")
     }
-    scenario("authenticated with unknown consent -> 400", UKOpenBankingV401AccountInfo) {
-      deleteAuthed("aisp", "account-access-consents", "fake-consentid").code should equal(400)
+    scenario("authenticated with unknown consent -> 403", UKOpenBankingV401AccountInfo) {
+      // Same answer as a consent that exists but is not the caller's, on purpose -- see the GET twin.
+      deleteAuthed("aisp", "account-access-consents", "fake-consentid").code should equal(403)
     }
     scenario("unauthenticated -> 401", UKOpenBankingV401AccountInfo) {
       deleteUnauthed("aisp", "account-access-consents", "fake-consentid").code should equal(401)
@@ -282,7 +320,11 @@ class UKOpenBankingV401AccountInfoTests extends UKOpenBankingV401ServerSetup {
       val consentId = createRealConsent() // owned by resourceUser1
       val response = deleteAuthedAsUser2("aisp", "account-access-consents", consentId)
       response.code should equal(403)
-      response.body.extract[ErrorMessage].message should startWith(ConsentDoesNotMatchUser)
+      // The refusal is still a 403 and still has no side effect, which is what this scenario
+      // guards. Only the wording moved: these endpoints now answer ConsentNotFound whatever the
+      // reason, so a caller cannot tell "that one is not yours" from "there is no such consent".
+      // The specific reason is logged instead.
+      response.body.extract[ErrorMessage].message should startWith(ConsentNotFound)
 
       val stillThere = Consents.consentProvider.vend.getConsentByConsentId(consentId).openOrThrowException("consent")
       stillThere.status should equal(ConsentStatus.AWAITINGAUTHORISATION.toString)
@@ -297,7 +339,11 @@ class UKOpenBankingV401AccountInfoTests extends UKOpenBankingV401ServerSetup {
       val consentId = createPendingConsentForConsumer1()
       val response = deleteAuthedAsUser2("aisp", "account-access-consents", consentId)
       response.code should equal(403)
-      response.body.extract[ErrorMessage].message should startWith(ConsentDoesNotMatchConsumer)
+      // The refusal is still a 403 and still has no side effect, which is what this scenario
+      // guards. Only the wording moved: these endpoints now answer ConsentNotFound whatever the
+      // reason, so a caller cannot tell "that one is not yours" from "there is no such consent".
+      // The specific reason is logged instead.
+      response.body.extract[ErrorMessage].message should startWith(ConsentNotFound)
 
       val stillThere = Consents.consentProvider.vend.getConsentByConsentId(consentId).openOrThrowException("consent")
       stillThere.status should equal(ConsentStatus.AWAITINGAUTHORISATION.toString)

--- a/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401ConsentAccessTests.scala
+++ b/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401ConsentAccessTests.scala
@@ -138,12 +138,34 @@ class UKOpenBankingV401ConsentAccessTests extends UKOpenBankingV401ServerSetup {
     }
 
     scenario("blank ids count as absent, not as a value to match", UKOpenBankingV401ConsentAccess) {
-      // A consent lodged before consumer binding existed stores no consumer id; nothing identifies a
-      // wrong caller, so it cannot be refused on that basis.
-      Consent.checkUKConsentAccess("", "", None, Some(tpp), callerIsScaFrontEnd = false) should equal(None)
-      Consent.checkUKConsentAccess(null, null, None, None, callerIsScaFrontEnd = false) should equal(None)
-      // A blank caller user id is not a PSU either -- it must not accidentally match a blank binding.
+      // A blank caller user id is not a PSU -- it must not accidentally match a blank binding.
       Consent.checkUKConsentAccess(psu, tpp, Some("  "), Some(tpp), callerIsScaFrontEnd = false) should equal(None)
+    }
+
+    // The two assertions that used to sit in the scenario above have inverted. They read
+    //   checkUKConsentAccess("", "", None, Some(tpp), false) should equal(None)
+    //   checkUKConsentAccess(null, null, None, None, false)  should equal(None)
+    // on the reasoning that a consent lodged before consumer binding existed "cannot be refused on
+    // that basis" because nothing identifies a wrong caller. The other half of that is that nothing
+    // identifies a RIGHT one either, and the profile scopes these endpoints to "an
+    // account-access-consent resource that they have created" -- a row naming no creator matches no
+    // caller rather than every caller. 4 of 753 UK consents on a long-lived instance record no
+    // consumer, and until now any authenticated caller could read and revoke them.
+    scenario("a consent that records no lodging TPP belongs to nobody", UKOpenBankingV401ConsentAccess) {
+      Consent.checkUKConsentAccess("", "", None, Some(tpp), callerIsScaFrontEnd = false) should
+        equal(Some(ConsentDoesNotMatchConsumer))
+      Consent.checkUKConsentAccess(null, null, None, None, callerIsScaFrontEnd = false) should
+        equal(Some(ConsentDoesNotMatchConsumer))
+    }
+
+    // Matching the PSU is necessary, not sufficient: the rule used to stop as soon as the two PSU
+    // ids agreed, so a second TPP holding a session for the same person reached a first TPP's
+    // consent. The UK case for the Consumer comparison is per-endpoint rather than blanket -- the
+    // Endpoints table marks GET and DELETE Client Credentials, so no PSU is party to them at all,
+    // and a PSU session here is an OBP extension that cannot be the thing that waives it.
+    scenario("a second TPP holding a session for the consent's own PSU is still refused", UKOpenBankingV401ConsentAccess) {
+      Consent.checkUKConsentAccess(psu, tpp, Some(psu), Some(otherTpp), callerIsScaFrontEnd = false) should
+        equal(Some(ConsentDoesNotMatchConsumer))
     }
   }
 

--- a/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401ConsentScopingTests.scala
+++ b/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401ConsentScopingTests.scala
@@ -266,6 +266,35 @@ class UKOpenBankingV401ConsentScopingTests extends UKOpenBankingV401ServerSetup 
       principal.map(_.userId) should equal(Full(resourceUser1.userId))
       callContext.flatMap(_.consenter.toOption) should equal(None)
     }
+
+    // The PSU used to be taken from the token rather than from the consent, and nothing here
+    // compared the two. So a token belonging to anyone at all, carrying a consent_id that is not
+    // theirs, was swapped onto that consent's shadow user -- with `consenter` set to the token's
+    // holder rather than to the person the consent is about.
+    //
+    // checkUKConsent then caught it, because it compares the consent's mUserId against `consenter`
+    // and they disagreed. But only the UK read endpoints call checkUKConsent: on every other
+    // endpoint family the swapped principal stood, and it carries the consent's account access. The
+    // refusal has to be decided here, where it is recorded on the CallContext and enforced for every
+    // endpoint by ResourceDocMiddleware.
+    scenario("a token whose subject is not the consent's PSU is refused, not swapped", UKConsentScoping) {
+      val consentId = authoriseConsentFor(testConsumer.consumerId.get, List(ReadAccountsBasic),
+        accountIds = List(acc))
+
+      Given("resourceUser2's session presenting a consent authorised by resourceUser1")
+      val (principal, callContext) =
+        Consent.applyUKConsentPrincipalFromToken(Full(resourceUser2), Some(bearerContextFor(consentId, testConsumer)))
+      val cc = callContext.getOrElse(fail("token path dropped the CallContext"))
+
+      Then("the principal is left alone rather than swapped onto the consent")
+      principal.map(_.userId) should equal(Full(resourceUser2.userId))
+      cc.consenter.toOption should equal(None)
+
+      And("the refusal is recorded, so every endpoint family enforces it and not just the UK reads")
+      cc.ukConsentUnresolved should equal(Some(ErrorMessages.ConsentDoesNotMatchUser))
+      Consent.unresolvedUKConsentRefusal(cc.ukConsentUnresolved, "/obp/v5.1.0/my/accounts") should
+        equal(Some(ErrorMessages.ConsentDoesNotMatchUser))
+    }
   }
 
   /**
@@ -381,6 +410,35 @@ class UKOpenBankingV401ConsentScopingTests extends UKOpenBankingV401ServerSetup 
       Consent.unresolvedUKConsentRefusal(None, "/obp/v5.1.0/my/accounts") should equal(None)
       Consent.unresolvedUKConsentRefusal(
         None, "/open-banking/v4.0.1/aisp/account-access-consents") should equal(None)
+    }
+
+    /**
+     * Which PSU the token path runs for. Extracted for the same reason as the rule above: the
+     * decision is worth pinning and the path that uses it cannot be driven from this suite.
+     *
+     * The consent row is the source of truth, as it already is on the header path, and the token's
+     * subject must agree with it. Losing the second half is the easy mistake, and it is silent:
+     * checkUKConsent compares the consent's mUserId against `consenter`, so deriving `consenter`
+     * from mUserId without also comparing the token would have that check compare the consent's user
+     * with itself and pass for anybody's token.
+     */
+    scenario("the token path takes its PSU from the consent, and the token must agree", UKConsentScoping) {
+      val psu = "the-psu-user-id"
+      val someoneElse = "a-different-user-id"
+
+      Given("a consent bound to a PSU")
+      Then("a token for that PSU resolves to them")
+      Consent.ukTokenPathPsuId(psu, psu) should equal(Right(psu))
+
+      And("a token for anyone else is refused, which is the check that must not be lost")
+      Consent.ukTokenPathPsuId(psu, someoneElse) should equal(Left(ErrorMessages.ConsentDoesNotMatchUser))
+
+      And("a consent naming no PSU was never authorised, so there is nobody it is on behalf of")
+      // Not a fallback to the token's user: that would serve everything that user can see, which is
+      // the whole of what a consent exists to narrow.
+      Consent.ukTokenPathPsuId("", psu) should equal(Left(ErrorMessages.ConsentNotFound))
+      Consent.ukTokenPathPsuId(null, psu) should equal(Left(ErrorMessages.ConsentNotFound))
+      Consent.ukTokenPathPsuId("   ", psu) should equal(Left(ErrorMessages.ConsentNotFound))
     }
 
     scenario("the consent stays inspectable and revocable by the TPP that lodged it", UKConsentScoping) {

--- a/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401ConsentScopingTests.scala
+++ b/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401ConsentScopingTests.scala
@@ -417,6 +417,37 @@ class UKOpenBankingV401ConsentScopingTests extends UKOpenBankingV401ServerSetup 
       // Revocation used to flip a status column and leave the granted rows in the table for good.
       Views.views.vend.accessGrantedToUserForConsumer(principal, Constant.ALL_CONSUMERS) shouldBe empty
     }
+
+    // The clean-up runs after conditionalRevoke has already committed the status change, so a throw
+    // in it does not undo the revoke -- it only hides that the revoke happened. The caller gets a
+    // 500 and the retry gets ConsentAlreadyRevoked, which leaves an AISP unable to complete the
+    // DELETE the profile requires of it, with no correct next step. The Berlin Group sibling a few
+    // lines away in MappedConsent already wraps its equivalent; this one did not.
+    //
+    // A stored JWT whose payload does not extract is enough to get there. getSignedPayloadAsJson
+    // does not verify the signature -- it parses the structure and hands back the claims -- so the
+    // extract that follows is what throws, and Box.map does not catch. The same trap is already
+    // documented on applyUKConsentPrincipalFromToken.
+    scenario("a consent whose stored JWT cannot be read is still revoked, and says so", UKConsentScoping) {
+      val consentId = authoriseConsentFor(testConsumer.consumerId.get, List(ReadAccountsBasic))
+
+      // Structurally a JWT, and the claims parse as JSON -- they are simply not a ConsentJWT.
+      def b64(s: String) = java.util.Base64.getUrlEncoder.withoutPadding.encodeToString(s.getBytes("UTF-8"))
+      Consents.consentProvider.vend.setJsonWebToken(
+        consentId, s"${b64("""{"alg":"HS256"}""")}.${b64("""{"not":"a consent"}""")}.signature-is-never-checked")
+
+      val revoked = Consents.consentProvider.vend.revoke(consentId)
+
+      withClue("the revoke threw rather than reporting the outcome: ") {
+        revoked.isDefined should equal(true)
+      }
+      Consents.consentProvider.vend.getConsentByConsentId(consentId)
+        .map(_.status) should equal(Full(ConsentStatus.REVOKED.toString))
+
+      // And it stays revoked: a second attempt is the ConsentAlreadyRevoked the caller used to be
+      // pushed into by the failure, rather than a way out of it.
+      Consents.consentProvider.vend.revoke(consentId).isDefined should equal(false)
+    }
   }
 
 }

--- a/obp-api/src/test/scala/code/api/berlin/group/v1_3/BerlinGroupV13ConsentAccessTests.scala
+++ b/obp-api/src/test/scala/code/api/berlin/group/v1_3/BerlinGroupV13ConsentAccessTests.scala
@@ -87,10 +87,45 @@ class BerlinGroupV13ConsentAccessTests extends BerlinGroupConsentFixtures {
         equal(Some(ConsentDoesNotMatchUser))
     }
 
+    // Matching the PSU is necessary, not sufficient. It used to be sufficient: the rule returned
+    // None the moment the two PSU ids agreed, without ever looking at the Consumer, so a second TPP
+    // holding a session for the same person could read and revoke the consent a first TPP lodged.
+    // One TPP's mandate over a consent is not another's -- the same principle the payment guard in
+    // Http4sBGv13PIS states, and IG 4.11's "may only apply to resources which have been created by
+    // the same TPP before" admits no PSU exception.
+    scenario("a second TPP holding a session for the consent's own PSU is still refused", BerlinGroupV13ConsentAccess) {
+      Consent.checkBerlinGroupConsentAccess(psu, tpp, Some(psu), Some(otherTpp), callerIsScaFrontEnd = false) should
+        equal(Some(ConsentDoesNotMatchConsumer))
+    }
+
     scenario("blank ids count as absent, not as a value to match", BerlinGroupV13ConsentAccess) {
-      Consent.checkBerlinGroupConsentAccess(null, null, None, None, callerIsScaFrontEnd = false) should equal(None)
       Consent.checkBerlinGroupConsentAccess("   ", tpp, Some(psu), Some(tpp), callerIsScaFrontEnd = false) should equal(None)
       Consent.checkBerlinGroupConsentAccess(psu, tpp, Some("  "), Some(tpp), callerIsScaFrontEnd = false) should equal(None)
+    }
+
+    // This assertion is inverted from what it used to say. It read
+    //   checkBerlinGroupConsentAccess(null, null, None, None, false) should equal(None)
+    // which pinned a consent recording no TPP as addressable by anybody -- "absent" was being read
+    // as "matches everything" rather than as "there is nobody this belongs to". Neither standard
+    // supports that: IG 4.11 scopes a resource to the TPP that created it, and UK scopes GET and
+    // DELETE to "an account-access-consent resource that they have created". A row naming no TPP
+    // satisfies neither, so it belongs to nobody and is refused.
+    //
+    // It is a real population, not a hypothetical: 10 of 566 Berlin Group consents and 4 of 753 UK
+    // consents record no consumer on a long-lived instance. They are already unreachable in Berlin
+    // Group today, by accident -- the hand-rolled `null == "None"` compare in the five reads is
+    // false for everyone -- so refusing them here changes nothing for those callers and only stops
+    // the UK pair, and the reads once they move onto this rule, from opening up.
+    scenario("a consent that records no lodging TPP belongs to nobody", BerlinGroupV13ConsentAccess) {
+      Consent.checkBerlinGroupConsentAccess(null, null, None, None, callerIsScaFrontEnd = false) should
+        equal(Some(ConsentDoesNotMatchConsumer))
+      Consent.checkBerlinGroupConsentAccess(null, "  ", Some(psu), Some(tpp), callerIsScaFrontEnd = false) should
+        equal(Some(ConsentDoesNotMatchConsumer))
+    }
+
+    scenario("an operator can restore the old behaviour for a migration window", BerlinGroupV13ConsentAccess) {
+      setPropsValues("consent_allow_legacy_unrecorded_tpp" -> "true")
+      Consent.checkBerlinGroupConsentAccess(null, null, None, None, callerIsScaFrontEnd = false) should equal(None)
     }
   }
 
@@ -258,6 +293,54 @@ class BerlinGroupV13ConsentAccessTests extends BerlinGroupConsentFixtures {
       headers: _*)
 
   private def psuIdHeader(userName: String) = List(("PSU-ID", userName))
+
+  // The five reads of a consent resource. They each used to compare
+  //   consent.mConsumerId.get == cc.consumer.map(_.consumerId.get).getOrElse("None")
+  // by hand, five separate times, rather than going through checkBerlinGroupConsentAccess like the
+  // authorisation pair above. Five copies of one security decision is how the two fail-opens fixed
+  // in the previous commit came to be fixed in the rule and not at these call sites: a hand-rolled
+  // Consumer compare cannot notice that the PSU half exists at all.
+  private def consentReads(consentId: String, session: Option[(Consumer, Token)]) = List(
+    "read the consent" -> makeGetRequest((V1_3_BG / "consents" / consentId).GET <@ (session)),
+    "read its status" -> makeGetRequest((V1_3_BG / "consents" / consentId / "status").GET <@ (session)),
+    "list its authorisations" -> makeGetRequest((V1_3_BG / "consents" / consentId / "authorisations").GET <@ (session)),
+    "read an authorisation's SCA status" ->
+      makeGetRequest((V1_3_BG / "consents" / consentId / "authorisations" / "any-authorisation-id").GET <@ (session))
+  )
+
+  feature("BG v1.3 - the consent reads apply the same ownership rule as the authorisation pair") {
+
+    scenario("the lodging TPP acting for a second PSU cannot read a consent bound to the first", BerlinGroupV13ConsentAccess) {
+      val consentId = createUnclaimedBerlinGroupConsent().consentId
+      Consents.consentProvider.vend.updateConsentUser(consentId, resourceUser1)
+
+      Then("the same TPP, but acting for a different person, is refused on every read")
+      // The Consumer matches -- this IS the TPP that lodged it -- so a Consumer-only compare says
+      // yes. The consent is bound to resourceUser1 and the session is resourceUser2's, and once a
+      // consent names a PSU the rule requires that PSU, which is what the authorisation pair has
+      // enforced all along and these reads did not.
+      consentReads(consentId, secondPsuOfTestConsumerSession).foreach { case (what, response) =>
+        withClue(s"a second PSU of the lodging TPP was allowed to $what: ") {
+          response.code should equal(403)
+        }
+      }
+
+      And("the lodging TPP on a client-credentials session still can")
+      // The normal Berlin Group caller: no genuine PSU in the session at all, so the PSU half does
+      // not apply and the Consumer decides. This is the half that must not regress.
+      consentReads(consentId, clientCredentialsSession).foreach { case (what, response) =>
+        withClue(s"the lodging TPP could not $what: ") {
+          response.code should equal(200)
+        }
+      }
+
+      And("so does DELETE, which is the fifth site and mutates, hence last")
+      makeDeleteRequest((V1_3_BG / "consents" / consentId).DELETE <@ (secondPsuOfTestConsumerSession))
+        .code should equal(403)
+      makeDeleteRequest((V1_3_BG / "consents" / consentId).DELETE <@ (clientCredentialsSession))
+        .code should equal(204)
+    }
+  }
 
   feature("BG v1.3 - a consent's authorisation sub-resources answer only to the TPP that lodged it") {
 

--- a/obp-api/src/test/scala/code/api/berlin/group/v1_3/PaymentInitiationServicePISApiTest.scala
+++ b/obp-api/src/test/scala/code/api/berlin/group/v1_3/PaymentInitiationServicePISApiTest.scala
@@ -13,6 +13,7 @@ import code.model.dataAccess.{BankAccountRouting, MappedBankAccount}
 import code.model.TokenType
 import code.setup.{APIResponse, DefaultUsers}
 import code.token.Tokens
+import code.transactionrequests.MappedTransactionRequest
 import net.liftweb.util.Helpers.randomString
 import net.liftweb.util.TimeHelpers.TimeSpan
 import code.views.Views
@@ -772,41 +773,50 @@ class PaymentInitiationServicePISApiTest extends BerlinGroupServerSetupV1_3 with
   // caller, so without an explicit check a paymentId is a bearer token: whoever holds it can read
   // the payment, list and start authorisations on it, and cancel it. The payment records who lodged
   // it; these scenarios hold every payment-scoped route to that record.
+  // Every scenario in the feature below needs the same starting point: one payment lodged by user1
+  // over the challenge threshold, so it sits awaiting SCA — the state in which a hijacked
+  // authorisation would actually move money. Shared rather than repeated because what each scenario
+  // is about is what happens *after* this, and three copies of the lodging made that hard to see.
+  private def ibanAccounts = BankAccountRouting
+    .findAll(By(BankAccountRouting.AccountRoutingScheme, AccountRoutingScheme.IBAN.toString))
+    .filterNot(_.bankId.value == "DEFAULT_BANK_ID_NOT_SET")
+
+  private def balanceOf(routing: BankAccountRouting) = MappedBankAccount.find(
+    By(MappedBankAccount.bank, routing.bankId.value),
+    By(MappedBankAccount.theAccountId, routing.accountId.value))
+    .map(_.balance).openOrThrowException("Can not be empty here")
+
+  private def paymentUrl(paymentId: String) =
+    V1_3_BG / PaymentServiceTypes.payments.toString / TransactionRequestTypes.SEPA_CREDIT_TRANSFERS.toString / paymentId
+
+  /** Lodges a payment as user1 and returns its id alongside the two accounts it moves between. */
+  private def lodgePaymentAsUser1(): (String, BankAccountRouting, BankAccountRouting) = {
+    val ibanFrom = ibanAccounts.head
+    val ibanTo = ibanAccounts.last
+    grantAccountAccess(ibanFrom)
+    val initiatePaymentJson =
+      s"""{
+         | "debtorAccount": { "iban": "${ibanFrom.accountRouting.address}" },
+         | "instructedAmount": { "currency": "EUR", "amount": "2001" },
+         | "creditorAccount": { "iban": "${ibanTo.accountRouting.address}" },
+         | "creditorName": "70charname"
+          }""".stripMargin
+    val responseInitiate: APIResponse = makePostRequest(
+      (V1_3_BG / PaymentServiceTypes.payments.toString / TransactionRequestTypes.SEPA_CREDIT_TRANSFERS.toString).POST <@ (user1),
+      initiatePaymentJson)
+    responseInitiate.code should equal(201)
+    (responseInitiate.body.extract[InitiatePaymentResponseJson].paymentId, ibanFrom, ibanTo)
+  }
+
   feature("test the BG v1.3 - a payment is only addressable by the party that initiated it") {
     scenario("a second TPP can neither read, authorise, nor cancel a payment it did not initiate", BerlinGroupV1_3, PIS, initiatePayment) {
-      val accountsRoutingIban = BankAccountRouting.findAll(By(BankAccountRouting.AccountRoutingScheme, AccountRoutingScheme.IBAN.toString))
-        .filterNot(_.bankId.value == "DEFAULT_BANK_ID_NOT_SET")
-      val ibanFrom = accountsRoutingIban.head
-      val ibanTo = accountsRoutingIban.last
-
-      def balanceOf(routing: BankAccountRouting) = MappedBankAccount.find(
-        By(MappedBankAccount.bank, routing.bankId.value),
-        By(MappedBankAccount.theAccountId, routing.accountId.value))
-        .map(_.balance).openOrThrowException("Can not be empty here")
-
-      grantAccountAccess(ibanFrom)
-
-      // Over the challenge threshold, so the payment stays in RCVD awaiting SCA — the state in which
-      // a hijacked authorisation would actually move money.
-      val initiatePaymentJson =
-        s"""{
-           | "debtorAccount": { "iban": "${ibanFrom.accountRouting.address}" },
-           | "instructedAmount": { "currency": "EUR", "amount": "2001" },
-           | "creditorAccount": { "iban": "${ibanTo.accountRouting.address}" },
-           | "creditorName": "70charname"
-            }""".stripMargin
-
       When("user1 initiates a payment")
-      val responseInitiate: APIResponse = makePostRequest(
-        (V1_3_BG / PaymentServiceTypes.payments.toString / TransactionRequestTypes.SEPA_CREDIT_TRANSFERS.toString).POST <@ (user1),
-        initiatePaymentJson)
-      responseInitiate.code should equal(201)
-      val paymentId = responseInitiate.body.extract[InitiatePaymentResponseJson].paymentId
+      val (paymentId, ibanFrom, ibanTo) = lodgePaymentAsUser1()
 
       val fromBalanceBefore = balanceOf(ibanFrom)
       val toBalanceBefore = balanceOf(ibanTo)
 
-      val payment = V1_3_BG / PaymentServiceTypes.payments.toString / TransactionRequestTypes.SEPA_CREDIT_TRANSFERS.toString / paymentId
+      val payment = paymentUrl(paymentId)
 
       Then("user2 is refused on every payment-scoped route")
       val refusals = List(
@@ -833,28 +843,9 @@ class PaymentInitiationServicePISApiTest extends BerlinGroupServerSetupV1_3 with
       ownerResponse.code should equal(200)
     }
     scenario("a second TPP acting for the same PSU is refused too", BerlinGroupV1_3, PIS, initiatePayment) {
-      val accountsRoutingIban = BankAccountRouting.findAll(By(BankAccountRouting.AccountRoutingScheme, AccountRoutingScheme.IBAN.toString))
-        .filterNot(_.bankId.value == "DEFAULT_BANK_ID_NOT_SET")
-      val ibanFrom = accountsRoutingIban.head
-      val ibanTo = accountsRoutingIban.last
-
-      grantAccountAccess(ibanFrom)
-
-      val initiatePaymentJson =
-        s"""{
-           | "debtorAccount": { "iban": "${ibanFrom.accountRouting.address}" },
-           | "instructedAmount": { "currency": "EUR", "amount": "2001" },
-           | "creditorAccount": { "iban": "${ibanTo.accountRouting.address}" },
-           | "creditorName": "70charname"
-            }""".stripMargin
-
       When("the PSU lodges a payment through one TPP")
-      val responseInitiate: APIResponse = makePostRequest(
-        (V1_3_BG / PaymentServiceTypes.payments.toString / TransactionRequestTypes.SEPA_CREDIT_TRANSFERS.toString).POST <@ (user1),
-        initiatePaymentJson)
-      responseInitiate.code should equal(201)
-      val paymentId = responseInitiate.body.extract[InitiatePaymentResponseJson].paymentId
-      val payment = V1_3_BG / PaymentServiceTypes.payments.toString / TransactionRequestTypes.SEPA_CREDIT_TRANSFERS.toString / paymentId
+      val (paymentId, _, _) = lodgePaymentAsUser1()
+      val payment = paymentUrl(paymentId)
 
       Then("the same PSU acting through a second TPP still cannot address it")
       // The person matches and only the TPP differs -- the case a person-only check waves through,
@@ -865,6 +856,28 @@ class PaymentInitiationServicePISApiTest extends BerlinGroupServerSetupV1_3 with
 
       And("the TPP that lodged it still can")
       makeGetRequest((payment / "status").GET <@ (user1)).code should equal(200)
+    }
+    scenario("a payment lodged before the consumer was recorded is still readable", BerlinGroupV1_3, PIS, initiatePayment) {
+      When("a payment is lodged")
+      val (paymentId, _, _) = lodgePaymentAsUser1()
+      val payment = paymentUrl(paymentId)
+
+      And("the recorded consumer is cleared, as it is on every payment lodged before the field existed")
+      // Not "": MappedTransactionRequestProvider writes the absent consumer as a literal null, so
+      // the column is SQL NULL and MappedString reads a null back out. The overwhelming majority of
+      // rows on any long-lived instance are in this state, so whatever the guard does with them it
+      // must not be to throw.
+      MappedTransactionRequest.find(By(MappedTransactionRequest.mTransactionRequestId, paymentId))
+        .map(_.mConsumerId(null).saveMe())
+        .openOrThrowException("the payment just lodged must be findable")
+
+      Then("the party that lodged it can still read it, its status and its authorisations")
+      List("read the payment" -> payment, "read its status" -> (payment / "status"),
+        "list its authorisations" -> (payment / "authorisations")).foreach { case (what, url) =>
+        withClue(s"the initiator could not $what: ") {
+          makeGetRequest(url.GET <@ (user1)).code should equal(200)
+        }
+      }
     }
   }
   // resourceUser1's own token, issued under a second consumer: same person, different TPP.


### PR DESCRIPTION
Follow-up to #2881, which merged while these were being worked through. Nine issues from its review, each its own commit, each written test-first — the test was observed failing before the fix in every case.

## The five defects the reviewer asked to fix

**1. `getOwnPaymentImpl` returned 500 for almost every stored payment.** It read the lodging consumer off the row with `.filter(_.nonEmpty)`, and `MappedTransactionRequestProvider` writes the absent consumer as a literal `null` rather than `""`. **1757 of 1800 rows** on a long-lived instance are in that state, and the helper guards all twelve payment-read call sites — so reading a payment, polling its status, listing its authorisations or cancelling it answered 500 *for the party that lodged it*. Reading a possibly-absent id was already solved four times over inside `ConsentUtil` as a local `present`, which is how a fifth caller came to be written without it; lifted to `Consent.present` and reused at all five sites.

**2. An SCA challenge could authorise a different consent.** `authoriseUKConsent` fetched the started challenge and discarded it. `validateChallengeAnswerC4` *is* handed the `consentId`, but `LocalMappedConnector` ignores it and matches on challenge id, answer and expected user alone. Measured before the fix: a challenge minted on a `ReadAccountsBasic` consent, answered against a `ReadAccountsBasic + ReadAccountsDetail + ReadBalances` consent → **200**, the wider consent `AUTHORISED` and bound to the PSU, while the consent actually challenged stayed `AWAITINGAUTHORISATION`. The Berlin Group half of #2881 already asserted this binding (`Http4sBGv13AIS`); the UK half now does, with the same guard, message and code.

**3. The Berlin Group consent reads apply the shared ownership rule.** Five sites — not the three named in review; `deleteConsent` and `getConsentInformation` spell the same comparison across intermediate vals. Five copies of one security decision is why the fixes in issue 6 below reached the rule and not these call sites.

**4. Removed `grantAccessToSystemViewForConsumer` / `grantAccessToCustomViewForConsumer`.** No callers, and none could have been added safely: consent grants are written under `Constant.ALL_CONSUMERS`, and `revokeConsentAccountAccess` sweeps by asking for *exactly* that, so a row written under a real consumer id is invisible to the sweep and the access outlives its consent. Their own comment recommended the opposite. The trait comment now says why the pair is absent.

**5. A revoke that cannot give the access back still reports the revoke.** `revokeConsentAccountAccess` ran after `conditionalRevoke` had committed, unguarded — a throw could not undo the revoke, only hide it, and the retry then got `ConsentAlreadyRevoked`, leaving an AISP unable to complete the DELETE the standards require. Reachable via a stored JWT that no longer extracts: `getSignedPayloadAsJson` does not verify the signature, and `Box.map` does not catch. Wrapped in `tryo` like its Berlin Group sibling, logged at error rather than swallowed.

## The four design questions, implemented

**6. A consent belongs to one TPP, and one naming none belongs to nobody.** Two fail-opens in the shared rule: matching the PSU ended the enquiry before the Consumer was compared, so a second TPP holding a session for the same person reached the first TPP's consent; and `owner.forall(...)` is vacuously true when no consumer is recorded, so such a consent was addressable by everyone. Real populations — **10 of 566** Berlin Group, **50 of 463** OBP-native, **4 of 753** UK consents record no consumer. Grounded in IG 4.11 ("may only apply to resources which have been created by the same TPP before") and the UK profile scoping GET/DELETE to a consent "that they have created", on a client-credentials token. `consent_allow_legacy_unrecorded_tpp` is a documented migration window, default false, warning on every use.

**7. A UK access token may only exercise a consent belonging to its own subject.** The PSU came from the token and was never compared to the consent, so any token carrying a `consent_id` that was not its holder's was swapped onto that consent's shadow user — the principal that holds the consent's account access. `checkUKConsent` caught it, but only the UK read endpoints call `checkUKConsent`; on every other endpoint family the swapped principal stood. The PSU now comes off the consent row, as `applyUKRules` already does, and the token's subject must be that PSU. **Both halves are load-bearing**: deriving `consenter` from `mUserId` without also comparing the token would leave `checkUKConsent` comparing the consent's user with itself. The comparison moves to the swap — which runs for every request and whose refusal `ResourceDocMiddleware` enforces everywhere — rather than going away.

**8. "Not yours" and "no such consent" answer the same.** They used to differ: 400 with the id echoed back, against 403 with the reason — enough to walk a list of ids and learn which are real. Both are now 403 `ConsentNotFound` with no id, on UK v3.1 and v4.0.1 and all five Berlin Group reads; the specific reason is logged. Six existing assertions change wording only — the IDOR regressions still assert 403 and still assert the consent was left untouched.

**9. The across-accounts transactions endpoint returns data, and only what was consented.** This one was not the defect expected. `GET /aisp/transactions` returned **nothing at all** for any account not at the instance's default bank: it passed the default `Bank` into `getModeratedTransactions`, and `moderateTransactionsWithSameAccount` refuses every transaction not belonging to the account it builds from that Bank, logging `Attempted to moderate a transaction using the incorrect moderated account` once per row — which the closing `.getOrElse(Nil)` turned into "this account has no transactions". Each account's own Bank is now resolved. With data flowing, the direction permissions apply here too: the profile's Permissions table lists `/transactions` **first** for both `ReadTransactionsCredits` and `ReadTransactionsDebits`, data cluster "Ability to read *only* credit transactions". Resolved per account, since a consent can grant different directions on different ones.

## Deliberately not included

- **A consent the TPP has DELETEd should answer 400 on later reads** (profile, *Changes to an Intent's Authorized State*); it answers 200 with `Status: CANC`. The profile wants 400 for a TPP-initiated DELETE and 200-with-CANC for a PSU cancelling at the ASPSP, and OBP writes the same `REVOKED` status for both through the same `MappedConsent.revoke`. Recording the origin is a schema change and its own piece of work.
- **`LocalMappedConnector.createChallengesC2` hardcodes `challengeType`**, discarding the caller's value — there is not one `OBP_CONSENT_CHALLENGE` row in the database. It does not affect issue 2's guard, which keys off `consentId`.

## Verification

Per commit: targeted suites, the out-of-repo probe suite against a rebuilt instance, then the full local suite; then pushed and CI waited on before starting the next issue.

- Full local suite each round: **3236–3247 passed, 0 failed, 0 aborted** (6 shards).
- CI green on all three staging PRs: **25/25** each.
- Probes: `run_probes.py` 109/0, `uk_view_endpoint_matrix.py` 12/12, `stale_revoke_failure.py` 17/0, `uk_direction.py` 9/0, `bg_legacy_payment.py` 15/15, `uk_token_path.py` and `uk_challenge_binding.py` OK.

**Both directions, every time.** Issue 7 is mutation-checked in both halves — removing the comparison fails the unit scenario *and* the integration one, and the integration failure shows the principal being swapped onto a consent the caller has nothing to do with. Issues 1, 2, 3, 5, 6, 8 and 9 were each observed red first.

Two probes turned out to have been passing only because of the fail-open in issue 6 — their UK revoke step used a consumer that had not lodged the consent, and matching the PSU was letting it through. Revoking is setup there, not the assertion, so the identity was corrected to the one the profile sanctions, and the behaviour that had been hiding was pinned as new assertions.