### PR TITLE
docs: fix typo recived -> received

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,4 +1008,4 @@ Please note that default translation file is `lift-core.properties`
 
 ## Funding Note
 
-This repository has recived funding via The OGCR Project which has received funding from the European Union's Horizon Europe programme under grant agreement 101218854.
+This repository has received funding via The OGCR Project which has received funding from the European Union's Horizon Europe programme under grant agreement 101218854.


### PR DESCRIPTION
One-word typo fix in `README.md:1011`: "This repository has recived funding" → `received`.
