### PR TITLE
fix: inject berlin_group_v1_3_alias_path for local test runs

### DIFF
--- a/run_tests_parallel.sh
+++ b/run_tests_parallel.sh
@@ -214,6 +214,12 @@ run_shard() {
     # fallback, so DynamicUtilTest / ConnectorMethodTest / AbacRuleTests /
     # DynamicResourceDocTest / DynamicMessageDocTest / DynamicCodeKillSwitchTest's ON
     # scenarios need this set explicitly or they fail locally with OBP-50020.
+    # OBP_BERLIN_GROUP_V1_3_ALIAS_PATH mirrors CI's berlin_group_v1_3_alias_path=0.6/v1
+    # (injected by both workflows' "Setup props" step): without it, OBP_BERLIN_GROUP_1_3_Alias
+    # reports an empty ScannedApiVersion("","","") and ScannedApis.isAddressable filters it
+    # out of versionMapScannedApis entirely, so ApiVersionUtilsTest's `versions.length shouldBe(21)`
+    # sees only 20 (CI green, local red) -- confirmed by reproducing the failure on a clean
+    # checkout with this var unset, then reproducing the pass with it set.
     # -pl obp-commons,obp-api mirrors CI: obp-commons' own util suites run on whichever
     # shard's filter matches com.openbankproject.* (the shard-4 catch-all); on every other
     # shard the filter matches nothing in obp-commons -> 0 tests there.
@@ -239,6 +245,7 @@ run_shard() {
     OBP_MAIL_TEST_MODE="true" \
     OBP_DYNAMIC_CODE_SANDBOX_PERMISSIONS='[new java.net.NetPermission("specifyStreamHandler"), new java.lang.reflect.ReflectPermission("suppressAccessChecks"), new java.lang.RuntimePermission("getenv.*"), new java.lang.RuntimePermission("accessDeclaredMembers"), new java.lang.RuntimePermission("getClassLoader")]' \
     OBP_ALLOW_USER_GENERATED_SCALA_CODE="true" \
+    OBP_BERLIN_GROUP_V1_3_ALIAS_PATH="0.6/v1" \
     OBP_API_INSTANCE_ID="shard_${n}_${port}" \
     "$TIMEOUT_BIN" 1200 mvn scalatest:test -pl obp-commons,obp-api -DfailIfNoTests=false \
         "-DwildcardSuites=${filter}" \


### PR DESCRIPTION
## Summary

`code.util.ApiVersionUtilsTest` asserts `ApiVersionUtils.versions.length shouldBe(21)`.
On a clean local checkout of `develop` this fails with "20 was not equal to 21",
while CI passes. Root cause: `test.default.props` is gitignored and each
developer maintains their own local copy, so it silently drifts from what
CI's "Setup props" step injects (`.github/workflows/build_pull_request.yml:291`,
`build_container.yml:297`).

Without `berlin_group_v1_3_alias_path` set, `OBP_BERLIN_GROUP_1_3_Alias`
reports an empty `ScannedApiVersion("","","")`, and
`ScannedApis.isAddressable` filters it out of `versionMapScannedApis`
entirely — so the local classpath scan finds 5 addressable scanned API
versions instead of 6, and `ApiVersionUtils.versions` (15 hardcoded +
scanned, deduplicated) comes out to 20 instead of 21.

## Fix

Inject `OBP_BERLIN_GROUP_V1_3_ALIAS_PATH="0.6/v1"` as an env var override in
`run_tests_parallel.sh`'s `run_shard` function, mirroring the exact pattern
already used for three other known local-vs-CI props gaps in the same
function (`OBP_MAIL_TEST_MODE`, `OBP_DYNAMIC_CODE_SANDBOX_PERMISSIONS`,
`OBP_ALLOW_USER_GENERATED_SCALA_CODE`) — `APIUtil.getPropsValue` gives
`OBP_*` env vars priority over the props file, so this closes the gap
without touching the developer's local, gitignored props file.

## Testing

Reproduced the failure on a clean `origin/develop` checkout (commit
`a98ba9847d843c6717f7f7aaa6c5cf6488819c9a`) with the env var unset — fails
with "20 was not equal to 21". Set only `OBP_BERLIN_GROUP_V1_3_ALIAS_PATH`
(props file otherwise untouched) and re-ran the same single-suite
invocation `run_shard` uses (`mvn scalatest:test -pl obp-api
-DwildcardSuites=code.util.ApiVersionUtilsTest` with the same env vars) —
passes.

## Note

Found while verifying full-suite results for an unrelated PR
(#2904, deleting retired Lift-era API standards). Confirmed via a
separate clean-checkout reproduction that this failure is unconnected to
that PR's changes — filing as its own fix here rather than folding it in.