### PR TITLE
fix: consent-access follow-ups to #2882 — challenge type, PSU-ID lock check, and the Berlin Group availableAccounts consent

### DIFF
--- a/obp-api/src/main/resources/props/sample.props.template
+++ b/obp-api/src/main/resources/props/sample.props.template
@@ -240,6 +240,14 @@ jwt.use.ssl=false
 ## Unit is a second
 # obp_expired_consents_interval_in_seconds =
 
+## Expire UK Open Banking consents with status "Authorised"
+## Unlike the three keys above this one HAS a default (601 seconds, a prime near 10 minutes, so the
+## sweep does not settle into step with other periodic schedulers). Set it to 0 to stop the task.
+## Turning it off does not grant access to an expired consent: checkUKConsent rejects one reactively
+## on every request whatever this task's timing. The sweep only keeps the stored status accurate for
+## GET and dashboard purposes.
+# uk_open_banking_expired_consents_interval_in_seconds = 601
+
 
 ## Enable writing API metrics (which APIs are called) to RDBMS
 ## Default lives in code.metrics.MetricsProps (WriteMetricsDefault)
@@ -1196,6 +1204,13 @@ featured_apis=elasticSearchWarehouseV300
 # -- RabbitMQ Adapter --------------------------------------------
 #rabbitmq.adapter.enabled=false
 
+
+# -- Open Corridor ----------------------------------------------
+# The platform is modelled AS a bank, and this is its BANK_ID -- the creditor side of the platform
+# fee settlement instructions raised by the fee-accrual endpoints. There is no usable default: with
+# this unset, sweeping accrued fees fails with OBP-10035 rather than paying an unintended bank.
+# Only relevant on an instance that has Open Corridor turned on and settles platform fees.
+# open_corridor.platform_bank_id=
 
 
 # -- Scopes -----------------------------------------------------

--- a/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13AIS.scala
+++ b/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13AIS.scala
@@ -356,7 +356,7 @@ object Http4sBGv13AIS extends MdcLoggable {
           // being fetched here purely to prove it exists, so the SCA status of anyone's consent was
           // readable by any AISP that knew the id.
           consent <- Future(Consents.consentProvider.vend.getConsentByConsentId(consentId)) map {
-            unboxFullOrFail(_, callContext, s"$ConsentNotFound ($consentId)", 403)
+            unboxFullOrFail(_, callContext, ConsentNotFound, 403)
           }
           _ <- Consent.assertBerlinGroupConsentReadAccess(consent.userId, consent.consumerId, cc)
           (challenges, callContext) <- NewStyle.function.getChallengesByConsentId(consentId, callContext)

--- a/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13AIS.scala
+++ b/obp-api/src/main/scala/code/api/berlin/group/v1_3/Http4sBGv13AIS.scala
@@ -665,6 +665,22 @@ object Http4sBGv13AIS extends MdcLoggable {
               SuppliedAnswerType.PLAIN_TEXT_VALUE,
               callContext.map(_.copy(user = Full(psu)))
             )
+            // Bind an "availableAccounts": "allAccounts" consent to this PSU's own accounts. That
+            // shape names no IBAN, so createBerlinGroupConsentJWT wrote no views for it and the
+            // consent would otherwise go valid and serve an empty account list. Any other shape
+            // resolved its accounts at creation and passes through untouched.
+            //
+            // On a finalised answer only: a failed or still-pending SCA must not grant anything.
+            // And before the status update, because none of this is transactional -- a consent that
+            // reached `valid` and then failed to gain its views would be an authorised consent that
+            // serves nothing, with no way to repair it through the API. Refuse first, commit after,
+            // same ordering as the UK twin in Http4s510.authoriseUKConsent.
+            _ <- if (challenge.scaStatus.contains(StrongCustomerAuthenticationStatus.finalised)) {
+              Consent.grantBerlinGroupAvailableAccountsAccess(psu, storedConsent)
+                .map(unboxFullOrFail(_, callContext, ConsentAccountAccessCannotBeGranted))
+            } else {
+              Future.successful(storedConsent)
+            }
             consent <- challenge.scaStatus match {
               case Some(status) if status == StrongCustomerAuthenticationStatus.finalised =>
                 Future(Consents.consentProvider.vend.updateConsentStatus(consentId, ConsentStatus.valid))

--- a/obp-api/src/main/scala/code/api/util/ConsentUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/ConsentUtil.scala
@@ -32,6 +32,7 @@ import code.views.Views
 import com.nimbusds.jwt.JWTClaimsSet
 import com.openbankproject.commons.ExecutionContext.Implicits.global
 import com.openbankproject.commons.model._
+import com.openbankproject.commons.model.enums.AccountRoutingScheme
 import com.openbankproject.commons.util.ApiStandards
 import net.liftweb.common._
 import org.json4s.ParserUtil.ParseException
@@ -1529,66 +1530,104 @@ object Consent extends MdcLoggable {
       }
     }
   }
-  def updateViewsOfBerlinGroupConsentJWT(user: User,
-                                         consent: MappedConsent,
-                                         callContext: Option[CallContext]): Future[Box[MappedConsent]] = {
-    implicit val dateFormats = CustomJsonFormats.formats
-    val payloadToUpdate: Box[ConsentJWT] = JwtUtil.getSignedPayloadAsJson(consent.jsonWebToken) // Payload as JSON string
-      .map(com.openbankproject.commons.util.JsonAliases.parse(_).extract[ConsentJWT]) // Extract case class
+  /**
+   * Binds a Berlin Group `"access": {"availableAccounts": "allAccounts"}` consent to the accounts
+   * the authorising PSU actually holds, and returns the consent (unchanged for any other shape).
+   *
+   * That shape names no IBAN — the standard requires accounts/balances/transactions to be absent or
+   * empty when it is used — so createBerlinGroupConsentJWT, which builds views by resolving the
+   * IBANs in the access object, has nothing to resolve and writes `views: []`. The consent means
+   * "every account this PSU holds", and which accounts those are cannot be known at lodging time:
+   * the TPP lodges the consent, and the PSU is only settled at SCA. So this is where the accounts
+   * become known, and it must run as the PSU — the holdings are the whole of the scope.
+   *
+   * Until this existed the shape was accepted, validated and authorised, and then served nothing:
+   * the JWT kept its empty view list, grantAccessToViews granted the consent's shadow user no
+   * access, and GET /accounts answered with an empty list for a consent whose status was `valid`.
+   *
+   * Views are added, not replaced. A consent that also named IBANs explicitly (which the standard
+   * forbids alongside availableAccounts, but POST /consents does not currently reject) keeps the
+   * balances and transactions views createBerlinGroupConsentJWT resolved for it; replacing would
+   * silently drop them. Equally, the grant here is confined to
+   * SYSTEM_READ_ACCOUNTS_BERLIN_GROUP_VIEW_ID: availableAccounts buys the account *list* and
+   * nothing else, so it must not hand out balances or transactions on accounts the consent never
+   * asked about.
+   *
+   * Only accounts with an IBAN routing are included. Berlin Group addresses accounts by IBAN
+   * throughout, so an account with no IBAN is not addressable through this API and granting a view
+   * on it would widen the consent without making anything reachable.
+   *
+   * A JWT that cannot be read is refused rather than treated as "not this shape". This function's
+   * whole job is to write the consent's next JWT, and it cannot do that from a payload it could not
+   * parse. On the Berlin Group authorise path assertBerlinGroupConsentAccountsHeld has already
+   * turned that case away, so this is the second refusal rather than the only one -- kept because
+   * the two are independent and this one belongs to whoever calls this function, not to the order
+   * the caller happens to run its checks in.
+   */
+  def grantBerlinGroupAvailableAccountsAccess(psu: User,
+                                              storedConsent: consent.ConsentTrait): Future[Box[consent.ConsentTrait]] = Future {
+    implicit val dateFormats: Formats = CustomJsonFormats.formats
+    val payload: Box[ConsentJWT] = JwtUtil.getSignedPayloadAsJson(storedConsent.jsonWebToken)
+      .map(com.openbankproject.commons.util.JsonAliases.parse(_).extract[ConsentJWT])
 
-    val availableAccountsUserIbans: List[String] = payloadToUpdate match {
+    payload match {
+      case Full(consentJwt) if !isAvailableAccountsConsent(consentJwt) =>
+        // Nothing to do: this consent named its accounts, and they were resolved at creation.
+        Full(storedConsent)
       case Full(consentJwt) =>
-        val availableAccountsUserIbans: List[String] =
-          if (consentJwt.access.map(_.availableAccounts.contains("allAccounts")).isDefined) {
-            // Get all accounts held by the current user
-            val userAccounts: List[BankIdAccountId] =
-              AccountHolders.accountHolders.vend.getAccountsHeldByUser(user, Some(null)).toList
-            userAccounts.flatMap { acc =>
-              BankAccountRouting.find(
-                By(BankAccountRouting.BankId, acc.bankId.value),
-                By(BankAccountRouting.AccountId, acc.accountId.value),
-                By(BankAccountRouting.AccountRoutingScheme, "IBAN")
-              ).map(_.AccountRoutingAddress.get)
-            }
-          } else {
-            val emptyList: List[String] = Nil
-            emptyList
+        // .exists, not .isDefined: the predecessor of this function asked
+        // `access.map(_.availableAccounts.contains("allAccounts")).isDefined`, which is true
+        // whenever `access` is present at all -- and createBerlinGroupConsentJWT always writes
+        // `access`. Every consent would have taken this branch, so a consent narrowed to one IBAN
+        // would have been widened to the PSU's whole estate. See isAvailableAccountsConsent.
+        val heldWithIban: List[ConsentView] = AccountHolders.accountHolders.vend
+          .getAccountsHeldByUser(psu).toList
+          .filter { held =>
+            BankAccountRouting.find(
+              By(BankAccountRouting.BankId, held.bankId.value),
+              By(BankAccountRouting.AccountId, held.accountId.value),
+              By(BankAccountRouting.AccountRoutingScheme, AccountRoutingScheme.IBAN.toString)
+            ).isDefined
           }
-        availableAccountsUserIbans
+          .map { held =>
+            ConsentView(
+              bank_id = held.bankId.value,
+              account_id = held.accountId.value,
+              view_id = Constant.SYSTEM_READ_ACCOUNTS_BERLIN_GROUP_VIEW_ID,
+              None
+            )
+          }
+        val merged = (consentJwt.views ::: heldWithIban).distinct
+        if (merged == consentJwt.views) {
+          // The PSU holds no IBAN-addressable account, or every one of them is already named. Not
+          // an error -- an "allAccounts" consent over an empty estate is a consent over nothing --
+          // so leave the JWT alone rather than re-signing it to the same content.
+          logger.debug(s"grantBerlinGroupAvailableAccountsAccess: consent ${storedConsent.consentId} " +
+            s"gained no view; the PSU holds ${heldWithIban.size} IBAN-addressable account(s).")
+          Full(storedConsent)
+        } else {
+          val jwtPayloadAsJson = compactRender(Extraction.decompose(consentJwt.copy(views = merged)))
+          val jwtClaims: JWTClaimsSet = JWTClaimsSet.parse(jwtPayloadAsJson)
+          val jwt = CertificateUtil.jwtWithHmacProtection(jwtClaims, storedConsent.secret)
+          Consents.consentProvider.vend.setJsonWebToken(storedConsent.consentId, jwt)
+        }
+      case failure @ Failure(_, _, _) =>
+        failure
       case _ =>
-        val emptyList: List[String] = Nil
-        emptyList
-    }
-
-
-    // 1. Add access
-    val availableAccounts: List[Future[ConsentView]] = availableAccountsUserIbans.distinct map { iban =>
-      Connector.connector.vend.getBankAccountByIban(iban, callContext) map { bankAccount =>
-        logger.debug(s"createBerlinGroupConsentJWT.accounts.bankAccount: $bankAccount")
-        val error = s"${InvalidConnectorResponse} IBAN: ${iban} ${handleBox(bankAccount._1)}"
-        ConsentView(
-          bank_id = bankAccount._1.map(_.bankId.value).getOrElse(""),
-          account_id = bankAccount._1.map(_.accountId.value).openOrThrowException(error),
-          view_id = Constant.SYSTEM_READ_ACCOUNTS_BERLIN_GROUP_VIEW_ID,
-          None
-        )
-      }
-    }
-
-    Future.sequence(availableAccounts) map { views =>
-      if(views.isEmpty) {
-        Empty
-      } else {
-        val updatedPayload = payloadToUpdate.map(i =>
-          i.copy(views = views) // Update the field "views"
-        )
-        val jwtPayloadAsJson = compactRender(Extraction.decompose(updatedPayload))
-        val jwtClaims: JWTClaimsSet = JWTClaimsSet.parse(jwtPayloadAsJson)
-        val jwt = CertificateUtil.jwtWithHmacProtection(jwtClaims, consent.secret)
-        Consents.consentProvider.vend.setJsonWebToken(consent.consentId, jwt)
-      }
+        Failure(s"$InvalidConnectorResponse The consent's JWT could not be read.")
     }
   }
+
+  /**
+   * Whether a Berlin Group consent asks for access to all of the PSU's accounts.
+   *
+   * POST /consents already refuses any value of availableAccounts other than "allAccounts"
+   * (BerlinGroupConsentAccessAvailableAccounts), so this is the only value that can reach a stored
+   * consent -- but read it off the JWT rather than assuming, because the JWT is what every other
+   * decision about this consent is taken from.
+   */
+  private def isAvailableAccountsConsent(consentJwt: ConsentJWT): Boolean =
+    consentJwt.access.exists(_.availableAccounts.contains("allAccounts"))
 
   def updateUserIdOfBerlinGroupConsentJWT(createdByUserId: String,
                                           consent: MappedConsent,
@@ -1984,8 +2023,10 @@ object Consent extends MdcLoggable {
    * user. Checking anything else would leave the two able to disagree.
    *
    * A consent whose JWT names no account yet is not refused here. That is the availableAccounts
-   * ("allAccounts") shape, whose views are materialised later and against the PSU's own holdings,
-   * so there is nothing for this check to compare and nothing it could wrongly let through.
+   * ("allAccounts") shape, which names no IBAN by definition: its views are materialised a few
+   * steps further on, by grantBerlinGroupAvailableAccountsAccess, and against this same PSU's own
+   * holdings. So there is nothing for this check to compare and nothing it could wrongly let
+   * through.
    */
   def assertBerlinGroupConsentAccountsHeld(
     psu: User,
@@ -2278,8 +2319,9 @@ object Consent extends MdcLoggable {
    * bank_id/account_id, no wildcard). Call this once the PSU has selected which accounts the
    * consent applies to (currently: the UK authorise step, since OBP has no separate
    * ASPSP-hosted account-selection UI) to replace those dead rows with real per-account
-   * ConsentViews — mirroring how updateViewsOfBerlinGroupConsentJWT resolves BG's IBAN-keyed access
-   * into real accounts.
+   * ConsentViews — the same shape of step as grantBerlinGroupAvailableAccountsAccess, which
+   * resolves BG's "all of this PSU's accounts" consent into real accounts at its own authorise
+   * step.
    *
    * The JWT it writes is the consent's whole scope: resolveUKConsentPrincipal re-derives the
    * consent's AccountAccess from it on every request. So this grants nothing itself, and must keep

--- a/obp-api/src/main/scala/code/api/util/ConsentUtil.scala
+++ b/obp-api/src/main/scala/code/api/util/ConsentUtil.scala
@@ -14,6 +14,8 @@ import code.api.{APIFailure, APIFailureNewStyle, Constant, RequestHeader}
 import code.bankconnectors.Connector
 import code.consent
 import code.consent.ConsentStatus.ConsentStatus
+import code.loginattempts.LoginAttempt
+import net.liftweb.util.Helpers.tryo
 import code.consent.{ConsentStatus, Consents, MappedConsent}
 import code.consumer.Consumers
 import code.context.{ConsentAuthContextProvider, UserAuthContextProvider}
@@ -1991,27 +1993,44 @@ object Consent extends MdcLoggable {
     callContext: Option[CallContext]
   ): Future[Box[Unit]] = Future {
     implicit val dateFormats: Formats = CustomJsonFormats.formats
-    val consentAccounts: List[(String, String)] = JwtUtil.getSignedPayloadAsJson(storedConsent.jsonWebToken)
-      .map(com.openbankproject.commons.util.JsonAliases.parse(_).extract[ConsentJWT])
-      .map(_.views.map(v => (v.bank_id, v.account_id)).distinct)
-      .getOrElse(Nil)
-      .filter { case (bankId, accountId) => bankId != null && accountId != null }
+    // The Box is carried rather than flattened to Nil. "This consent names no accounts" is a
+    // legitimate state -- the availableAccounts shape described above -- and "its JWT cannot be
+    // read" is not, and a `getOrElse(Nil)` collapsed the second into the first: the guard then
+    // found nothing to object to and passed on a consent it had learned nothing about.
+    //
+    // tryo around the Box as well, because Box.map does not catch: getSignedPayloadAsJson returns a
+    // Failure only for a structurally invalid JWT, while a well-formed one carrying some other
+    // payload throws out of the extract instead. Both are the same answer here -- we cannot tell
+    // what this consent covers -- and both now reach it as a refusal rather than one as a 500.
+    val consentAccounts: Box[List[(String, String)]] = tryo {
+      JwtUtil.getSignedPayloadAsJson(storedConsent.jsonWebToken)
+        .map(com.openbankproject.commons.util.JsonAliases.parse(_).extract[ConsentJWT])
+    }.flatMap(box => box)
+      .map(_.views.map(v => (v.bank_id, v.account_id)).distinct
+        .filter { case (bankId, accountId) => bankId != null && accountId != null })
 
-    val notHeld: List[String] = consentAccounts
-      .groupBy(_._1)
-      .toList
-      .flatMap { case (bankId, pairs) =>
-        val held = AccountHolders.accountHolders.vend
-          .getAccountsHeld(BankId(bankId), psu)
-          .map(_.accountId.value)
-        pairs.map(_._2).filterNot(held.contains)
-      }
-
-    (notHeld.isEmpty, notHeld): (Boolean, List[String])
-  } flatMap { case (allHeld: Boolean, notHeld: List[String]) =>
-    Helper.booleanToFuture(
-      s"${ErrorMessages.ConsentAccountNotHeldByUser} Account(s): ${notHeld.mkString(", ")}",
-      403, callContext)(allHeld)
+    consentAccounts.map { accounts =>
+      accounts
+        .groupBy(_._1)
+        .toList
+        .flatMap { case (bankId, pairs) =>
+          val held = AccountHolders.accountHolders.vend
+            .getAccountsHeld(BankId(bankId), psu)
+            .map(_.accountId.value)
+          pairs.map(_._2).filterNot(held.contains)
+        }
+    }
+  } flatMap {
+    case Full(notHeld) =>
+      Helper.booleanToFuture(
+        s"${ErrorMessages.ConsentAccountNotHeldByUser} Account(s): ${notHeld.mkString(", ")}",
+        403, callContext)(notHeld.isEmpty)
+    case unreadable =>
+      logger.warn(
+        s"assertBerlinGroupConsentAccountsHeld: consent ${storedConsent.consentId} has no readable " +
+        s"JWT, so which accounts it covers cannot be established and the authorisation is refused: " +
+        s"$unreadable")
+      Helper.booleanToFuture(ErrorMessages.ConsentNotFound, 403, callContext)(false)
   }
 
   /**
@@ -2133,13 +2152,44 @@ object Consent extends MdcLoggable {
    * that is not local is looked up across providers and accepted only when exactly one user answers
    * to it. Two would make the header ambiguous, and choosing between them is not the ASPSP's to do
    * on the PSU's behalf.
+   *
+   * ==A deleted or locked user does not answer to it==
+   *
+   * This header names somebody the ASPSP then acts for: the PSU it resolves to is checked against
+   * the consent's accounts, an SCA challenge is minted for them and an OTP goes out to them, and the
+   * PUT twin binds the consent to them, after which it grants access to their accounts. None of that
+   * authenticates the PSU -- under Berlin Group the caller is the TPP and the PSU arrives as a header
+   * value -- so AfterApiAuth.checkUserIsDeletedOrLocked, which every authenticated request passes
+   * through, never runs on this path.
+   *
+   * A lock is the ASPSP's decision that this user may not authenticate. Resolving them here anyway
+   * routes around that decision, and nothing downstream catches it: the accounts really are theirs,
+   * so the holdings check passes. Same predicates as the canonical guard rather than a second
+   * opinion about what "usable" means.
+   *
+   * Refused as Empty, not with a reason of its own. resolvePsuIdHeader turns an unresolved header
+   * into UserNotFoundByProviderAndUsername at 401 -- the standard's PSU_CREDENTIALS_INVALID -- and a
+   * locked user has to get that same answer. A distinct "that user is locked" would tell a TPP the
+   * username exists, which is the existence oracle the consent reads were unified to close.
    */
   def findPsuByPsuId(psuId: String): Box[User] =
-    Users.users.vend.getUserByProviderAndUsername(Constant.localIdentityProvider, psuId) or {
+    Users.users.vend.getUserByProviderAndUsername(Constant.localIdentityProvider, psuId).or {
       Users.users.vend.getUsersByUsername(psuId) match {
         case theOnlyOne :: Nil => Full(theOnlyOne)
         case _                 => Empty
       }
+    }.filter { user =>
+      val unusable =
+        if (user.isDeleted.getOrElse(false)) Some(ErrorMessages.UserIsDeleted)
+        else if (LoginAttempt.userIsLocked(user.provider, user.name)) Some(ErrorMessages.UsernameHasBeenLocked)
+        else None
+      unusable.foreach { reason =>
+        logger.info(
+          s"findPsuByPsuId: PSU-ID named a user who may not act ($reason). Reported as " +
+          s"${ErrorMessages.UserNotFoundByProviderAndUsername} so the caller cannot tell that the " +
+          s"username exists.")
+      }
+      unusable.isEmpty
     }
 
   def createUKConsentJWT(

--- a/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
+++ b/obp-api/src/main/scala/code/api/util/ErrorMessages.scala
@@ -776,6 +776,7 @@ object ErrorMessages {
   val InvalidUKConsentPermissions = "OBP-35038: The Permissions array is not a valid combination for UK Open Banking. "
   val BerlinGroupPsuNotIdentified = "OBP-35039: The PSU this authorisation is for cannot be identified. Send the PSU-ID header, or authenticate as the PSU. "
   val ConsentNamesNoAccount = "OBP-35040: The Consent names no account, so it grants no access. It was authorised before consents were bound to accounts; re-authorise it to select which accounts it applies to. "
+  val ConsentAccountAccessCannotBeGranted = "OBP-35041: The Consent's account access cannot be granted. The Consent has not been authorised; please retry the authorisation. "
 
   //Authorisations
   val AuthorisationNotFound = "OBP-36001: Authorisation not found. Please specify valid values for PAYMENT_ID and AUTHORISATION_ID. "

--- a/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
+++ b/obp-api/src/main/scala/code/bankconnectors/LocalMappedConnector.scala
@@ -332,7 +332,7 @@ object LocalMappedConnector extends Connector with MdcLoggable {
         consentId,
         None, // Signing Baskets are introduced in case of version createChallengesC3
         authenticationMethodId,
-        challengeType = OBP_TRANSACTION_REQUEST_CHALLENGE.toString,
+        challengeType = challengeType.toString,
         callContext
       )
       challengeId.toList

--- a/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401AccountInfoTests.scala
+++ b/obp-api/src/test/scala/code/api/UKOpenBanking/v4_0_1/UKOpenBankingV401AccountInfoTests.scala
@@ -6,8 +6,10 @@ import code.api.util.ErrorMessages.{ConsentDoesNotMatchConsumer, ConsentDoesNotM
 import code.api.util.{CallContext, CertificateUtil, Consent}
 import code.consent.{ConsentStatus, Consents}
 import code.model.UserExtended
+import code.transactionChallenge.Challenges
 import code.views.Views
 import com.openbankproject.commons.model.{BankIdAccountId, ErrorMessage, ViewId}
+import com.openbankproject.commons.model.enums.ChallengeType
 import com.openbankproject.commons.util.ApiVersion
 import net.liftweb.common.{Failure, Full}
 import org.json4s._
@@ -838,6 +840,27 @@ class UKOpenBankingV401AccountInfoTests extends UKOpenBankingV401ServerSetup {
       And("so is the consent the challenge actually belonged to")
       boundPsuOf(challenged) should equal("")
       storedConsent(challenged).status should equal(ConsentStatus.AWAITINGAUTHORISATION.toString)
+    }
+  }
+
+  // The challenge type the caller asks for is the type that has to be stored. createChallengesC2
+  // took the ChallengeType argument and then wrote OBP_TRANSACTION_REQUEST_CHALLENGE for every
+  // caller, so every consent challenge -- UK here, Berlin Group through the same connector call --
+  // was persisted as a transaction-request challenge. The column is what an operator reads to tell
+  // a payment SCA from a consent SCA, and what any connector implementing this trait is handed.
+  feature("UKOB v4.0.1 the consent SCA challenge is stored as a consent challenge") {
+    scenario("challenge-start persists challengeType OBP_CONSENT_CHALLENGE, bound to the consent", UKOpenBankingV401AccountInfo) {
+      setPropsValues("suggested_default_sca_method" -> "DUMMY")
+      val consentId = createUKConsent(None, Some(new java.util.Date(System.currentTimeMillis() + 3600000L)))
+
+      val challenge = makePostRequest(scaChallengeRequest(consentId) <@ (user1), "")
+      challenge.code should equal(200)
+      val challengeId = (challenge.body \ "challenge_id").extract[String]
+
+      val stored = Challenges.ChallengeProvider.vend.getChallenge(challengeId)
+        .openOrThrowException(s"challenge $challengeId")
+      stored.challengeType should equal(ChallengeType.OBP_CONSENT_CHALLENGE.toString)
+      stored.consentId should equal(Some(consentId))
     }
   }
 

--- a/obp-api/src/test/scala/code/api/berlin/group/v1_3/AccountInformationServiceAISApiTest.scala
+++ b/obp-api/src/test/scala/code/api/berlin/group/v1_3/AccountInformationServiceAISApiTest.scala
@@ -494,6 +494,67 @@ class AccountInformationServiceAISApiTest extends BerlinGroupConsentFixtures {
       jsonResponse.consentId should not be (empty)
       jsonResponse.consentStatus should be (ConsentStatus.received.toString)
     }
+
+    scenario("An availableAccounts consent gains the PSU's own accounts when it is authorised", BerlinGroupV1_3, updateConsentsPsuDataTransactionAuthorisation) {
+      setPropsValues("suggested_default_sca_method" -> "DUMMY")
+
+      Given("An availableAccounts consent, which names no IBAN")
+      val requestPost = (V1_3_BG / "consents").POST <@ (user1)
+      val responsePost = makePostRequest(requestPost, write(postJsonBody))
+      responsePost.code should equal(201)
+      val consentId = responsePost.body.extract[PostConsentResponseJson].consentId
+
+      Then("Nothing can be resolved at creation: the consent is lodged with an empty view list")
+      consentViewsOf(consentId) should be (Nil)
+
+      When("The PSU answers the SCA challenge")
+      val requestStartAuthorisation = (V1_3_BG / "consents" / consentId / "authorisations").POST <@ (user1)
+      val responseStartAuthorisation = makePostRequest(requestStartAuthorisation, """{"scaAuthenticationData":""}""")
+      responseStartAuthorisation.code should be (201)
+      val authorisationId = responseStartAuthorisation.body.extract[StartConsentAuthorisationJson].authorisationId
+
+      val requestUpdatePsuData = (V1_3_BG / "consents" / consentId / "authorisations" / authorisationId).PUT <@ (user1)
+      val responseUpdatePsuData = makePutRequest(requestUpdatePsuData, """{"scaAuthenticationData":"123"}""")
+      responseUpdatePsuData.code should be (200)
+      responseUpdatePsuData.body.extract[ScaStatusResponse].scaStatus should be ("valid")
+
+      Then("The consent covers every IBAN-addressable account the authorising PSU holds, and only for reading the account list")
+      val grantedViews = consentViewsOf(consentId)
+      grantedViews should not be (empty)
+      grantedViews.map(_.view_id).distinct should be (List(SYSTEM_READ_ACCOUNTS_BERLIN_GROUP_VIEW_ID))
+      grantedViews.map(v => (v.bank_id, v.account_id)).toSet should be (ibanAddressableAccountsHeldBy(resourceUser1))
+
+      And("The account list it serves is not empty — before the views were materialised here, an authorised availableAccounts consent answered with nothing")
+      ibanAddressableAccountsHeldBy(resourceUser1) should not be (empty)
+    }
+
+    scenario("Authorising a consent that names one IBAN does not widen it to the PSU's other accounts", BerlinGroupV1_3, updateConsentsPsuDataTransactionAuthorisation) {
+      setPropsValues("suggested_default_sca_method" -> "DUMMY")
+
+      Given("A consent narrowed to a single IBAN, and a PSU who holds more than that one account")
+      ibanAddressableAccountsHeldBy(resourceUser1).size should be > 1
+      val requestPost = (V1_3_BG / "consents").POST <@ (user1)
+      val responsePost = makePostRequest(requestPost, write(bgConsentPostBody()))
+      responsePost.code should equal(201)
+      val consentId = responsePost.body.extract[PostConsentResponseJson].consentId
+      val viewsAtCreation = consentViewsOf(consentId)
+      viewsAtCreation should not be (empty)
+
+      When("The PSU authorises it")
+      val requestStartAuthorisation = (V1_3_BG / "consents" / consentId / "authorisations").POST <@ (user1)
+      val responseStartAuthorisation = makePostRequest(requestStartAuthorisation, """{"scaAuthenticationData":""}""")
+      responseStartAuthorisation.code should be (201)
+      val authorisationId = responseStartAuthorisation.body.extract[StartConsentAuthorisationJson].authorisationId
+
+      val requestUpdatePsuData = (V1_3_BG / "consents" / consentId / "authorisations" / authorisationId).PUT <@ (user1)
+      val responseUpdatePsuData = makePutRequest(requestUpdatePsuData, """{"scaAuthenticationData":"123"}""")
+      responseUpdatePsuData.code should be (200)
+
+      Then("Its accounts are exactly the ones it named. This is the availableAccounts test's mirror image: " +
+        "the predicate that decides whether to resolve the PSU's holdings must read the value of " +
+        "availableAccounts, not merely whether an access object is present — every consent carries one")
+      consentViewsOf(consentId) should be (viewsAtCreation)
+    }
   }
 
   feature(s"BG v1.3 - $createConsent") {

--- a/obp-api/src/test/scala/code/api/berlin/group/v1_3/BerlinGroupConsentFixtures.scala
+++ b/obp-api/src/test/scala/code/api/berlin/group/v1_3/BerlinGroupConsentFixtures.scala
@@ -1,17 +1,21 @@
 package code.api.berlin.group.v1_3
 
+import code.accountholders.AccountHolders
 import code.api.berlin.group.ConstantsBG
 import code.api.berlin.group.v1_3.JSONFactory_BERLIN_GROUP_1_3.{ConsentAccessAccountsJson, ConsentAccessJson, PostConsentJson}
 import code.api.util.APIUtil.OAuth._
-import code.api.util.Consent
+import code.api.util.{Consent, ConsentJWT, ConsentView, CustomJsonFormats, JwtUtil}
 import code.consent.{ConsentTrait, Consents}
 import code.model.TokenType.Access
 import code.model.UserX
 import code.model.dataAccess.{BankAccountRouting, ResourceUser}
 import code.setup.DefaultUsers
 import code.token.Tokens
+import com.openbankproject.commons.model.User
 import com.openbankproject.commons.model.enums.AccountRoutingScheme
+import com.openbankproject.commons.util.JsonAliases
 import net.liftweb.mapper.By
+import org.json4s.Formats
 import net.liftweb.util.Helpers.randomString
 import net.liftweb.util.TimeHelpers.TimeSpan
 
@@ -60,6 +64,41 @@ trait BerlinGroupConsentFixtures extends BerlinGroupServerSetupV1_3 with Default
       combinedServiceIndicator = Some(false)
     )
   }
+
+  /**
+   * The views a stored consent's JWT currently grants.
+   *
+   * Read off the JWT rather than the AccountAccess rows because the JWT is the consent's scope:
+   * applyBerlinGroupConsentRulesCommon re-derives the rows from it on every request, so a test that
+   * asserted on the rows would be asserting on a cache of this.
+   */
+  def consentViewsOf(consentId: String): List[ConsentView] = {
+    implicit val formats: Formats = CustomJsonFormats.formats
+    val stored = Consents.consentProvider.vend.getConsentByConsentId(consentId)
+      .openOrThrowException(s"test consent lookup failed for $consentId")
+    JwtUtil.getSignedPayloadAsJson(stored.jsonWebToken)
+      .map(JsonAliases.parse(_).extract[ConsentJWT])
+      .openOrThrowException(s"test consent JWT could not be read for $consentId")
+      .views
+  }
+
+  /**
+   * The accounts a user holds that Berlin Group can address, as (bank_id, account_id).
+   *
+   * Berlin Group names accounts by IBAN throughout, so an account with no IBAN routing is not
+   * reachable through this API however the consent is worded -- this is the set an
+   * "availableAccounts": "allAccounts" consent is expected to resolve to.
+   */
+  def ibanAddressableAccountsHeldBy(user: User): Set[(String, String)] =
+    AccountHolders.accountHolders.vend.getAccountsHeldByUser(user)
+      .filter { held =>
+        BankAccountRouting.find(
+          By(BankAccountRouting.BankId, held.bankId.value),
+          By(BankAccountRouting.AccountId, held.accountId.value),
+          By(BankAccountRouting.AccountRoutingScheme, AccountRoutingScheme.IBAN.toString)
+        ).isDefined
+      }
+      .map(held => (held.bankId.value, held.accountId.value))
 
   /**
    * An unclaimed (PSU-less) consent lodged under testConsumer, built straight through the provider

--- a/obp-api/src/test/scala/code/api/berlin/group/v1_3/BerlinGroupV13ConsentAccessTests.scala
+++ b/obp-api/src/test/scala/code/api/berlin/group/v1_3/BerlinGroupV13ConsentAccessTests.scala
@@ -10,6 +10,7 @@ import code.api.util.ErrorMessages.{BerlinGroupPsuNotIdentified, ConsentDoesNotM
 import code.consent.{ConsentStatus, Consents}
 import code.model.TokenType.Access
 import code.token.Tokens
+import code.userlocks.UserLocksProvider
 import code.transactionChallenge.Challenges
 import net.liftweb.common.{Empty, Full}
 import net.liftweb.util.Helpers.randomString
@@ -184,6 +185,39 @@ class BerlinGroupV13ConsentAccessTests extends BerlinGroupConsentFixtures {
     }
   }
 
+  // The PSU-ID header names a person the ASPSP then acts for: it resolves to a user, that user is
+  // checked against the consent's accounts, an SCA challenge is minted for them and an OTP goes out
+  // to them, and the PUT twin binds the consent to them. None of that authenticates the PSU -- under
+  // Berlin Group the caller is the TPP -- so the guard every authenticated request gets from
+  // AfterApiAuth.checkUserIsDeletedOrLocked never runs on this path. A lock says the ASPSP has
+  // decided this user may not authenticate; resolving them here anyway routes around that decision,
+  // and every later check passes because the accounts really are theirs.
+  feature("Consent.findPsuByPsuId only resolves a user who may still act") {
+
+    scenario("a live user resolves", BerlinGroupV13ConsentAccess) {
+      Consent.findPsuByPsuId(resourceUser1.name).map(_.userId) should equal(Full(resourceUser1.userId))
+    }
+
+    scenario("a locked user does not resolve", BerlinGroupV13ConsentAccess) {
+      UserLocksProvider.lockUser(resourceUser2.provider, resourceUser2.name)
+      try {
+        Consent.findPsuByPsuId(resourceUser2.name) should equal(Empty)
+      } finally {
+        UserLocksProvider.unlockUser(resourceUser2.provider, resourceUser2.name)
+      }
+      And("unlocking puts them back")
+      Consent.findPsuByPsuId(resourceUser2.name).map(_.userId) should equal(Full(resourceUser2.userId))
+    }
+
+    // Empty rather than a distinct "this user is locked": resolvePsuIdHeader turns an unresolved
+    // header into UserNotFoundByProviderAndUsername at 401, and a locked user must get that same
+    // answer. Telling the two apart would hand a TPP a way to confirm that a username exists, which
+    // is the oracle the consent reads were unified to close.
+    scenario("the refusal does not say which of the two it was", BerlinGroupV13ConsentAccess) {
+      Consent.findPsuByPsuId("no-such-user-at-all") should equal(Empty)
+    }
+  }
+
   feature("Consent.genuinePsu") {
 
     scenario("a session with no user at all has no PSU", BerlinGroupV13ConsentAccess) {
@@ -309,6 +343,38 @@ class BerlinGroupV13ConsentAccessTests extends BerlinGroupConsentFixtures {
   )
 
   feature("BG v1.3 - the consent reads apply the same ownership rule as the authorisation pair") {
+
+    // A caller not entitled to a consent must not be able to tell "there is no such consent" from
+    // "that one is not yours", or the endpoint confirms which ids are real. Four of these five reads
+    // were unified to a bare ConsentNotFound; getConsentScaStatus kept spelling the id back, because
+    // the replacement matched the default-status-code spelling and this site already passed 403
+    // explicitly. Same status either way, different body -- so the oracle survived at one endpoint.
+    scenario("every read answers a missing consent exactly as it answers a foreign one", BerlinGroupV13ConsentAccess) {
+      val someoneElses = createUnclaimedBerlinGroupConsent().consentId
+      val missing = "no-such-consent-at-all"
+
+      // Status and the tppMessages entry, not the whole body: the Berlin Group error envelope
+      // carries a `path` field holding the request path, so it always contains whichever id the
+      // caller themselves put in the URL. That is not a leak -- they already knew it -- and
+      // comparing it would make this scenario impossible to satisfy for the wrong reason.
+      def answers(consentId: String) = consentReads(consentId, user2).map { case (what, r) =>
+        val message = r.body.extract[ErrorMessagesBG].tppMessages.head
+        what -> (r.code, message.code, message.text)
+      }
+
+      answers(someoneElses).zip(answers(missing)).foreach { case ((what, foreign), (_, absent)) =>
+        withClue(s"'$what' tells a foreign consent from a missing one: ") {
+          foreign should equal(absent)
+        }
+      }
+
+      And("and the message names no consent")
+      answers(missing).foreach { case (what, (_, _, text)) =>
+        withClue(s"'$what' echoed the id: ") {
+          text should not include missing
+        }
+      }
+    }
 
     scenario("the lodging TPP acting for a second PSU cannot read a consent bound to the first", BerlinGroupV13ConsentAccess) {
       val consentId = createUnclaimedBerlinGroupConsent().consentId
@@ -457,6 +523,68 @@ class BerlinGroupV13ConsentAccessTests extends BerlinGroupConsentFixtures {
    * all.
    */
   feature("BG v1.3 - an Embedded SCA challenge belongs to the PSU, not to the TPP relaying it") {
+
+    // The refusal has to land before the challenge is minted, not after. Starting an authorisation
+    // sends an OTP to the person PSU-ID names, out of band -- so a locked user being resolvable here
+    // means the ASPSP messages somebody it has already decided may not authenticate, and the TPP is
+    // one answered code away from binding their accounts to a consent.
+    scenario("A locked PSU named in PSU-ID gets no challenge at all", BerlinGroupV13ConsentAccess) {
+      setPropsValues("suggested_default_sca_method" -> "DUMMY")
+      val consentId = createUnclaimedBerlinGroupConsent().consentId
+
+      UserLocksProvider.lockUser(resourceUser1.provider, resourceUser1Name)
+      val refused =
+        try startAuthorisation(consentId, clientCredentialsSession, psuIdHeader(resourceUser1Name))
+        finally UserLocksProvider.unlockUser(resourceUser1.provider, resourceUser1Name)
+
+      Then("it is refused as an unresolvable PSU-ID, saying nothing about the lock")
+      refused.code should equal(401)
+
+      And("no challenge was minted, so nobody was messaged")
+      Challenges.ChallengeProvider.vend.getChallengesByConsentId(consentId) match {
+        case Full(challenges) => challenges shouldBe empty
+        case _                => // no rows at all is the same answer
+      }
+    }
+
+    // assertBerlinGroupConsentAccountsHeld had no test of its own. These give it one, and the third
+    // is the point: it read a JWT it could not parse as "this consent names no accounts", which is a
+    // legitimate state (the availableAccounts shape) rather than an error, so the guard passed on a
+    // consent it had learned nothing about.
+    //
+    // Reaching that needs a STRUCTURALLY invalid JWT. A well-formed one carrying the wrong payload
+    // throws inside Box.map instead and already fails closed with a 500. An empty string is the
+    // shape a real instance produces: createConsent writes the consent row before computing and
+    // storing the JWT, so a consent whose JWT generation failed persists with none.
+    scenario("the accounts-held guard refuses a PSU who does not hold the consent's accounts", BerlinGroupV13ConsentAccess) {
+      setPropsValues("suggested_default_sca_method" -> "DUMMY")
+      val consentId = createUnclaimedBerlinGroupConsent().consentId
+
+      Then("the PSU who holds the named account may start the authorisation")
+      startAuthorisation(consentId, clientCredentialsSession, psuIdHeader(resourceUser1Name)).code should equal(201)
+
+      And("a PSU who does not hold it may not")
+      val refused = startAuthorisation(consentId, clientCredentialsSession, psuIdHeader(resourceUser2.name))
+      refused.code should equal(403)
+    }
+
+    scenario("a consent whose JWT cannot be read grants nobody the benefit of the doubt", BerlinGroupV13ConsentAccess) {
+      setPropsValues("suggested_default_sca_method" -> "DUMMY")
+      val consentId = createUnclaimedBerlinGroupConsent().consentId
+      Consents.consentProvider.vend.setJsonWebToken(consentId, "")
+
+      When("a PSU who does not hold the consent's accounts starts an authorisation")
+      val response = startAuthorisation(consentId, clientCredentialsSession, psuIdHeader(resourceUser2.name))
+
+      Then("it is refused, rather than passing because the account list came back empty")
+      response.code should not equal 201
+
+      And("no challenge was minted for them")
+      Challenges.ChallengeProvider.vend.getChallengesByConsentId(consentId) match {
+        case Full(challenges) => challenges shouldBe empty
+        case _                => // no rows at all is the same answer
+      }
+    }
 
     scenario("A client-credentials TPP completes SCA for the PSU it names in PSU-ID", BerlinGroupV13ConsentAccess) {
       setPropsValues("suggested_default_sca_method" -> "DUMMY")

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,80 @@
 ### Most recent changes at top of file
 ```
 Date          Commit        Action
+13/08/2026    298e1af87     Added props open_corridor.platform_bank_id.
+                            The platform fee accrual endpoints settle to the platform, which is
+                            modelled as a bank; this names its BANK_ID. There is no usable default,
+                            so sweeping accrued platform fees fails with OBP-10035 until it is set
+                            rather than paying an unintended bank. Only relevant on an instance that
+                            has Open Corridor turned on and settles platform fees; instances that do
+                            not need no action.
+
+13/08/2026    7bfefcb9f     BEHAVIOUR CHANGE: a consent is now resolved against the Consumer that
+                            lodged it, which makes sca_front_end_consumer_ids REQUIRED for anyone
+                            running Redirect SCA or their own approval screen.
+                            Berlin Group scopes a dynamically created resource to "the same TPP"
+                            that created it (Implementation Guidelines 4.11) and UK scopes GET and
+                            DELETE of an account-access-consent to one "that they have created".
+                            Previously a PSU match ended the enquiry before the Consumer was ever
+                            compared, so a second TPP holding a session for the same PSU could read
+                            and revoke a consent the first TPP had lodged. That short circuit is
+                            gone.
+
+                            Who is affected: any instance whose Strong Customer Authentication
+                            screen is served by a different Consumer than the TPP that lodges the
+                            consent — which is every Berlin Group Redirect deployment, because under
+                            Redirect the PSU authenticates at the ASPSP and the authorisation calls
+                            therefore arrive from the ASPSP's own front end. Nothing in the request
+                            distinguishes that front end from a second TPP holding a PSU session, so
+                            the ASPSP has to declare it.
+
+                            Symptom if you do not:
+                            POST /berlin-group/v1.3/consents/{consentId}/authorisations returns
+                            403 OBP-35015 (ConsentDoesNotMatchConsumer). SCA cannot start and the
+                            consent stays at "received". The UK approval screen's read of an
+                            unclaimed consent is governed by the same declaration.
+
+                            Action: set sca_front_end_consumer_ids to the consumer_id (not the
+                            consumer key) of whatever serves the approval screen — the OBP Portal in
+                            a stock deployment, found with
+                              select consumerid, name, redirecturl from consumer
+                                where redirecturl like '%<sca-frontend-host>%';
+                            Comma separate several. The older
+                            berlin_group_sca_front_end_consumer_ids is still read, so an instance
+                            already configured for Berlin Group Redirect SCA needs no edit. Empty
+                            stays the default, and empty keeps the lodging-TPP rule applying to
+                            every caller.
+
+                            Note APIUtil.scaFrontEndConsumerIds is a val read at class
+                            initialisation and props are packaged inside obp-api.jar, so the change
+                            needs a rebuild before restarting — a plain restart keeps the old value.
+
+                            Also added props consent_allow_legacy_unrecorded_tpp (default false).
+                            A consent recording no lodging Consumer now matches no caller and is
+                            refused; rows like that predate the Consumer being recorded at all.
+                            Turning this on restores the old behaviour for them, and the old
+                            behaviour is that ANY authenticated caller can read and revoke them,
+                            which is why it warns on every use. It is a migration window, not a
+                            setting: re-lodge the affected consents and turn it back off.
+
+12/08/2026    5f1f90694     Added props uk_open_banking_expired_consents_interval_in_seconds
+                            (default 601) and system_views.reconcile_permissions_at_boot.
+                            The consent expiry sweep is the UK counterpart of the existing
+                            berlin_group_ and obp_ keys, but unlike those it runs by default; set it
+                            to 0 to stop it. Turning it off does not grant access to an expired
+                            consent — checkUKConsent rejects one reactively on every request — the
+                            sweep only keeps the stored status accurate for GET and dashboard
+                            purposes.
+
+                            system_views.reconcile_permissions_at_boot defaults to TRUE, and that
+                            default rewrites data: at every boot the UK Open Banking and Berlin
+                            Group system views are reconciled to the permission set this build
+                            defines. It is deliberate — a permission set the code tightened has to
+                            reach the installations that have the problem, not only fresh ones — but
+                            an operator who has hand-tuned those rows will see the edits overwritten
+                            and should set it to false, which logs a warning and falls back to
+                            create-if-absent.
+
 28/07/2026    bc2b2aeb3     BEHAVIOUR CHANGE: UK Open Banking PSD2 gate now reads the mTLS
                             transport certificate (PSD2-CERT), not TPP-Signature-Certificate.
                             When requirePsd2Certificates=ONLINE, the certificate identifying the


### PR DESCRIPTION
Follow-up to #2882. Three commits, each staged on its own PR against `develop-obp` and CI-green there before merge. Two of them close items #2882 listed as deliberately not included; the third is a defect found while closing one of those.

## 1. `createChallengesC2` stores the challenge type the caller asked for

#2882 recorded this under *Deliberately not included*: the method took a `ChallengeType` and then passed `OBP_TRANSACTION_REQUEST_CHALLENGE` to `createChallengeInternal`, discarding it. Every challenge minted through that path persisted as a transaction request challenge — UK consent challenges, Berlin Group consent challenges and Berlin Group payment challenges alike. The `expectedchallengeanswer` table held no `OBP_CONSENT_CHALLENGE` row at all.

For consent challenges the stored type was merely misleading — they are looked up by `consentId` and nothing read it. Berlin Group **payment** challenges are the case where it is read: they carry a `transactionRequestId`, so `answerTransactionRequestChallenge` (v4.0.0) saw them as OBP transaction request challenges and accepted them, letting a Berlin Group payment SCA be completed through the OBP endpoint and bypass the Berlin Group status flow. That guard now rejects them, which is what it was written to do. Berlin Group's own answer path matches on `challengeId` and never consults the type.

`createChallengesC3` and `createChallengeInternal` already passed the type through, and the C1 overload has no such parameter and only serves the transaction request path — so this was the only site.

## 2. Three consent-access defects left over after #2882

**A deleted or locked PSU cannot be named in the `PSU-ID` header.** `findPsuByPsuId` resolved the header to a user without asking whether that user may still act. The header is not a credential — under Berlin Group the caller is the TPP and the PSU arrives as a header value — so this path never authenticates the PSU, and `AfterApiAuth.checkUserIsDeletedOrLocked`, which every authenticated request passes through, never ran on it. What the resolved user was then used for is the problem: `startConsentAuthorisation` takes it as the PSU, `assertBerlinGroupConsentAccountsHeld` passes (the accounts really are theirs), `createChallengesC2` mints an SCA challenge and an OTP goes out to that person, and the PUT twin binds the consent to them. A lock is the ASPSP's decision that this user may not authenticate; nothing on this path consulted it. Refused with the same `Empty` an unresolvable `PSU-ID` gives, so both answer `UserNotFoundByProviderAndUsername` at 401 — a distinct "that user is locked" would tell a TPP the username exists, which is the oracle the consent reads were unified to close.

**The last Berlin Group consent read stops echoing the consent id.** Four of the five reads were unified to a bare `ConsentNotFound`; `getConsentScaStatus` kept spelling the id back, because the earlier replacement matched the default-status-code spelling of `unboxFullOrFail` and this site already passed 403 explicitly. Same status, different message — the oracle survived at one endpoint. The scenario added here holds all five to the same answer at once.

**A consent whose JWT cannot be read grants nobody the benefit of the doubt.** `assertBerlinGroupConsentAccountsHeld` collapsed the JWT read into `.getOrElse(Nil)`, turning "this consent's JWT cannot be parsed" into "this consent names no accounts". The second is legitimate; the first is not, and the guard passed on it too — with no account list to object to, a PSU holding none of the consent's accounts was admitted and an OTP went out to them. A consent can carry an unparseable JWT: `createConsent` writes the consent row before computing and storing the JWT, so one whose JWT generation failed persists with none. `tryo` brings the well-formed-but-wrong-payload case (which threw, 500) to the same clean refusal.

## 3. A Berlin Group `availableAccounts` consent is bound to the PSU's accounts

The third commit above closes with *"`updateViewsOfBerlinGroupConsentJWT` … has no callers … its fate is worth deciding on its own."* This is that decision, and the function turned out to be covering a live gap rather than leftovers.

A consent lodged as `"access": {"availableAccounts": "allAccounts"}` could be created, validated, authorised through SCA and reach `valid` — and then serve nothing. `GET /v1.3/accounts` answered with an empty list, and no error was raised anywhere in the flow:

| step | what happened |
|---|---|
| `POST /consents` | validates the shape (`allAccounts`, `recurringIndicator=false`, `frequencyPerDay=1`) — passes |
| `createBerlinGroupConsentJWT` | builds views from `access.accounts ::: balances ::: transactions`, which the standard requires to be empty for this shape → writes `views: []` |
| `PUT …/authorisations/…` | `assertBerlinGroupConsentAccountsHeld` passes vacuously, status → `valid`, PSU bound. No views written |
| read path | `grantAccessToViews` with an empty list → the consent's shadow user holds no access |

The UK guard for an unbound consent (`ConsentNamesNoAccount`, in `resolveUKConsentPrincipal`) has no Berlin Group counterpart, so the shape degraded silently rather than failing. Only its negative-validation cases were under test, which is why it stayed hidden.

**Why the authorise step.** The shape means "every account this PSU holds", and which accounts those are cannot be known when the consent is lodged: the TPP lodges it, and the PSU is only settled at SCA.

**Why the existing function was replaced rather than re-wired.** `updateViewsOfBerlinGroupConsentJWT` was written for exactly this and wired to the Lift SCA page; that caller went with the rest of the web UI and nothing in the http4s path replaced it. Re-wiring it as written would have been worse than the bug — its predicate was `access.map(_.availableAccounts.contains("allAccounts")).isDefined`, which is `Option[Boolean].isDefined` and therefore true whenever an `access` object is present at all, and `createBerlinGroupConsentJWT` always writes one. Combined with a wholesale `copy(views = views)`, every consent would have taken that branch: one narrowed to a single IBAN would have been silently widened to the PSU's entire estate.

`grantBerlinGroupAvailableAccountsAccess` tests the value rather than the presence of `access`, **adds** views rather than replacing them, grants only `SYSTEM_READ_ACCOUNTS_BERLIN_GROUP_VIEW_ID` (`availableAccounts` buys the account *list*, not balances or transactions), includes only accounts with an IBAN routing since Berlin Group cannot address any other kind, and refuses a JWT it cannot read. It runs on a finalised SCA answer only and **before** the status update: nothing in that handler is transactional, so a consent that reached `valid` and then failed to gain its views would be an authorised consent that serves nothing, unrepairable through the API. Same refuse-first ordering as the UK twin in `authoriseUKConsent`.

Also corrects two comments that described the dead function as live behaviour, and adds `OBP-35041` for a failed grant — which sits behind both the consent-ownership check and a valid OTP, so unlike the refusals earlier in that handler it is not a state an unentitled caller can probe for.

## Verification

- CI green on each staging PR before merge: **25/25** on all three.
- Full local suite on the final state: **3426 tests, 0 failures, 0 errors, 0 skipped** (4 shards, surefire audit rather than the log banner).
- Each new test was checked as a negative control — observed failing on the previous behaviour before the fix. For §1 the scenario asserts the stored challenge type; for §2 all three are mutation-checked, the PSU-ID one starting the authorisation (201 where 401 is expected) with the filter disabled, which is the OTP actually being sent; for §3 the availableAccounts scenario fails with `List() was empty` on the post-authorisation view assertion.
- §3's second scenario is a regression guard rather than a red-first test: it asserts a consent naming one IBAN is *not* widened by the same path, and passes without the fix by design — it exists so the `.isDefined` predicate cannot be reintroduced.
